### PR TITLE
Tweak queue names

### DIFF
--- a/trustgraph-base/trustgraph/schema/documents.py
+++ b/trustgraph-base/trustgraph/schema/documents.py
@@ -60,5 +60,5 @@ document_embeddings_request_queue = topic(
     'doc-embeddings', kind='non-persistent', namespace='request'
 )
 document_embeddings_response_queue = topic(
-    'doc-embeddings-response', kind='non-persistent', namespace='response', 
+    'doc-embeddings', kind='non-persistent', namespace='response',
 )

--- a/trustgraph-base/trustgraph/schema/graph.py
+++ b/trustgraph-base/trustgraph/schema/graph.py
@@ -34,7 +34,7 @@ graph_embeddings_request_queue = topic(
     'graph-embeddings', kind='non-persistent', namespace='request'
 )
 graph_embeddings_response_queue = topic(
-    'graph-embeddings-response', kind='non-persistent', namespace='response', 
+    'graph-embeddings', kind='non-persistent', namespace='response'
 )
 
 ############################################################################
@@ -67,5 +67,5 @@ triples_request_queue = topic(
     'triples', kind='non-persistent', namespace='request'
 )
 triples_response_queue = topic(
-    'triples-response', kind='non-persistent', namespace='response',
+    'triples', kind='non-persistent', namespace='response'
 )

--- a/trustgraph-base/trustgraph/schema/models.py
+++ b/trustgraph-base/trustgraph/schema/models.py
@@ -23,7 +23,7 @@ text_completion_request_queue = topic(
     'text-completion', kind='non-persistent', namespace='request'
 )
 text_completion_response_queue = topic(
-    'text-completion-response', kind='non-persistent', namespace='response', 
+    'text-completion', kind='non-persistent', namespace='response'
 )
 
 ############################################################################
@@ -41,5 +41,5 @@ embeddings_request_queue = topic(
     'embeddings', kind='non-persistent', namespace='request'
 )
 embeddings_response_queue = topic(
-    'embeddings-response', kind='non-persistent', namespace='response'
+    'embeddings', kind='non-persistent', namespace='response'
 )

--- a/trustgraph-base/trustgraph/schema/prompt.py
+++ b/trustgraph-base/trustgraph/schema/prompt.py
@@ -59,7 +59,7 @@ prompt_request_queue = topic(
     'prompt', kind='non-persistent', namespace='request'
 )
 prompt_response_queue = topic(
-    'prompt-response', kind='non-persistent', namespace='response'
+    'prompt', kind='non-persistent', namespace='response'
 )
 
 ############################################################################

--- a/trustgraph-base/trustgraph/schema/retrieval.py
+++ b/trustgraph-base/trustgraph/schema/retrieval.py
@@ -20,7 +20,7 @@ graph_rag_request_queue = topic(
     'graph-rag', kind='non-persistent', namespace='request'
 )
 graph_rag_response_queue = topic(
-    'graph-rag-response', kind='non-persistent', namespace='response'
+    'graph-rag', kind='non-persistent', namespace='response'
 )
 
 ############################################################################
@@ -40,5 +40,5 @@ document_rag_request_queue = topic(
     'doc-rag', kind='non-persistent', namespace='request'
 )
 document_rag_response_queue = topic(
-    'doc-rag-response', kind='non-persistent', namespace='response'
+    'doc-rag', kind='non-persistent', namespace='response'
 )


### PR DESCRIPTION
Get rid of -response suffix on Q names, the full path already has 'response'