### PR TITLE
trustgraph-base .chunks / .documents confusion in the API

### DIFF
--- a/trustgraph-base/trustgraph/base/document_embeddings_client.py
+++ b/trustgraph-base/trustgraph/base/document_embeddings_client.py
@@ -27,7 +27,7 @@ class DocumentEmbeddingsClient(RequestResponse):
         if resp.error:
             raise RuntimeError(resp.error.message)
 
-        return resp.documents
+        return resp.chunks
 
 class DocumentEmbeddingsClientSpec(RequestResponseSpec):
     def __init__(

--- a/trustgraph-base/trustgraph/clients/document_embeddings_client.py
+++ b/trustgraph-base/trustgraph/clients/document_embeddings_client.py
@@ -47,5 +47,5 @@ class DocumentEmbeddingsClient(BaseClient):
         return self.call(
             user=user, collection=collection,
             vectors=vectors, limit=limit, timeout=timeout
-        ).documents
+        ).chunks
 

--- a/trustgraph-base/trustgraph/messaging/translators/embeddings_query.py
+++ b/trustgraph-base/trustgraph/messaging/translators/embeddings_query.py
@@ -36,10 +36,10 @@ class DocumentEmbeddingsResponseTranslator(MessageTranslator):
     def from_pulsar(self, obj: DocumentEmbeddingsResponse) -> Dict[str, Any]:
         result = {}
         
-        if obj.documents:
-            result["documents"] = [
-                doc.decode("utf-8") if isinstance(doc, bytes) else doc
-                for doc in obj.documents
+        if obj.chunks:
+            result["chunks"] = [
+                chunk.decode("utf-8") if isinstance(chunk, bytes) else chunk
+                for chunk in obj.chunks
             ]
         
         return result


### PR DESCRIPTION
Fixes error...

```
Exception: document-rag-error: 'DocumentEmbeddingsResponse' object has no attribute 'documents'
```

caused by chunks / documents naming mismatch
