### PR TITLE
Pulsar resilience refactor

### DIFF
--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -20,6 +20,18 @@ scrape_configs:
       - targets:
         - 'pulsar:8080'
 
+  - job_name: 'bookie'
+    scrape_interval: 5s
+    static_configs:
+      - targets:
+        - 'bookie:8000'
+
+  - job_name: 'zookeeper'
+    scrape_interval: 5s
+    static_configs:
+      - targets:
+        - 'zookeeper:8000'
+
   - job_name: 'pdf-decoder'
     scrape_interval: 5s
     static_configs:

--- a/templates/components/pulsar.jsonnet
+++ b/templates/components/pulsar.jsonnet
@@ -8,25 +8,91 @@ local url = import "values/url.jsonnet";
 
         create:: function(engine)
 
-//            local confVolume = engine.volume("pulsar-conf").with_size("2G");
-            local dataVolume = engine.volume("pulsar-data").with_size("20G");
+            local zkVolume = engine.volume("zookeeper").with_size("1G");
 
-            local container =
+            local zkContainer = 
+                engine.container("zookeeper")
+                    .with_image(images.pulsar)
+                    .with_command([
+                        "bash",
+                        "-c",
+                        "bin/apply-config-from-env.py conf/zookeeper.conf && bin/generate-zookeeper-config.sh conf/zookeeper.conf && exec bin/pulsar zookeeper"
+                    ])
+                    .with_limits("0.1", "400M")
+                    .with_reservations("0.05", "400M")
+                    .with_volume_mount(zkVolume, "/pulsar/data/zookeeper")
+                    .with_environment({
+                        "metadataStoreUrl": "zk:zookeeper:2181",
+                        "PULSAR_MEM": "-Xms256m -Xmx256m -XX:MaxDirectMemorySize=256m",
+                    })
+                    .with_port(2181, 2181, "zookeeper")
+                    .with_port(2888, 2888, "zookeeper2")
+                    .with_port(3888, 3888, "zookeeper3");
+
+            local initContainer =
+                engine.container("pulsar-init")
+                    .with_image(images.pulsar)
+                    .with_command([
+                        "bash",
+                        "-c",
+                        "sleep 10 && bin/pulsar initialize-cluster-metadata --cluster cluster-a --zookeeper zookeeper:2181 --configuration-store zookeeper:2181 --web-service-url http://pulsar:8080 --broker-service-url pulsar://pulsar:6650",
+                    ])
+                    // Excessive?!
+                    .with_limits("1", "3000M")
+                    .with_reservations("0.1", "3000M");
+
+
+            local bookieVolume = engine.volume("bookie").with_size("20G");
+
+            local bookieContainer = 
+                engine.container("bookie")
+                    .with_image(images.pulsar)
+                    .with_command([
+                        "bash",
+                        "-c",
+                        "sleep 5; bin/apply-config-from-env.py conf/bookkeeper.conf && exec bin/pulsar bookie"
+                        // false ^ causes this to be a 'failure' exit.
+                    ])
+                    .with_limits("1", "800M")
+                    .with_reservations("0.1", "800M")
+                    .with_user(0)
+                    .with_volume_mount(bookieVolume, "/pulsar/data/bookkeeper")
+                    .with_environment({
+                        "clusterName": "cluster-a",
+                        "zkServers": "zookeeper:2181",
+                        "bookieId": "bookie",
+                        "metadataStoreUri": "metadata-store:zk:zookeeper:2181",
+                        "advertisedAddress": "bookie",
+                        "BOOKIE_MEM": "-Xms512m -Xmx512m -XX:MaxDirectMemorySize=256m",
+                    })
+                    .with_port(3181, 3181, "bookie");
+
+            local brokerContainer = 
                 engine.container("pulsar")
                     .with_image(images.pulsar)
-                    .with_command(["bin/pulsar", "standalone"])
+                    .with_command([
+                        "bash",
+                        "-c",
+                        "bin/apply-config-from-env.py conf/broker.conf && exec bin/pulsar broker"
+                    ])
+                    .with_limits("1", "800M")
+                    .with_reservations("0.1", "800M")
                     .with_environment({
-                        "PULSAR_MEM": "-Xms600M -Xmx600M"
+                        "metadataStoreUrl": "zk:zookeeper:2181",
+                        "zookeeperServers": "zookeeper:2181",
+                        "clusterName": "cluster-a",
+                        "managedLedgerDefaultEnsembleSize": "1",
+                        "managedLedgerDefaultWriteQuorum": "1",
+                        "managedLedgerDefaultAckQuorum": "1",
+                        "advertisedAddress": "pulsar",
+                        "advertisedListeners": "external:pulsar://pulsar:6650",
+                        "PULSAR_MEM": "-Xms512m -Xmx512m -XX:MaxDirectMemorySize=256m",
                     })
-                    .with_limits("2.0", "1500M")
-                    .with_reservations("1.0", "1500M")
-//                    .with_volume_mount(confVolume, "/pulsar/conf")
-                    .with_volume_mount(dataVolume, "/pulsar/data")
-                    .with_port(6650, 6650, "bookie")
-                    .with_port(8080, 8080, "http");
+                    .with_port(6650, 6650, "pulsar")
+                    .with_port(8080, 8080, "admin");
 
             local adminContainer =
-                engine.container("init-pulsar")
+                engine.container("init-trustgraph")
                     .with_image(images.trustgraph)
                     .with_command([
                         "tg-init-pulsar",
@@ -36,10 +102,31 @@ local url = import "values/url.jsonnet";
                     .with_limits("1", "128M")
                     .with_reservations("0.1", "128M");
 
-            local containerSet = engine.containers(
-                "pulsar",
+            local zkContainerSet = engine.containers(
+                "zookeeper",
                 [
-                    container
+                    zkContainer,
+                ]
+            );
+
+            local initContainerSet = engine.containers(
+                "init-pulsar",
+                [
+                    initContainer,
+                ]
+            );
+
+            local bookieContainerSet = engine.containers(
+                "bookie",
+                [
+                    bookieContainer,
+                ]
+            );
+
+            local brokerContainerSet = engine.containers(
+                "broker",
+                [
+                    brokerContainer,
                 ]
             );
 
@@ -50,17 +137,29 @@ local url = import "values/url.jsonnet";
                 ]
             );
 
-            local service =
-                engine.service(containerSet)
-                .with_port(6650, 6650, "bookie")
-                .with_port(8080, 8080, "http");
+            local zkService =
+                engine.service(zkContainerSet)
+                .with_port(2181, 2181, "zookeeper");
+
+            local bookieService =
+                engine.service(bookieContainerSet)
+                .with_port(6650, 6650, "bookie");
+
+            local brokerService =
+                engine.service(brokerContainerSet)
+                .with_port(8080, 8080, "broker");
 
             engine.resources([
-//                confVolume,
-                dataVolume,
-                containerSet,
+                zkVolume,
+                bookieVolume,
+                zkContainerSet,
+                initContainerSet,
+                bookieContainerSet,
+                brokerContainerSet,
                 adminContainerSet,
-                service,
+                zkService,
+                bookieService,
+                brokerService,
             ])
 
     }

--- a/templates/components/pulsar.jsonnet
+++ b/templates/components/pulsar.jsonnet
@@ -156,7 +156,9 @@ local url = import "values/url.jsonnet";
             // Zookeeper service
             local zkService =
                 engine.service(zkContainerSet)
-                .with_port(2181, 2181, "zookeeper");
+                .with_port(2181, 2181, "zookeeper")
+                .with_port(2888, 2888, "zookeeper2")
+                .with_port(3888, 3888, "zookeeper3");
 
             // Bookkeeper service
             local bookieService =
@@ -166,7 +168,8 @@ local url = import "values/url.jsonnet";
             // Pulsar broker service
             local brokerService =
                 engine.service(brokerContainerSet)
-                .with_port(8080, 8080, "broker");
+                .with_port(6650, 6650, "pulsar")
+                .with_port(8080, 8080, "admin");
 
             engine.resources([
                 zkVolume,

--- a/templates/components/pulsar.jsonnet
+++ b/templates/components/pulsar.jsonnet
@@ -63,7 +63,7 @@ local url = import "values/url.jsonnet";
                     .with_command([
                         "bash",
                         "-c",
-                        "sleep 5; bin/apply-config-from-env.py conf/bookkeeper.conf && exec bin/pulsar bookie"
+                        "bin/apply-config-from-env.py conf/bookkeeper.conf && exec bin/pulsar bookie"
                         // false ^ causes this to be a 'failure' exit.
                     ])
                     .with_limits("1", "800M")

--- a/templates/engine/docker-compose.jsonnet
+++ b/templates/engine/docker-compose.jsonnet
@@ -22,6 +22,8 @@
 
         with_image:: function(x) self + { image: x },
 
+        with_user:: function(x) self + { user: x },
+
         with_command:: function(x) self + { command: x },
 
         with_environment:: function(x) self + {
@@ -73,6 +75,10 @@
 
                 (if std.objectHas(container, "command") then
                 { command: container.command }
+                else {}) +
+
+                (if std.objectHas(container, "user") then
+                { user: container.user }
                 else {}) +
 
                 (if ! std.isEmpty(container.environment) then


### PR DESCRIPTION
- Replace Pulsar standalone with separate components: booker, Pulsar broker, Zookeeper
- Resilient state means that failure/restart of components leaves a working system
- Whole system can be stopped and started, continues working

Issues:
- Standalone Pulsar has bookie address known to broker 127.0.0.1, this works with components inside and outside the cluster. When split out, this results in a different in addresses inside vs outside the cluster.
- As a result of the above, command-line utilities which use the Pulsar API don't work in a docker compose deployment

Appears to increase startup time of Pulsar by around 20-30 seconds, which probably doesn't affect overall startup time.

Need to consider how to handle this, it's possible to address it with multiple broker listener configuration. Alternatively, can port the external utilities to use REST and the API gateway.