### PR TITLE
Feature/prompt set cli

### DIFF
--- a/trustgraph-cli/scripts/tg-set-prompt
+++ b/trustgraph-cli/scripts/tg-set-prompt
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+
+"""
+Dumps out the current prompts
+"""
+
+import argparse
+import os
+from trustgraph.api import Api, ConfigKey, ConfigValue
+import json
+import tabulate
+import textwrap
+
+default_url = os.getenv("TRUSTGRAPH_URL", 'http://localhost:8088/')
+
+def set_system(url, system):
+
+    api = Api(url)
+
+    api.config_put([
+        ConfigValue(type="prompt", key="system", value=json.dumps(system))
+    ])
+
+    print("System prompt set.")
+
+def set_prompt(url, id, prompt, response, schema):
+
+    api = Api(url)
+
+    values = api.config_get([
+        ConfigKey(type="prompt", key="template-index")
+    ])
+
+    ix = json.loads(values[0].value)
+
+    object = {
+        "id": id,
+        "prompt": prompt,
+    }
+
+    if response:
+        object["response-type"] = response
+    else:
+        object["response-type"] = "text"
+
+    if schema:
+        object["schema"] = schema
+
+    if id not in ix:
+        ix.append(id)
+
+    values = api.config_put([
+        ConfigValue(
+            type="prompt", key="template-index", value=json.dumps(ix)
+        ),
+        ConfigValue(
+            type="prompt", key=f"template.{id}", value=json.dumps(object)
+        )
+    ])
+
+    print("Prompt set.")
+
+def main():
+
+    parser = argparse.ArgumentParser(
+        prog='tg-show-prompts',
+        description=__doc__,
+    )
+
+    parser.add_argument(
+        '-u', '--api-url',
+        default=default_url,
+        help=f'API URL (default: {default_url})',
+    )
+
+    parser.add_argument(
+        '--id',
+        help=f'Prompt ID',
+    )
+
+    parser.add_argument(
+        '--response',
+        help=f'Response form, should be one of: text json',
+    )
+
+    parser.add_argument(
+        '--schema',
+        help=f'JSON schema, for JSON response form',
+    )
+
+    parser.add_argument(
+        '--prompt',
+        help=f'Prompt template',
+    )
+
+    parser.add_argument(
+        '--system',
+        help=f'System prompt',
+    )
+
+    args = parser.parse_args()
+
+    try:
+
+        if args.system:
+            if args.id or args.prompt or args.schema or args.response:
+                raise RuntimeError("Can't use --system with other args")
+                
+            set_system(
+                url=args.api_url, system=args.system
+            )
+
+        else:
+
+            if args.id is None:
+                raise RuntimeError("Must specify --id for prompt")
+
+            if args.prompt is None:
+                raise RuntimeError("Must specify --prompt for prompt")
+
+            if args.response:
+                if args.response not in ["text", "json"]:
+                    raise RuntimeError("Response must be one of: text json")
+                    
+            if args.schema:
+                try:
+                    schobj = json.loads(args.schema)
+                except:
+                    raise RuntimeError("JSON schema must be valid JSON")
+            else:
+                schobj = None
+
+            set_prompt(
+                url=args.api_url, id=args.id, prompt=args.prompt,
+                response=args.response, schema=schobj
+            )
+
+    except Exception as e:
+
+        print("Exception:", e, flush=True)
+
+main()
+

--- a/trustgraph-cli/setup.py
+++ b/trustgraph-cli/setup.py
@@ -63,6 +63,7 @@ setuptools.setup(
         "scripts/tg-save-kg-core",
         "scripts/tg-save-doc-embeds",
         "scripts/tg-show-config",
+        "scripts/tg-set-prompt",
         "scripts/tg-show-tools",
         "scripts/tg-show-prompts",
     ]


### PR DESCRIPTION
Set a prompt with no args (response=text is the default)...
```
$ tg-set-prompt --id fish --prompt 'What is a fish like?' --response=text
```

Invoke the prompt...
```
$ tg-invoke-prompt fish
Okay, let's break down what a fish is like! Fish are incredibly diverse, but they share some common characteristics:

1.  **Live in Water:** This is the defining feature. Fish are aquatic animals found in saltwater (oceans, seas) and freshwater (rivers, lakes, ponds).
...
```

With prompt variables...
```
$ tg-set-prompt --id legs --prompt 'How many legs does a {{animal}} have? '
$ tg-invoke-prompt 'legs' 'animal=cat'
A cat typically has **four** legs.
```

Multiple prompt variables...

```
$ tg-set-prompt --id addition --prompt 'Add {{x}} and {{y}}.'
Prompt set.
$ tg-invoke-prompt addition x=12 y=14
Okay, adding 12 and 14:

12 + 14 = 26
```

JSON output...
```
$ tg-set-prompt --id legs --prompt 'How many legs does a {{animal}} have?  Return as a JSON object.' --response=json
$ tg-invoke-prompt 'legs' 'animal=cat'
{
    "animal": "cat",
    "numberOfLegs": 4
}
```
Note: response=json tells the prompt engine to parse the output as JSON and return an object instead of text.  In order to get this to work, the LLM prompt needs to absolutely do the work to get the LLM to output JSON, including describing parameters etc.


Dump out all the prompts...
```
$ tg-show-prompts
...
fish:
+----------+----------------------+
| prompt   | What is a fish like? |
| response | text                 |
+----------+----------------------+

legs:
+----------+-----------------------------------------------------------------+
| prompt   | How many legs does a {{animal}} have?  Return as a JSON object. |
| response | json                                                            |
+----------+-----------------------------------------------------------------+

addition:
+----------+----------------------+
| prompt   | Add {{x}} and {{y}}. |
| response | text                 |
+----------+----------------------+
```