### PR TITLE
Add support for Cassandra auth with SSL check

### DIFF
--- a/trustgraph-flow/trustgraph/direct/cassandra.py
+++ b/trustgraph-flow/trustgraph/direct/cassandra.py
@@ -1,6 +1,7 @@
 
 from cassandra.cluster import Cluster
 from cassandra.auth import PlainTextAuthProvider
+from ssl import SSLContext, PROTOCOL_TLSv1_2
 
 class TrustGraph:
 
@@ -17,8 +18,9 @@ class TrustGraph:
         self.username = username
             
         if username and password:
+            ssl_context = SSLContext(PROTOCOL_TLSv1_2)
             auth_provider = PlainTextAuthProvider(username=username, password=password)
-            self.cluster = Cluster(hosts, auth_provider=auth_provider)
+            self.cluster = Cluster(hosts, auth_provider=auth_provider, ssl_context=ssl_context)
         else:
             self.cluster = Cluster(hosts)
         self.session = self.cluster.connect()

--- a/trustgraph-flow/trustgraph/librarian/table_store.py
+++ b/trustgraph-flow/trustgraph/librarian/table_store.py
@@ -6,6 +6,7 @@ from .. exceptions import RequestError
 from cassandra.cluster import Cluster
 from cassandra.auth import PlainTextAuthProvider
 from cassandra.query import BatchStatement
+from ssl import SSLContext, PROTOCOL_TLSv1_2
 import uuid
 import time
 
@@ -21,12 +22,14 @@ class TableStore:
         print("Connecting to Cassandra...", flush=True)
 
         if cassandra_user and cassandra_password:
+            ssl_context = SSLContext(PROTOCOL_TLSv1_2)
             auth_provider = PlainTextAuthProvider(
                 username=cassandra_user, password=cassandra_password
             )
             self.cluster = Cluster(
                 cassandra_host,
-                auth_provider=auth_provider
+                auth_provider=auth_provider,
+                ssl_context=ssl_context
             )
         else:
             self.cluster = Cluster(cassandra_host)

--- a/trustgraph-flow/trustgraph/storage/rows/cassandra/write.py
+++ b/trustgraph-flow/trustgraph/storage/rows/cassandra/write.py
@@ -10,6 +10,7 @@ import argparse
 import time
 from cassandra.cluster import Cluster
 from cassandra.auth import PlainTextAuthProvider
+from ssl import SSLContext, PROTOCOL_TLSv1_2
 
 from .... schema import Rows
 from .... schema import rows_store_queue
@@ -17,6 +18,7 @@ from .... log_level import LogLevel
 from .... base import Consumer
 
 module = ".".join(__name__.split(".")[1:-1])
+ssl_context = SSLContext(PROTOCOL_TLSv1_2)
 
 default_input_queue = rows_store_queue
 default_subscriber = module
@@ -45,7 +47,7 @@ class Processor(Consumer):
         
         if graph_username and graph_password:
             auth_provider = PlainTextAuthProvider(username=graph_username, password=graph_password)
-            self.cluster = Cluster(graph_host.split(","), auth_provider=auth_provider)
+            self.cluster = Cluster(graph_host.split(","), auth_provider=auth_provider, ssl_context=ssl_context)
         else:
             self.cluster = Cluster(graph_host.split(","))
         self.session = self.cluster.connect()


### PR DESCRIPTION
Following recommended approach in Datastax documenation I've added the necessary TLS/SSL check

https://docs.datastax.com/en/developer/python-driver/3.17/security/index.html
https://github.com/bitnami/charts/issues/12931

This was raised as an issue after trying to start the containers and recieving the following error

```store-triples-1             | Exception ('Unable to connect to any servers', {'10.0.0.5:9042': ProtocolError('This version of the driver does not support protocol version 21')})```
This pull request introduces SSL/TLS support for Cassandra connections across multiple files in the `trustgraph-flow` project. The changes ensure secure connections by incorporating the `SSLContext` with `PROTOCOL_TLSv1_2`.

### Enhancements to Cassandra connections:

* [`trustgraph-flow/trustgraph/direct/cassandra.py`](diffhunk://#diff-7f7079c949cc163dc30ce3dbe5509a7a0f756b67583a22feecc20cd83b800fa8R4): Added SSL/TLS support by importing `SSLContext` and `PROTOCOL_TLSv1_2`, and updating the `Cluster` initialization to use the `ssl_context` parameter. [[1]](diffhunk://#diff-7f7079c949cc163dc30ce3dbe5509a7a0f756b67583a22feecc20cd83b800fa8R4) [[2]](diffhunk://#diff-7f7079c949cc163dc30ce3dbe5509a7a0f756b67583a22feecc20cd83b800fa8R21-R23)
* [`trustgraph-flow/trustgraph/librarian/table_store.py`](diffhunk://#diff-260cb47adacfc751256750d006884e8a44b27e9ec29f25245877062ae204adccR9): Enhanced the connection security by adding `SSLContext` and `PROTOCOL_TLSv1_2`, and modifying the `Cluster` initialization to include the `ssl_context` parameter. [[1]](diffhunk://#diff-260cb47adacfc751256750d006884e8a44b27e9ec29f25245877062ae204adccR9) [[2]](diffhunk://#diff-260cb47adacfc751256750d006884e8a44b27e9ec29f25245877062ae204adccR25-R32)
* [`trustgraph-flow/trustgraph/storage/rows/cassandra/write.py`](diffhunk://#diff-bce9c168e6e56801f6569b1081c7f33f98a82c099754eddd952f59b6c19b451fR13-R21): Improved security by integrating `SSLContext` and `PROTOCOL_TLSv1_2`, and updating the `Cluster` initialization to utilize the `ssl_context` parameter. [[1]](diffhunk://#diff-bce9c168e6e56801f6569b1081c7f33f98a82c099754eddd952f59b6c19b451fR13-R21) [[2]](diffhunk://#diff-bce9c168e6e56801f6569b1081c7f33f98a82c099754eddd952f59b6c19b451fL48-R50)