### PR TITLE
Add user and password auth for Cassandra

### DIFF
--- a/trustgraph-flow/trustgraph/direct/cassandra.py
+++ b/trustgraph-flow/trustgraph/direct/cassandra.py
@@ -6,7 +6,7 @@ class TrustGraph:
 
     def __init__(
             self, hosts=None,
-            keyspace="trustgraph", table="default",
+            keyspace="trustgraph", table="default", username=None, password=None
     ):
 
         if hosts is None:
@@ -14,8 +14,13 @@ class TrustGraph:
 
         self.keyspace = keyspace
         self.table = table
+        self.username = username
             
-        self.cluster = Cluster(hosts)
+        if username and password:
+            auth_provider = PlainTextAuthProvider(username=username, password=password)
+            self.cluster = Cluster(hosts, auth_provider=auth_provider)
+        else:
+            self.cluster = Cluster(hosts)
         self.session = self.cluster.connect()
 
         self.init()

--- a/trustgraph-flow/trustgraph/query/triples/cassandra/service.py
+++ b/trustgraph-flow/trustgraph/query/triples/cassandra/service.py
@@ -26,6 +26,8 @@ class Processor(ConsumerProducer):
         output_queue = params.get("output_queue", default_output_queue)
         subscriber = params.get("subscriber", default_subscriber)
         graph_host = params.get("graph_host", default_graph_host)
+        graph_username = params.get("graph_username", None)
+        graph_password = params.get("graph_password", None)
 
         super(Processor, self).__init__(
             **params | {
@@ -35,10 +37,14 @@ class Processor(ConsumerProducer):
                 "input_schema": TriplesQueryRequest,
                 "output_schema": TriplesQueryResponse,
                 "graph_host": graph_host,
+                "graph_username": graph_username,
+                "graph_password": graph_password,
             }
         )
 
         self.graph_host = [graph_host]
+        self.username = graph_username
+        self.password = graph_password
         self.table = None
 
     def create_value(self, ent):
@@ -56,10 +62,17 @@ class Processor(ConsumerProducer):
             table = (v.user, v.collection)
 
             if table != self.table:
-                self.tg = TrustGraph(
-                    hosts=self.graph_host,
-                    keyspace=v.user, table=v.collection,
-                )
+                if self.username and self.password:
+                    self.tg = TrustGraph(
+                        hosts=self.graph_host,
+                        keyspace=v.user, table=v.collection,
+                        username=self.username, password=self.password
+                    )
+                else:
+                    self.tg = TrustGraph(
+                        hosts=self.graph_host,
+                        keyspace=v.user, table=v.collection,
+                    )
                 self.table = table
 
             # Sender-produced ID
@@ -176,6 +189,19 @@ class Processor(ConsumerProducer):
             default="localhost",
             help=f'Graph host (default: localhost)'
         )
+        
+        parser.add_argument(
+            '--graph-username',
+            default=None,
+            help=f'Cassandra username'
+        )
+        
+        parser.add_argument(
+            '--graph-password',
+            default=None,
+            help=f'Cassandra password'
+        )
+
 
 def run():
 


### PR DESCRIPTION
This pull request introduces support for authentication in the TrustGraph Cassandra connections by adding username and password parameters. The most important changes include modifications to the `TrustGraph` class and updates to various service and write processor classes to handle the new authentication parameters.

Enhancements to authentication:

* [`trustgraph-flow/trustgraph/direct/cassandra.py`](diffhunk://#diff-7f7079c949cc163dc30ce3dbe5509a7a0f756b67583a22feecc20cd83b800fa8L9-R22): Added `username` and `password` parameters to the `TrustGraph` class constructor and updated the connection logic to use these credentials if provided.

Updates to service processors:

* [`trustgraph-flow/trustgraph/query/triples/cassandra/service.py`](diffhunk://#diff-ce7bde6ce9680968aadc41467b40f22c4a9bcd7a81c4c436266522c03ee44f2eR29-R30): Added `graph_username` and `graph_password` parameters to the `Processor` class constructor, updated the `handle` method to use these parameters when creating a `TrustGraph` instance, and added corresponding argument parsing. [[1]](diffhunk://#diff-ce7bde6ce9680968aadc41467b40f22c4a9bcd7a81c4c436266522c03ee44f2eR29-R30) [[2]](diffhunk://#diff-ce7bde6ce9680968aadc41467b40f22c4a9bcd7a81c4c436266522c03ee44f2eR40-R47) [[3]](diffhunk://#diff-ce7bde6ce9680968aadc41467b40f22c4a9bcd7a81c4c436266522c03ee44f2eR65-R71) [[4]](diffhunk://#diff-ce7bde6ce9680968aadc41467b40f22c4a9bcd7a81c4c436266522c03ee44f2eR193-R205)

Updates to write processors:

* [`trustgraph-flow/trustgraph/storage/rows/cassandra/write.py`](diffhunk://#diff-bce9c168e6e56801f6569b1081c7f33f98a82c099754eddd952f59b6c19b451fR32-R49): Added `graph_username` and `graph_password` parameters to the `Processor` class constructor, updated the connection logic to use these credentials if provided, and added corresponding argument parsing. [[1]](diffhunk://#diff-bce9c168e6e56801f6569b1081c7f33f98a82c099754eddd952f59b6c19b451fR32-R49) [[2]](diffhunk://#diff-bce9c168e6e56801f6569b1081c7f33f98a82c099754eddd952f59b6c19b451fR132-R143)
* [`trustgraph-flow/trustgraph/storage/triples/cassandra/write.py`](diffhunk://#diff-66c417bbe6dd75b3e04d263254d16438d46d3dafb0880ae52d1afa42e702f501R31-R47): Added `graph_username` and `graph_password` parameters to the `Processor` class constructor, updated the `handle` method to use these parameters when creating a `TrustGraph` instance, and added corresponding argument parsing. [[1]](diffhunk://#diff-66c417bbe6dd75b3e04d263254d16438d46d3dafb0880ae52d1afa42e702f501R31-R47) [[2]](diffhunk://#diff-66c417bbe6dd75b3e04d263254d16438d46d3dafb0880ae52d1afa42e702f501R61-R67) [[3]](diffhunk://#diff-66c417bbe6dd75b3e04d263254d16438d46d3dafb0880ae52d1afa42e702f501R99-R110)