### PR TITLE
Fix k8s with_user invocation

### DIFF
--- a/templates/engine/k8s.jsonnet
+++ b/templates/engine/k8s.jsonnet
@@ -14,6 +14,8 @@
 
         with_image:: function(x) self + { image: x },
 
+        with_user:: function(x) self + { user: x },
+
         with_command:: function(x) self + { command: x },
 
         with_environment:: function(x) self + {


### PR DESCRIPTION
Catch with_user invocation, store the user.

It is not used, K8s generation already had user/group 0, otherwise volumes don't mount properly