### PR TITLE
Add support for Qdrant API Auth

### DIFF
--- a/trustgraph-flow/trustgraph/query/doc_embeddings/qdrant/service.py
+++ b/trustgraph-flow/trustgraph/query/doc_embeddings/qdrant/service.py
@@ -30,6 +30,8 @@ class Processor(ConsumerProducer):
         output_queue = params.get("output_queue", default_output_queue)
         subscriber = params.get("subscriber", default_subscriber)
         store_uri = params.get("store_uri", default_store_uri)
+        #optional api key
+        api_key = params.get("api_key", None)
 
         super(Processor, self).__init__(
             **params | {
@@ -39,10 +41,11 @@ class Processor(ConsumerProducer):
                 "input_schema": DocumentEmbeddingsRequest,
                 "output_schema": DocumentEmbeddingsResponse,
                 "store_uri": store_uri,
+                "api_key": api_key,
             }
         )
 
-        self.client = QdrantClient(url=store_uri)
+        self.client = QdrantClient(url=store_uri, api_key=api_key)
 
     def handle(self, msg):
 
@@ -111,7 +114,13 @@ class Processor(ConsumerProducer):
         parser.add_argument(
             '-t', '--store-uri',
             default=default_store_uri,
-            help=f'Milvus store URI (default: {default_store_uri})'
+            help=f'Qdrant store URI (default: {default_store_uri})'
+        )
+        
+        parser.add_argument(
+            '-k', '--api-key',
+            default=None,
+            help=f'API key for qdrant (default: None)'
         )
 
 def run():

--- a/trustgraph-flow/trustgraph/query/graph_embeddings/qdrant/service.py
+++ b/trustgraph-flow/trustgraph/query/graph_embeddings/qdrant/service.py
@@ -30,6 +30,7 @@ class Processor(ConsumerProducer):
         output_queue = params.get("output_queue", default_output_queue)
         subscriber = params.get("subscriber", default_subscriber)
         store_uri = params.get("store_uri", default_store_uri)
+        api_key = params.get("api_key", None)
 
         super(Processor, self).__init__(
             **params | {
@@ -39,10 +40,11 @@ class Processor(ConsumerProducer):
                 "input_schema": GraphEmbeddingsRequest,
                 "output_schema": GraphEmbeddingsResponse,
                 "store_uri": store_uri,
+                "api_key": api_key,
             }
         )
 
-        self.client = QdrantClient(url=store_uri)
+        self.client = QdrantClient(url=store_uri, api_key=api_key)
 
     def create_value(self, ent):
         if ent.startswith("http://") or ent.startswith("https://"):
@@ -137,7 +139,13 @@ class Processor(ConsumerProducer):
         parser.add_argument(
             '-t', '--store-uri',
             default=default_store_uri,
-            help=f'Milvus store URI (default: {default_store_uri})'
+            help=f'Qdrant store URI (default: {default_store_uri})'
+        )
+        
+        parser.add_argument(
+            '-k', '--api-key',
+            default=None,
+            help=f'API key for qdrant (default: None)'
         )
 
 def run():

--- a/trustgraph-flow/trustgraph/storage/doc_embeddings/qdrant/write.py
+++ b/trustgraph-flow/trustgraph/storage/doc_embeddings/qdrant/write.py
@@ -26,6 +26,7 @@ class Processor(Consumer):
         input_queue = params.get("input_queue", default_input_queue)
         subscriber = params.get("subscriber", default_subscriber)
         store_uri = params.get("store_uri", default_store_uri)
+        api_key = params.get("api_key", None)
 
         super(Processor, self).__init__(
             **params | {
@@ -33,6 +34,7 @@ class Processor(Consumer):
                 "subscriber": subscriber,
                 "input_schema": ChunkEmbeddings,
                 "store_uri": store_uri,
+                "api_key": api_key,
             }
         )
 
@@ -96,7 +98,13 @@ class Processor(Consumer):
         parser.add_argument(
             '-t', '--store-uri',
             default=default_store_uri,
-            help=f'Qdrant store URI (default: {default_store_uri})'
+            help=f'Qdrant URI (default: {default_store_uri})'
+        )
+        
+        parser.add_argument(
+            '-k', '--api-key',
+            default=None,
+            help=f'Qdrant API key (default: None)'
         )
 
 def run():

--- a/trustgraph-flow/trustgraph/storage/graph_embeddings/qdrant/write.py
+++ b/trustgraph-flow/trustgraph/storage/graph_embeddings/qdrant/write.py
@@ -26,6 +26,7 @@ class Processor(Consumer):
         input_queue = params.get("input_queue", default_input_queue)
         subscriber = params.get("subscriber", default_subscriber)
         store_uri = params.get("store_uri", default_store_uri)
+        api_key = params.get("api_key", None)
 
         super(Processor, self).__init__(
             **params | {
@@ -33,12 +34,13 @@ class Processor(Consumer):
                 "subscriber": subscriber,
                 "input_schema": GraphEmbeddings,
                 "store_uri": store_uri,
+                "api_key": api_key,
             }
         )
 
         self.last_collection = None
 
-        self.client = QdrantClient(url=store_uri)
+        self.client = QdrantClient(url=store_uri, api_key=api_key)
 
     def handle(self, msg):
 
@@ -95,6 +97,12 @@ class Processor(Consumer):
             '-t', '--store-uri',
             default=default_store_uri,
             help=f'Qdrant store URI (default: {default_store_uri})'
+        )
+        
+        parser.add_argument(
+            '-k', '--api-key',
+            default=None,
+            help=f'Qdrant API key'
         )
 
 def run():


### PR DESCRIPTION
Added the necessary changes to support API Key in Qdrant Client Query+Storage
- Doc Embeddings
- Graph Embeddings

Issue #299 

This pull request includes changes to add support for an optional API key parameter across various services in the `trustgraph-flow` project. The changes involve updating the initialization methods to accept the API key, modifying the client instantiation to use the API key, and adding command-line arguments for the API key.

### Add support for optional API key:

* [`trustgraph-flow/trustgraph/query/doc_embeddings/qdrant/service.py`](diffhunk://#diff-dc33fe7ddf67d02ad8da7950e7b2c8739a4a0d97cd82dec86251c77f92f3d10dR33-R34): Added `api_key` parameter in `__init__` method and updated `QdrantClient` instantiation to use the API key. Also added a command-line argument for the API key. [[1]](diffhunk://#diff-dc33fe7ddf67d02ad8da7950e7b2c8739a4a0d97cd82dec86251c77f92f3d10dR33-R34) [[2]](diffhunk://#diff-dc33fe7ddf67d02ad8da7950e7b2c8739a4a0d97cd82dec86251c77f92f3d10dR44-R48) [[3]](diffhunk://#diff-dc33fe7ddf67d02ad8da7950e7b2c8739a4a0d97cd82dec86251c77f92f3d10dL114-R123)
* [`trustgraph-flow/trustgraph/query/graph_embeddings/qdrant/service.py`](diffhunk://#diff-4c34604ab5a437e8e09b0dd7d199d7d1849772f53d8d52b0fc4dcf7260a8f09cR33): Added `api_key` parameter in `__init__` method and updated `QdrantClient` instantiation to use the API key. Also added a command-line argument for the API key. [[1]](diffhunk://#diff-4c34604ab5a437e8e09b0dd7d199d7d1849772f53d8d52b0fc4dcf7260a8f09cR33) [[2]](diffhunk://#diff-4c34604ab5a437e8e09b0dd7d199d7d1849772f53d8d52b0fc4dcf7260a8f09cR43-R47) [[3]](diffhunk://#diff-4c34604ab5a437e8e09b0dd7d199d7d1849772f53d8d52b0fc4dcf7260a8f09cL140-R148)
* [`trustgraph-flow/trustgraph/storage/doc_embeddings/qdrant/write.py`](diffhunk://#diff-a175da33e4a5be8820d2b99bc421c95640643fd824b0a106b76855cce8680485R29-R37): Added `api_key` parameter in `__init__` method and updated `QdrantClient` instantiation to use the API key. Also added a command-line argument for the API key. [[1]](diffhunk://#diff-a175da33e4a5be8820d2b99bc421c95640643fd824b0a106b76855cce8680485R29-R37) [[2]](diffhunk://#diff-a175da33e4a5be8820d2b99bc421c95640643fd824b0a106b76855cce8680485L99-R107)
* [`trustgraph-flow/trustgraph/storage/graph_embeddings/qdrant/write.py`](diffhunk://#diff-d6a4d00db53361dfa54203d78fc0c5cd5e5f0d9749cdf73a88271306b8a0ce8dR29-R43): Added `api_key` parameter in `__init__` method and updated `QdrantClient` instantiation to use the API key. Also added a command-line argument for the API key. [[1]](diffhunk://#diff-d6a4d00db53361dfa54203d78fc0c5cd5e5f0d9749cdf73a88271306b8a0ce8dR29-R43) [[2]](diffhunk://#diff-d6a4d00db53361dfa54203d78fc0c5cd5e5f0d9749cdf73a88271306b8a0ce8dR102-R107)