### PR TITLE
Fix async/sync load issues with knowledge streaming APIs

### DIFF
--- a/trustgraph-flow/trustgraph/gateway/document_embeddings_load.py
+++ b/trustgraph-flow/trustgraph/gateway/document_embeddings_load.py
@@ -59,6 +59,6 @@ class DocumentEmbeddingsLoadEndpoint(SocketEndpoint):
                     ],
                 )
 
-                await self.publisher.send(None, elt)
+                self.publisher.send(None, elt)
 
         running.stop()

--- a/trustgraph-flow/trustgraph/gateway/graph_embeddings_load.py
+++ b/trustgraph-flow/trustgraph/gateway/graph_embeddings_load.py
@@ -36,6 +36,7 @@ class GraphEmbeddingsLoadEndpoint(SocketEndpoint):
     async def listener(self, ws, running):
         
         async for msg in ws:
+
             # On error, finish
             if msg.type == WSMsgType.ERROR:
                 break
@@ -59,7 +60,6 @@ class GraphEmbeddingsLoadEndpoint(SocketEndpoint):
                     ]
                 )
 
-                await self.publisher.send(None, elt)
-
+                self.publisher.send(None, elt)
 
         running.stop()

--- a/trustgraph-flow/trustgraph/gateway/requestor.py
+++ b/trustgraph-flow/trustgraph/gateway/requestor.py
@@ -53,11 +53,9 @@ class ServiceRequestor:
 
             q = self.sub.subscribe(id)
 
-            print("BOUT TO SEDN")
             await asyncio.to_thread(
                 self.pub.send, id, self.to_request(request)
             )
-            print("SENT")
 
             while True:
 

--- a/trustgraph-flow/trustgraph/gateway/socket.py
+++ b/trustgraph-flow/trustgraph/gateway/socket.py
@@ -19,7 +19,7 @@ class SocketEndpoint:
         self.operation = "socket"
 
     async def listener(self, ws, running):
-        
+
         async for msg in ws:
             # On error, finish
             if msg.type == WSMsgType.TEXT:
@@ -53,7 +53,7 @@ class SocketEndpoint:
         try:
             await self.listener(ws, running)
         except Exception as e:
-            print(e, flush=True)
+            print("Socket exception:", e, flush=True)
 
         running.stop()
 

--- a/trustgraph-flow/trustgraph/gateway/triples_load.py
+++ b/trustgraph-flow/trustgraph/gateway/triples_load.py
@@ -51,7 +51,7 @@ class TriplesLoadEndpoint(SocketEndpoint):
                     triples=to_subgraph(data["triples"]),
                 )
 
-                await self.publisher.send(None, elt)
+                self.publisher.send(None, elt)
 
 
         running.stop()


### PR DESCRIPTION
Knowledge core load APIs are broken in 0.21, results in a stream of errors in the gateway log.

This provides a fix