### PR TITLE
Fix Mistral OCR ident to be standard pdf-decoder

### DIFF
--- a/tests/unit/test_decoding/test_mistral_ocr_processor.py
+++ b/tests/unit/test_decoding/test_mistral_ocr_processor.py
@@ -288,7 +288,7 @@ class TestMistralOcrProcessor(IsolatedAsyncioTestCase):
         run()
         
         # Assert
-        mock_launch.assert_called_once_with("mistral-ocr", 
+        mock_launch.assert_called_once_with("pdf-decoder",
             "\nSimple decoder, accepts PDF documents on input, outputs pages from the\nPDF document as text as separate output objects.\n")
 
 

--- a/trustgraph-flow/trustgraph/decoding/mistral_ocr/processor.py
+++ b/trustgraph-flow/trustgraph/decoding/mistral_ocr/processor.py
@@ -21,7 +21,7 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-default_ident = "mistral-ocr"
+default_ident = "pdf-decoder"
 default_api_key = os.getenv("MISTRAL_TOKEN")
 
 pages_per_chunk = 5


### PR DESCRIPTION
This causes Mistral OCR to behave like a PDF decoder in the pipelines