### PR TITLE
Agent tweaks for v0.19

### DIFF
--- a/templates/components/agent-manager-react.jsonnet
+++ b/templates/components/agent-manager-react.jsonnet
@@ -19,6 +19,10 @@ local default_prompts = import "prompts/default-prompts.jsonnet";
                         "agent-manager-react",
                         "-p",
                         url.pulsar,
+                        "--prompt-request-queue",
+                        "non-persistent://tg/request/prompt-rag",
+                        "--prompt-response-queue",
+                        "non-persistent://tg/response/prompt-rag",
                         "--tool-type",
                     ] + [
                         tool.id + "=" + tool.type

--- a/trustgraph-flow/trustgraph/agent/react/service.py
+++ b/trustgraph-flow/trustgraph/agent/react/service.py
@@ -14,8 +14,6 @@ from ... schema import AgentRequest, AgentResponse, AgentStep
 from ... schema import agent_request_queue, agent_response_queue
 from ... schema import prompt_request_queue as pr_request_queue
 from ... schema import prompt_response_queue as pr_response_queue
-from ... schema import text_completion_request_queue as tc_request_queue
-from ... schema import text_completion_response_queue as tc_response_queue
 from ... schema import graph_rag_request_queue as gr_request_queue
 from ... schema import graph_rag_response_queue as gr_response_queue
 from ... clients.prompt_client import PromptClient
@@ -133,12 +131,6 @@ class Processor(ConsumerProducer):
         prompt_response_queue = params.get(
             "prompt_response_queue", pr_response_queue
         )
-        text_completion_request_queue = params.get(
-            "text_completion_request_queue", tc_request_queue
-        )
-        text_completion_response_queue = params.get(
-            "text_completion_response_queue", tc_response_queue
-        )
         graph_rag_request_queue = params.get(
             "graph_rag_request_queue", gr_request_queue
         )
@@ -155,8 +147,6 @@ class Processor(ConsumerProducer):
                 "output_schema": AgentResponse,
                 "prompt_request_queue": prompt_request_queue,
                 "prompt_response_queue": prompt_response_queue,
-                "text_completion_request_queue": tc_request_queue,
-                "text_completion_response_queue": tc_response_queue,
                 "graph_rag_request_queue": gr_request_queue,
                 "graph_rag_response_queue": gr_response_queue,
             }
@@ -166,13 +156,6 @@ class Processor(ConsumerProducer):
             subscriber=subscriber,
             input_queue=prompt_request_queue,
             output_queue=prompt_response_queue,
-            pulsar_host = self.pulsar_host
-        )
-
-        self.llm = LlmClient(
-            subscriber=subscriber,
-            input_queue=text_completion_request_queue,
-            output_queue=text_completion_response_queue,
             pulsar_host = self.pulsar_host
         )
 
@@ -338,18 +321,6 @@ class Processor(ConsumerProducer):
             '--prompt-response-queue',
             default=pr_response_queue,
             help=f'Prompt response queue (default: {pr_response_queue})',
-        )
-
-        parser.add_argument(
-            '--text-completion-request-queue',
-            default=tc_request_queue,
-            help=f'Text completion request queue (default: {tc_request_queue})',
-        )
-
-        parser.add_argument(
-            '--text-completion-response-queue',
-            default=tc_response_queue,
-            help=f'Text completion response queue (default: {tc_response_queue})',
         )
 
         parser.add_argument(

--- a/trustgraph-flow/trustgraph/agent/react/tools.py
+++ b/trustgraph-flow/trustgraph/agent/react/tools.py
@@ -14,6 +14,6 @@ class TextCompletionImpl:
         self.context = context
     def invoke(self, **arguments):
         return self.context.prompt.request(
-            "question", { "question": arguments.get("computation") }
+            "question", { "question": arguments.get("question") }
         )
 


### PR DESCRIPTION
- Removed unused LLM client configuration from agent-manager-react
- Change agent-manager-react template to use prompt-rag instead of prompt
- Changed TextCompletion tool to use 'question' instead of 'computation' for its parameter.