### PR TITLE
Increase timeout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 
 # VERSION=$(shell git describe | sed 's/^v//')
-VERSION=0.7.11
+VERSION=0.7.12
 
 DOCKER=podman
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import os
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
-version = "0.7.11"
+version = "0.7.12"
 
 setuptools.setup(
     name="trustgraph",

--- a/trustgraph/clients/base.py
+++ b/trustgraph/clients/base.py
@@ -8,6 +8,9 @@ from pulsar.schema import JsonSchema
 
 from .. exceptions import *
 
+# Default timeout for a request/response.  In seconds.
+DEFAULT_TIMEOUT=300
+
 # Ugly
 ERROR=_pulsar.LoggerLevel.Error
 WARN=_pulsar.LoggerLevel.Warn
@@ -55,7 +58,7 @@ class BaseClient:
 
     def call(self, **args):
 
-        timeout = args.get("timeout", 30)
+        timeout = args.get("timeout", DEFAULT_TIMEOUT)
 
         if "timeout" in args:
             del args["timeout"]
@@ -112,7 +115,6 @@ class BaseClient:
     def __del__(self):
 
         if hasattr(self, "consumer"):
-#             self.consumer.unsubscribe()
             self.consumer.close()
             
         if hasattr(self, "producer"):


### PR DESCRIPTION
Request/response operations have a default timeout of 30 seconds, increase to 300 to cater for longer LLM completions