### PR TITLE
Add multi-threading to consumer base-class and all LLMs

### DIFF
--- a/trustgraph-base/trustgraph/base/consumer_spec.py
+++ b/trustgraph-base/trustgraph/base/consumer_spec.py
@@ -4,10 +4,11 @@ from . consumer import Consumer
 from . spec import Spec
 
 class ConsumerSpec(Spec):
-    def __init__(self, name, schema, handler):
+    def __init__(self, name, schema, handler, concurrency = 1):
         self.name = name
         self.schema = schema
         self.handler = handler
+        self.concurrency = concurrency
 
     def add(self, flow, processor, definition):
 
@@ -24,6 +25,7 @@ class ConsumerSpec(Spec):
             schema = self.schema,
             handler = self.handler,
             metrics = consumer_metrics,
+            concurrency = self.concurrency
         )
 
         # Consumer handle gets access to producers and other

--- a/trustgraph-base/trustgraph/base/llm_service.py
+++ b/trustgraph-base/trustgraph/base/llm_service.py
@@ -11,9 +11,13 @@ from .. exceptions import TooManyRequests
 from .. base import FlowProcessor, ConsumerSpec, ProducerSpec
 
 default_ident = "text-completion"
+default_concurrency = 1
 
 class LlmResult:
-    def __init__(self, text=None, in_token=None, out_token=None, model=None):
+    def __init__(
+            self, text = None, in_token = None, out_token = None,
+            model = None,
+    ):
         self.text = text
         self.in_token = in_token
         self.out_token = out_token
@@ -25,14 +29,19 @@ class LlmService(FlowProcessor):
     def __init__(self, **params):
 
         id = params.get("id")
+        concurrency = params.get("concurrency", 1)
 
-        super(LlmService, self).__init__(**params | { "id": id })
+        super(LlmService, self).__init__(**params | {
+            "id": id,
+            "concurrency": concurrency,
+        })
 
         self.register_specification(
             ConsumerSpec(
                 name = "request",
                 schema = TextCompletionRequest,
-                handler = self.on_request
+                handler = self.on_request,
+                concurrency = concurrency,
             )
         )
 
@@ -114,6 +123,13 @@ class LlmService(FlowProcessor):
 
     @staticmethod
     def add_args(parser):
+
+        parser.add_argument(
+            '-c', '--concurrency',
+            type=int,
+            default=default_concurrency,
+            help=f'LLM max output tokens (default: {default_concurrency})'
+        )
 
         FlowProcessor.add_args(parser)
 

--- a/trustgraph-base/trustgraph/base/subscriber.py
+++ b/trustgraph-base/trustgraph/base/subscriber.py
@@ -1,4 +1,8 @@
 
+# Subscriber is similar to consumer: It provides a service to take stuff
+# off of a queue and make it available using an internal broker system,
+# so suitable for when multiple recipients are reading from the same queue
+
 from pulsar.schema import JsonSchema
 import asyncio
 import _pulsar


### PR DESCRIPTION
There's a --concurrency option on all LLMs which states how many LLM threads can run in parallel.

Note: only works on async processors, some of the LLM services are synchronous, and need non-blocking support adding to get this to work