### PR TITLE
Fix/save core hang

### DIFF
--- a/trustgraph-cli/scripts/tg-load-kg-core
+++ b/trustgraph-cli/scripts/tg-load-kg-core
@@ -57,7 +57,9 @@ async def load_triples(running, queue, url):
 
                 try:
                     msg = await asyncio.wait_for(queue.get(), 1)
-                except TimeoutError:
+                except:
+                    # Hopefully it's TimeoutError.  Annoying to match since
+                    # it changed in 3.11.
                     continue
 
                 msg ={

--- a/trustgraph-cli/scripts/tg-load-kg-core
+++ b/trustgraph-cli/scripts/tg-load-kg-core
@@ -29,7 +29,9 @@ async def load_ge(running, queue, url):
 
                 try:
                     msg = await asyncio.wait_for(queue.get(), 1)
-                except TimeoutError:
+                except:
+                    # Hopefully it's TimeoutError.  Annoying to match since
+                    # it changed in 3.11.
                     continue
 
                 msg = {

--- a/trustgraph-cli/scripts/tg-save-kg-core
+++ b/trustgraph-cli/scripts/tg-save-kg-core
@@ -133,7 +133,9 @@ async def output(running, queue, path, format):
 
             try:
                 msg = await asyncio.wait_for(queue.get(), 0.5)
-            except TimeoutError:
+            except:
+                # Hopefully it's TimeoutError.  Annoying to match since
+                # it changed in 3.11.
                 continue
 
             if format == "msgpack":


### PR DESCRIPTION
Fix hang in core load/save.  Caused by API change in Python 3.11 queue.get raises...
- asyncio.exception.TimeoutError (3.10)
- TimeoutError (3.11...)