### PR TITLE
Feature/tool group

### DIFF
--- a/docs/tech-specs/tool-group.md
+++ b/docs/tech-specs/tool-group.md
@@ -1,0 +1,435 @@
+# TrustGraph Tool Group System
+## Technical Specification v1.0
+
+### Executive Summary
+
+This specification defines a tool grouping system for TrustGraph agents that allows fine-grained control over which tools are available for specific requests. The system introduces group-based tool filtering through configuration and request-level specification, enabling better security boundaries, resource management, and functional partitioning of agent capabilities.
+
+### 1. Overview
+
+#### 1.1 Problem Statement
+
+Currently, TrustGraph agents have access to all configured tools regardless of request context or security requirements. This creates several challenges:
+
+- **Security Risk**: Sensitive tools (e.g., data modification) are available even for read-only queries
+- **Resource Waste**: Complex tools are loaded even when simple queries don't require them  
+- **Functional Confusion**: Agents may select inappropriate tools when simpler alternatives exist
+- **Multi-tenant Isolation**: Different user groups need access to different tool sets
+
+#### 1.2 Solution Overview
+
+The tool group system introduces:
+
+1. **Group Classification**: Tools are tagged with group memberships during configuration
+2. **Request-level Filtering**: AgentRequest specifies which tool groups are permitted
+3. **Runtime Enforcement**: Agents only have access to tools matching the requested groups
+4. **Flexible Grouping**: Tools can belong to multiple groups for complex scenarios
+
+### 2. Schema Changes
+
+#### 2.1 Tool Configuration Schema Enhancement
+
+The existing tool configuration is enhanced with a `group` field:
+
+**Before:**
+```json
+{
+  "name": "knowledge-query",
+  "type": "knowledge-query", 
+  "description": "Query the knowledge graph"
+}
+```
+
+**After:**
+```json
+{
+  "name": "knowledge-query",
+  "type": "knowledge-query",
+  "description": "Query the knowledge graph",
+  "group": ["read-only", "knowledge", "basic"]
+}
+```
+
+**Group Field Specification:**
+- `group`: Array(String) - List of groups this tool belongs to
+- **Optional**: Tools without group field belong to "default" group
+- **Multi-membership**: Tools can belong to multiple groups
+- **Case-sensitive**: Group names are exact string matches
+
+#### 2.2 AgentRequest Schema Enhancement
+
+The `AgentRequest` schema in `trustgraph-base/trustgraph/schema/services/agent.py` is enhanced:
+
+**Current AgentRequest:**
+- `question`: String - User query
+- `plan`: String - Execution plan  
+- `state`: String - Agent state
+- `history`: Array(AgentStep) - Execution history
+
+**Enhanced AgentRequest:**
+- `question`: String - User query
+- `plan`: String - Execution plan
+- `state`: String - Agent state  
+- `history`: Array(AgentStep) - Execution history
+- `group`: Array(String) - **NEW** - Tool groups allowed for this request
+
+**Group Field Behavior:**
+- **Optional**: If not specified, defaults to ["default"]
+- **Intersection**: Only tools matching at least one specified group are available
+- **Empty array**: No tools available (agent can only use internal reasoning)
+- **Wildcard**: Special group "*" grants access to all tools
+
+### 3. Tool Group Categories
+
+#### 3.1 Predefined Group Categories
+
+**Security-Based Groups:**
+- `read-only`: Tools that only read data (GraphQuery, KnowledgeQuery)
+- `write`: Tools that modify data (GraphUpdate, DocumentStore)
+- `admin`: Administrative tools (SystemConfig, UserManagement)
+
+**Functional Groups:**
+- `knowledge`: Knowledge graph operations
+- `text`: Text processing and completion
+- `search`: Search and retrieval operations
+- `compute`: Computation and analysis tools
+
+**Complexity Groups:**
+- `basic`: Simple, fast tools for common operations
+- `advanced`: Complex tools for specialized tasks  
+- `experimental`: Beta/experimental tools
+
+**Resource Groups:**
+- `local`: Tools that run locally
+- `remote`: Tools that require external services
+- `expensive`: Resource-intensive tools
+
+#### 3.2 Custom Group Examples
+
+Organizations can define domain-specific groups:
+
+```json
+{
+  "financial-tools": ["stock-query", "portfolio-analysis"],
+  "medical-tools": ["diagnosis-assist", "drug-interaction"],
+  "legal-tools": ["contract-analysis", "case-search"]
+}
+```
+
+### 4. Implementation Details
+
+#### 4.1 Tool Loading and Filtering
+
+**Configuration Phase:**
+1. All tools are loaded from configuration with their group assignments
+2. Tools without explicit groups are assigned to "default" group
+3. Group membership is validated and stored in tool registry
+
+**Request Processing Phase:**
+1. AgentRequest arrives with optional group specification
+2. Agent filters available tools based on group intersection
+3. Only matching tools are passed to agent execution context
+4. Agent operates with filtered tool set throughout request lifecycle
+
+#### 4.2 Group Resolution Logic
+
+```
+For each configured tool:
+  tool_groups = tool.group || ["default"]
+  
+For each request:
+  requested_groups = request.group || ["default"]
+  
+Tool is available if:
+  intersection(tool_groups, requested_groups) is not empty
+  OR
+  "*" in requested_groups
+```
+
+#### 4.3 Agent Integration Points
+
+**ReAct Agent:**
+- Tool filtering occurs in agent_manager.py during tool registry creation
+- Available tools list is pre-filtered before plan generation
+- No changes to execution logic required
+
+**Confidence-Based Agent:**
+- Tool filtering occurs in planner.py during plan generation
+- ExecutionStep validation ensures only available tools are used
+- Flow controller enforces tool availability at runtime
+
+### 5. Configuration Examples
+
+#### 5.1 Tool Configuration with Groups
+
+```yaml
+tool:
+  knowledge-query:
+    type: knowledge-query
+    name: "Knowledge Graph Query"
+    description: "Query the knowledge graph for entities and relationships"
+    group: ["read-only", "knowledge", "basic"]
+    
+  graph-update:
+    type: graph-update
+    name: "Graph Update"
+    description: "Add or modify entities in the knowledge graph"
+    group: ["write", "knowledge", "admin"]
+    
+  text-completion:
+    type: text-completion
+    name: "Text Completion"
+    description: "Generate text using language models"
+    group: ["read-only", "text", "basic"]
+    
+  complex-analysis:
+    type: mcp-tool
+    name: "Complex Analysis Tool"
+    description: "Perform complex data analysis"
+    group: ["advanced", "compute", "expensive"]
+    mcp_tool_id: "analysis-server"
+```
+
+#### 5.2 Request Examples
+
+**Read-only Knowledge Query:**
+```json
+{
+  "question": "What entities are connected to Company X?",
+  "group": ["read-only", "knowledge"]
+}
+```
+*Available tools: knowledge-query only*
+
+**Administrative Task:**
+```json
+{
+  "question": "Update the company profile and analyze impact",
+  "group": ["write", "knowledge", "compute"]
+}
+```
+*Available tools: graph-update, complex-analysis*
+
+**Unrestricted Access:**
+```json
+{
+  "question": "Perform comprehensive analysis",
+  "group": ["*"]
+}
+```
+*Available tools: All configured tools*
+
+**Basic Operations Only:**
+```json
+{
+  "question": "Simple information lookup",
+  "group": ["basic"]
+}
+```
+*Available tools: knowledge-query, text-completion*
+
+### 6. Security Considerations
+
+#### 6.1 Access Control Integration
+
+**Gateway-Level Filtering:**
+- Gateway can enforce group restrictions based on user permissions
+- Prevent elevation of privileges through request manipulation
+- Audit trail includes requested and granted tool groups
+
+**Example Gateway Logic:**
+```
+user_permissions = get_user_permissions(request.user_id)
+allowed_groups = user_permissions.tool_groups
+requested_groups = request.group
+
+# Validate request doesn't exceed permissions
+if not is_subset(requested_groups, allowed_groups):
+    reject_request("Insufficient permissions for requested tool groups")
+```
+
+#### 6.2 Audit and Monitoring
+
+**Enhanced Audit Trail:**
+- Log requested tool groups per request
+- Track tool usage by group membership
+- Monitor unauthorized group access attempts
+- Alert on unusual group usage patterns
+
+### 7. Migration Strategy
+
+#### 7.1 Backward Compatibility
+
+**Phase 1: Additive Changes**
+- Add optional `group` field to tool configurations
+- Add optional `group` field to AgentRequest schema
+- Default behavior: All existing tools belong to "default" group
+- Existing requests without group field use "default" group
+
+**Existing Behavior Preserved:**
+- Tools without group configuration continue to work
+- Requests without group specification access all tools
+- No breaking changes to existing deployments
+
+#### 7.2 Migration Path
+
+**Step 1: Schema Deployment**
+- Deploy enhanced schemas with optional fields
+- Verify existing tools and requests continue to work
+
+**Step 2: Tool Classification**
+- Gradually add group classifications to tool configurations
+- Start with security-critical tools (read-only vs write)
+- Expand to functional and complexity groups
+
+**Step 3: Request Integration**
+- Update client applications to specify appropriate groups
+- Implement gateway-level access control
+- Monitor usage patterns and refine groups
+
+**Step 4: Enforcement**
+- Gradually tighten default permissions
+- Eventually require explicit group specification for new deployments
+
+### 8. Monitoring and Observability
+
+#### 8.1 New Metrics
+
+**Tool Group Usage:**
+- `agent_tool_group_requests_total` - Counter of requests by group
+- `agent_tool_group_availability` - Gauge of tools available per group
+- `agent_filtered_tools_count` - Histogram of tool count after filtering
+
+**Security Metrics:**
+- `agent_group_access_denied_total` - Counter of unauthorized group access
+- `agent_privilege_escalation_attempts_total` - Counter of suspicious requests
+
+#### 8.2 Logging Enhancements
+
+**Request Logging:**
+```json
+{
+  "request_id": "req-123",
+  "requested_groups": ["read-only", "knowledge"],
+  "available_tools": ["knowledge-query"],
+  "filtered_tools": ["graph-update", "admin-tool"],
+  "execution_time": "1.2s"
+}
+```
+
+### 9. Testing Strategy
+
+#### 9.1 Unit Tests
+
+**Tool Filtering Logic:**
+- Test group intersection calculations
+- Verify default group assignment
+- Test wildcard group behavior
+- Validate empty group handling
+
+**Configuration Validation:**
+- Test tool loading with various group configurations
+- Verify schema validation for invalid group specifications
+- Test backward compatibility with existing configurations
+
+#### 9.2 Integration Tests
+
+**Agent Behavior:**
+- Verify agents only see filtered tools
+- Test request execution with various group combinations
+- Validate error handling when no tools are available
+
+**Security Testing:**
+- Test privilege escalation prevention
+- Verify audit trail accuracy
+- Test gateway integration with user permissions
+
+#### 9.3 End-to-End Scenarios
+
+**Multi-tenant Usage:**
+```
+Scenario: Different users with different tool access
+Given: User A has "read-only" permissions
+  And: User B has "write" permissions
+When: Both request knowledge operations
+Then: User A gets filtered tool set
+  And: User B gets full tool set
+  And: All usage is properly audited
+```
+
+### 10. Performance Considerations
+
+#### 10.1 Tool Loading Impact
+
+**Configuration Loading:**
+- Group metadata is loaded once at startup
+- Minimal memory overhead per tool
+- No impact on tool initialization time
+
+**Request Processing:**
+- Tool filtering occurs once per request
+- O(n) complexity where n = number of configured tools
+- Negligible impact for typical tool counts (< 100)
+
+#### 10.2 Optimization Strategies
+
+**Pre-computed Group Sets:**
+- Cache tool sets by group combination
+- Avoid repeated filtering for common group patterns
+- Memory vs computation tradeoff
+
+**Lazy Loading:**
+- Load tool implementations only when needed
+- Reduce startup time for deployments with many tools
+- Dynamic tool registration based on group requirements
+
+### 11. Future Enhancements
+
+#### 11.1 Dynamic Group Assignment
+
+**Context-Aware Grouping:**
+- Assign tools to groups based on request context
+- Time-based group availability (business hours only)
+- Load-based group restrictions (expensive tools during low usage)
+
+#### 11.2 Group Hierarchies
+
+**Nested Group Structure:**
+```json
+{
+  "knowledge": {
+    "read": ["knowledge-query", "entity-search"],
+    "write": ["graph-update", "entity-create"]
+  }
+}
+```
+
+#### 11.3 Tool Recommendations
+
+**Group-Based Suggestions:**
+- Suggest optimal tool groups for request types
+- Learn from usage patterns to improve recommendations
+- Provide fallback groups when preferred tools are unavailable
+
+### 12. Open Questions
+
+1. **Group Validation**: Should invalid group names in requests cause hard failures or warnings?
+
+2. **Group Discovery**: Should the system provide an API to list available groups and their tools?
+
+3. **Dynamic Groups**: Should groups be configurable at runtime or only at startup?
+
+4. **Group Inheritance**: Should tools inherit groups from their parent categories or implementations?
+
+5. **Performance Monitoring**: What additional metrics are needed to track group-based tool usage effectively?
+
+### 13. Conclusion
+
+The tool group system provides:
+
+- **Security**: Fine-grained access control over agent capabilities
+- **Performance**: Reduced tool loading and selection overhead
+- **Flexibility**: Multi-dimensional tool classification
+- **Compatibility**: Seamless integration with existing agent architectures
+
+This system enables TrustGraph deployments to better manage tool access, improve security boundaries, and optimize resource usage while maintaining full backward compatibility with existing configurations and requests.

--- a/tests/integration/test_tool_group_integration.py
+++ b/tests/integration/test_tool_group_integration.py
@@ -7,7 +7,13 @@ tool filtering and execution in the ReAct agent service.
 
 import pytest
 import json
+import sys
+import os
 from unittest.mock import Mock, AsyncMock, patch
+
+# Add trustgraph paths for imports
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', 'trustgraph-base'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', 'trustgraph-flow'))
 
 from trustgraph.schema import AgentRequest, AgentResponse, AgentStep
 from trustgraph.agent.react.service import Processor

--- a/tests/integration/test_tool_group_integration.py
+++ b/tests/integration/test_tool_group_integration.py
@@ -1,0 +1,454 @@
+"""
+Integration tests for the tool group system.
+
+Tests the complete workflow from AgentRequest processing through 
+tool filtering and execution in the ReAct agent service.
+"""
+
+import pytest
+import json
+from unittest.mock import Mock, AsyncMock, patch
+
+from trustgraph.schema import AgentRequest, AgentResponse, AgentStep
+from trustgraph.agent.react.service import Processor
+from trustgraph.agent.react.types import Tool, Argument
+
+
+@pytest.fixture
+def sample_tools():
+    """Sample tools with different groups and states for testing."""
+    return {
+        'knowledge_query': Tool(
+            name='knowledge_query',
+            description='Query knowledge graph',
+            implementation=Mock(),
+            config={
+                'group': ['read-only', 'knowledge', 'basic'],
+                'state': 'analysis',
+                'available_in_states': ['undefined', 'research']
+            },
+            arguments=[]
+        ),
+        'graph_update': Tool(
+            name='graph_update', 
+            description='Update knowledge graph',
+            implementation=Mock(),
+            config={
+                'group': ['write', 'knowledge', 'admin'],
+                'available_in_states': ['analysis', 'modification']
+            },
+            arguments=[]
+        ),
+        'text_completion': Tool(
+            name='text_completion',
+            description='Generate text',
+            implementation=Mock(),
+            config={
+                'group': ['read-only', 'text', 'basic'],
+                'state': 'undefined'
+                # No available_in_states = available in all states
+            },
+            arguments=[]
+        ),
+        'complex_analysis': Tool(
+            name='complex_analysis',
+            description='Complex analysis tool',
+            implementation=Mock(),
+            config={
+                'group': ['advanced', 'compute', 'expensive'],
+                'state': 'results',
+                'available_in_states': ['analysis']
+            },
+            arguments=[]
+        )
+    }
+
+
+@pytest.fixture
+def agent_processor():
+    """Create agent processor for testing."""
+    return Processor(id="test-agent", max_iterations=5)
+
+
+class TestAgentRequestProcessing:
+    """Test AgentRequest processing with tool groups and states."""
+
+    @pytest.mark.asyncio
+    async def test_basic_group_filtering(self, agent_processor, sample_tools):
+        """Test that agent only sees tools matching requested groups."""
+        
+        # Setup agent with sample tools
+        agent_processor.agent.tools = sample_tools
+        
+        # Mock the agent's react method to return a Final response
+        from trustgraph.agent.react.types import Final
+        mock_final = Final(final="Test response")
+        agent_processor.agent.react = AsyncMock(return_value=mock_final)
+        
+        # Create request with read-only group
+        request = AgentRequest(
+            question="Test question",
+            state="undefined",
+            group=["read-only", "knowledge"],
+            history=[]
+        )
+        
+        responses = []
+        
+        async def mock_respond(response):
+            responses.append(response)
+            
+        async def mock_next(next_request):
+            pass  # Not needed for this test
+            
+        # Process request
+        await agent_processor.agent_request(request, mock_respond, mock_next, {})
+        
+        # Verify agent was called with filtered tools
+        agent_processor.agent.react.assert_called_once()
+        call_kwargs = agent_processor.agent.react.call_args.kwargs
+        
+        # The agent should have been created with filtered tools
+        # We can't directly inspect the temp agent, but we can verify the filtering worked
+        # by checking that only appropriate tools would have been available
+        
+        # Verify final response was sent
+        assert len(responses) == 1
+        assert responses[0].answer == "Test response"
+
+    @pytest.mark.asyncio 
+    async def test_state_based_filtering(self, agent_processor, sample_tools):
+        """Test filtering based on current state."""
+        
+        agent_processor.agent.tools = sample_tools
+        
+        from trustgraph.agent.react.types import Final
+        mock_final = Final(final="Analysis complete")
+        agent_processor.agent.react = AsyncMock(return_value=mock_final)
+        
+        # Create request in 'analysis' state
+        request = AgentRequest(
+            question="Perform analysis",
+            state="analysis",  
+            group=["advanced", "compute"],
+            history=[]
+        )
+        
+        responses = []
+        
+        async def mock_respond(response):
+            responses.append(response)
+            
+        # Process request
+        await agent_processor.agent_request(request, mock_respond, lambda x: None, {})
+        
+        # Verify response
+        assert len(responses) == 1
+        assert responses[0].answer == "Analysis complete"
+
+    @pytest.mark.asyncio
+    async def test_state_transition_handling(self, agent_processor, sample_tools):
+        """Test state transitions after tool execution."""
+        
+        agent_processor.agent.tools = sample_tools
+        
+        # Mock agent to return an action that uses knowledge_query
+        from trustgraph.agent.react.types import Action
+        mock_action = Action(
+            thought="I need to query knowledge",
+            name="knowledge_query",
+            arguments={},
+            observation="Found information"
+        )
+        agent_processor.agent.react = AsyncMock(return_value=mock_action)
+        
+        # Create initial request
+        request = AgentRequest(
+            question="Research question",
+            state="undefined",
+            group=["read-only", "knowledge"],
+            history=[]
+        )
+        
+        next_requests = []
+        
+        async def mock_next(next_request):
+            next_requests.append(next_request)
+            
+        # Process request
+        await agent_processor.agent_request(request, lambda x: None, mock_next, {})
+        
+        # Verify state transition occurred
+        assert len(next_requests) == 1
+        next_req = next_requests[0]
+        assert next_req.state == "analysis"  # knowledge_query transitions to analysis
+        assert next_req.group == ["read-only", "knowledge"]
+
+    @pytest.mark.asyncio
+    async def test_wildcard_group_access(self, agent_processor, sample_tools):
+        """Test wildcard group grants access to all tools."""
+        
+        agent_processor.agent.tools = sample_tools
+        
+        from trustgraph.agent.react.types import Final
+        mock_final = Final(final="All tools available")
+        agent_processor.agent.react = AsyncMock(return_value=mock_final)
+        
+        # Create request with wildcard group
+        request = AgentRequest(
+            question="Administrative task",
+            state="undefined",
+            group=["*"],  # Wildcard access
+            history=[]
+        )
+        
+        responses = []
+        
+        async def mock_respond(response):
+            responses.append(response)
+            
+        # Process request  
+        await agent_processor.agent_request(request, mock_respond, lambda x: None, {})
+        
+        # All tools should have been available to the agent
+        assert len(responses) == 1
+        assert responses[0].answer == "All tools available"
+
+    @pytest.mark.asyncio
+    async def test_no_matching_tools(self, agent_processor, sample_tools):
+        """Test behavior when no tools match the requested groups."""
+        
+        agent_processor.agent.tools = sample_tools
+        
+        from trustgraph.agent.react.types import Final
+        mock_final = Final(final="No tools available")
+        agent_processor.agent.react = AsyncMock(return_value=mock_final)
+        
+        # Create request with non-matching group
+        request = AgentRequest(
+            question="Some task",
+            state="undefined", 
+            group=["nonexistent-group"],
+            history=[]
+        )
+        
+        responses = []
+        
+        async def mock_respond(response):
+            responses.append(response)
+            
+        # Process request
+        await agent_processor.agent_request(request, mock_respond, lambda x: None, {})
+        
+        # Agent should still work but with empty tool set
+        assert len(responses) == 1
+
+    @pytest.mark.asyncio
+    async def test_default_group_behavior(self, agent_processor):
+        """Test default group behavior when no group is specified."""
+        
+        # Create tools with and without explicit groups
+        tools = {
+            'default_tool': Tool(
+                name='default_tool',
+                description='Default tool',
+                implementation=Mock(),
+                config={},  # No group = default group
+                arguments=[]
+            ),
+            'admin_tool': Tool(
+                name='admin_tool',
+                description='Admin tool', 
+                implementation=Mock(),
+                config={'group': ['admin']},
+                arguments=[]
+            )
+        }
+        
+        agent_processor.agent.tools = tools
+        
+        from trustgraph.agent.react.types import Final
+        mock_final = Final(final="Default tools only")
+        agent_processor.agent.react = AsyncMock(return_value=mock_final)
+        
+        # Create request without specifying group (should default to ["default"])
+        request = AgentRequest(
+            question="Basic task",
+            state="undefined",
+            group=None,  # Should default to ["default"]
+            history=[]
+        )
+        
+        responses = []
+        
+        async def mock_respond(response):
+            responses.append(response)
+            
+        # Process request
+        await agent_processor.agent_request(request, mock_respond, lambda x: None, {})
+        
+        # Only default_tool should have been available
+        assert len(responses) == 1
+
+
+class TestToolConfigurationLoading:
+    """Test tool configuration loading with group metadata."""
+
+    @pytest.mark.asyncio
+    async def test_tool_config_validation(self, agent_processor):
+        """Test that invalid tool configurations are rejected."""
+        
+        # Mock configuration with invalid group field
+        invalid_config = {
+            "tool": {
+                "invalid-tool": json.dumps({
+                    "name": "invalid_tool",
+                    "description": "Invalid tool",
+                    "type": "text-completion",
+                    "group": "not-a-list"  # Should be list
+                })
+            }
+        }
+        
+        # Should raise validation error
+        with pytest.raises(ValueError, match="'group' field must be a list"):
+            await agent_processor.on_tools_config(invalid_config, 1)
+
+    @pytest.mark.asyncio
+    async def test_valid_tool_config_loading(self, agent_processor):
+        """Test that valid tool configurations load successfully."""
+        
+        valid_config = {
+            "tool": {
+                "valid-tool": json.dumps({
+                    "name": "valid_tool",
+                    "description": "Valid tool",
+                    "type": "text-completion",
+                    "group": ["read-only", "text"],
+                    "state": "analysis",
+                    "available_in_states": ["undefined", "research"]
+                })
+            }
+        }
+        
+        # Should not raise any exception
+        await agent_processor.on_tools_config(valid_config, 1)
+        
+        # Verify tool was loaded with correct config
+        assert "valid_tool" in agent_processor.agent.tools
+        tool = agent_processor.agent.tools["valid_tool"]
+        assert tool.config["group"] == ["read-only", "text"]
+        assert tool.config["state"] == "analysis"
+
+
+class TestCompleteWorkflow:
+    """Test complete multi-step workflows with state transitions."""
+
+    @pytest.mark.asyncio
+    async def test_research_analysis_workflow(self, agent_processor, sample_tools):
+        """Test complete research -> analysis -> results workflow."""
+        
+        agent_processor.agent.tools = sample_tools
+        
+        # Step 1: Initial research request
+        from trustgraph.agent.react.types import Action
+        research_action = Action(
+            thought="I should query the knowledge base",
+            name="knowledge_query", 
+            arguments={"query": "test"},
+            observation="Found relevant information"
+        )
+        
+        agent_processor.agent.react = AsyncMock(return_value=research_action)
+        
+        request1 = AgentRequest(
+            question="Research topic X",
+            state="undefined",
+            group=["read-only", "knowledge"],
+            history=[]
+        )
+        
+        next_requests = []
+        
+        async def capture_next(req):
+            next_requests.append(req)
+            
+        # Execute step 1
+        await agent_processor.agent_request(request1, lambda x: None, capture_next, {})
+        
+        # Verify state transition to analysis
+        assert len(next_requests) == 1
+        step2_request = next_requests[0]
+        assert step2_request.state == "analysis"
+        assert len(step2_request.history) == 1
+        
+        # Step 2: Analysis phase
+        analysis_action = Action(
+            thought="Now I can perform complex analysis",
+            name="complex_analysis",
+            arguments={"data": "research results"},
+            observation="Analysis completed"
+        )
+        
+        agent_processor.agent.react = AsyncMock(return_value=analysis_action)
+        
+        # Update request groups for analysis phase
+        step2_request.group = ["advanced", "compute"]
+        
+        next_requests_2 = []
+        
+        # Execute step 2
+        await agent_processor.agent_request(step2_request, lambda x: None, 
+                                          lambda req: next_requests_2.append(req), {})
+        
+        # Verify final state transition
+        assert len(next_requests_2) == 1
+        final_request = next_requests_2[0]
+        assert final_request.state == "results"
+        assert len(final_request.history) == 2
+
+    @pytest.mark.asyncio
+    async def test_multi_tenant_scenario(self, agent_processor, sample_tools):
+        """Test different users with different permissions."""
+        
+        agent_processor.agent.tools = sample_tools
+        
+        from trustgraph.agent.react.types import Final
+        
+        # User A: Read-only permissions
+        user_a_final = Final(final="Read-only operations completed")
+        agent_processor.agent.react = AsyncMock(return_value=user_a_final)
+        
+        request_a = AgentRequest(
+            question="What information is available about X?",
+            state="undefined",
+            group=["read-only"],
+            history=[]
+        )
+        
+        responses_a = []
+        await agent_processor.agent_request(request_a, 
+                                          lambda r: responses_a.append(r), 
+                                          lambda x: None, {})
+        
+        # User B: Admin permissions  
+        user_b_final = Final(final="Administrative tasks completed")
+        agent_processor.agent.react = AsyncMock(return_value=user_b_final)
+        
+        request_b = AgentRequest(
+            question="Update the knowledge base",
+            state="analysis", 
+            group=["write", "admin"],
+            history=[]
+        )
+        
+        responses_b = []
+        await agent_processor.agent_request(request_b,
+                                          lambda r: responses_b.append(r),
+                                          lambda x: None, {})
+        
+        # Verify both users got appropriate responses
+        assert len(responses_a) == 1
+        assert len(responses_b) == 1
+        assert "Read-only" in responses_a[0].answer
+        assert "Administrative" in responses_b[0].answer

--- a/tests/integration/test_tool_group_integration.py
+++ b/tests/integration/test_tool_group_integration.py
@@ -31,7 +31,7 @@ def sample_tools():
             config={
                 'group': ['read-only', 'knowledge', 'basic'],
                 'state': 'analysis',
-                'available_in_states': ['undefined', 'research']
+                'applicable-states': ['undefined', 'research']
             },
             arguments=[]
         ),
@@ -41,7 +41,7 @@ def sample_tools():
             implementation=Mock(),
             config={
                 'group': ['write', 'knowledge', 'admin'],
-                'available_in_states': ['analysis', 'modification']
+                'applicable-states': ['analysis', 'modification']
             },
             arguments=[]
         ),
@@ -52,7 +52,7 @@ def sample_tools():
             config={
                 'group': ['read-only', 'text', 'basic'],
                 'state': 'undefined'
-                # No available_in_states = available in all states
+                # No applicable-states = available in all states
             },
             arguments=[]
         ),
@@ -63,7 +63,7 @@ def sample_tools():
             config={
                 'group': ['advanced', 'compute', 'expensive'],
                 'state': 'results',
-                'available_in_states': ['analysis']
+                'applicable-states': ['analysis']
             },
             arguments=[]
         )
@@ -332,7 +332,7 @@ class TestToolConfigurationLoading:
                     "type": "text-completion",
                     "group": ["read-only", "text"],
                     "state": "analysis",
-                    "available_in_states": ["undefined", "research"]
+                    "applicable-states": ["undefined", "research"]
                 })
             }
         }

--- a/tests/unit/test_agent/test_tool_filter.py
+++ b/tests/unit/test_agent/test_tool_filter.py
@@ -80,10 +80,10 @@ class TestToolFiltering:
         assert all(tool in filtered for tool in tools)
 
     def test_filter_tools_by_state(self):
-        """Test filtering based on available_in_states."""
+        """Test filtering based on applicable-states."""
         tools = {
-            'init_tool': Mock(config={'available_in_states': ['undefined']}),
-            'analysis_tool': Mock(config={'available_in_states': ['analysis']}),
+            'init_tool': Mock(config={'applicable-states': ['undefined']}),
+            'analysis_tool': Mock(config={'applicable-states': ['analysis']}),
             'any_state_tool': Mock(config={})  # available in all states
         }
         
@@ -95,10 +95,10 @@ class TestToolFiltering:
         assert 'any_state_tool' in filtered
 
     def test_filter_tools_state_wildcard(self):
-        """Test tools with '*' in available_in_states are always available."""
+        """Test tools with '*' in applicable-states are always available."""
         tools = {
-            'wildcard_tool': Mock(config={'available_in_states': ['*']}),
-            'specific_tool': Mock(config={'available_in_states': ['research']})
+            'wildcard_tool': Mock(config={'applicable-states': ['*']}),
+            'specific_tool': Mock(config={'applicable-states': ['research']})
         }
         
         # Filter for 'analysis' state
@@ -112,19 +112,19 @@ class TestToolFiltering:
         tools = {
             'valid_tool': Mock(config={
                 'group': ['read-only'],
-                'available_in_states': ['analysis']
+                'applicable-states': ['analysis']
             }),
             'wrong_group': Mock(config={
                 'group': ['admin'],
-                'available_in_states': ['analysis']
+                'applicable-states': ['analysis']
             }),
             'wrong_state': Mock(config={
                 'group': ['read-only'],
-                'available_in_states': ['research']
+                'applicable-states': ['research']
             }),
             'wrong_both': Mock(config={
                 'group': ['admin'],
-                'available_in_states': ['research']
+                'applicable-states': ['research']
             })
         }
         
@@ -186,7 +186,7 @@ class TestConfigValidation:
         config = {
             'group': ['read-only', 'basic'],
             'state': 'analysis',
-            'available_in_states': ['undefined', 'research']
+            'applicable-states': ['undefined', 'research']
         }
         
         # Should not raise an exception
@@ -213,16 +213,16 @@ class TestConfigValidation:
         with pytest.raises(ValueError, match="'state' field must be a string"):
             validate_tool_config(config)
 
-    def test_validate_available_in_states_not_list(self):
-        """Test validation fails when available_in_states is not a list."""
-        config = {'available_in_states': 'undefined'}  # Should be list
+    def test_validate_applicable_states_not_list(self):
+        """Test validation fails when applicable-states is not a list."""
+        config = {'applicable-states': 'undefined'}  # Should be list
         
-        with pytest.raises(ValueError, match="'available_in_states' field must be a list"):
+        with pytest.raises(ValueError, match="'applicable-states' field must be a list"):
             validate_tool_config(config)
 
-    def test_validate_available_in_states_non_string_elements(self):
-        """Test validation fails when available_in_states contains non-strings."""
-        config = {'available_in_states': ['undefined', 123]}
+    def test_validate_applicable_states_non_string_elements(self):
+        """Test validation fails when applicable-states contains non-strings."""
+        config = {'applicable-states': ['undefined', 123]}
         
         with pytest.raises(ValueError, match="All state names must be strings"):
             validate_tool_config(config)
@@ -257,7 +257,7 @@ class TestToolAvailability:
 
     def test_tool_available_string_state_conversion(self):
         """Test that single state string is converted to list."""
-        tool = Mock(config={'available_in_states': 'analysis'})  # Single string
+        tool = Mock(config={'applicable-states': 'analysis'})  # Single string
         
         assert _is_tool_available(tool, ['default'], 'analysis')
         assert not _is_tool_available(tool, ['default'], 'research')
@@ -281,16 +281,16 @@ class TestWorkflowScenarios:
             'knowledge_query': Mock(config={
                 'group': ['read-only', 'knowledge'],
                 'state': 'analysis',
-                'available_in_states': ['undefined', 'research']
+                'applicable-states': ['undefined', 'research']
             }),
             'complex_analysis': Mock(config={
                 'group': ['advanced', 'compute'],
                 'state': 'results',
-                'available_in_states': ['analysis']
+                'applicable-states': ['analysis']
             }),
             'text_completion': Mock(config={
                 'group': ['read-only', 'text', 'basic']
-                # No available_in_states = available in all states
+                # No applicable-states = available in all states
             })
         }
         

--- a/tests/unit/test_agent/test_tool_filter.py
+++ b/tests/unit/test_agent/test_tool_filter.py
@@ -1,0 +1,321 @@
+"""
+Unit tests for the tool filtering logic in the tool group system.
+"""
+
+import pytest
+import sys
+import os
+from unittest.mock import Mock
+
+# Add trustgraph-flow to path for imports
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', '..', 'trustgraph-flow'))
+
+from trustgraph.agent.tool_filter import (
+    filter_tools_by_group_and_state,
+    get_next_state,
+    validate_tool_config,
+    _is_tool_available
+)
+
+
+class TestToolFiltering:
+    """Test tool filtering based on groups and states."""
+
+    def test_filter_tools_default_group(self):
+        """Tools without groups should belong to 'default' group."""
+        tools = {
+            'tool1': Mock(config={}),
+            'tool2': Mock(config={'group': ['read-only']})
+        }
+        
+        # Request default group (implicit)
+        filtered = filter_tools_by_group_and_state(tools, None, None)
+        
+        # Only tool1 should be available (no group = default group)
+        assert 'tool1' in filtered
+        assert 'tool2' not in filtered
+
+    def test_filter_tools_explicit_groups(self):
+        """Test filtering with explicit group membership."""
+        tools = {
+            'read_tool': Mock(config={'group': ['read-only', 'basic']}),
+            'write_tool': Mock(config={'group': ['write', 'admin']}),
+            'mixed_tool': Mock(config={'group': ['read-only', 'write']})
+        }
+        
+        # Request read-only tools
+        filtered = filter_tools_by_group_and_state(tools, ['read-only'], None)
+        
+        assert 'read_tool' in filtered
+        assert 'write_tool' not in filtered
+        assert 'mixed_tool' in filtered  # Has read-only in its groups
+
+    def test_filter_tools_multiple_requested_groups(self):
+        """Test filtering with multiple requested groups."""
+        tools = {
+            'tool1': Mock(config={'group': ['read-only']}),
+            'tool2': Mock(config={'group': ['write']}),
+            'tool3': Mock(config={'group': ['admin']})
+        }
+        
+        # Request read-only and write tools
+        filtered = filter_tools_by_group_and_state(tools, ['read-only', 'write'], None)
+        
+        assert 'tool1' in filtered
+        assert 'tool2' in filtered
+        assert 'tool3' not in filtered
+
+    def test_filter_tools_wildcard_group(self):
+        """Test wildcard group grants access to all tools."""
+        tools = {
+            'tool1': Mock(config={'group': ['read-only']}),
+            'tool2': Mock(config={'group': ['admin']}),
+            'tool3': Mock(config={})  # default group
+        }
+        
+        # Request wildcard access
+        filtered = filter_tools_by_group_and_state(tools, ['*'], None)
+        
+        assert len(filtered) == 3
+        assert all(tool in filtered for tool in tools)
+
+    def test_filter_tools_by_state(self):
+        """Test filtering based on available_in_states."""
+        tools = {
+            'init_tool': Mock(config={'available_in_states': ['undefined']}),
+            'analysis_tool': Mock(config={'available_in_states': ['analysis']}),
+            'any_state_tool': Mock(config={})  # available in all states
+        }
+        
+        # Filter for 'analysis' state
+        filtered = filter_tools_by_group_and_state(tools, ['default'], 'analysis')
+        
+        assert 'init_tool' not in filtered
+        assert 'analysis_tool' in filtered
+        assert 'any_state_tool' in filtered
+
+    def test_filter_tools_state_wildcard(self):
+        """Test tools with '*' in available_in_states are always available."""
+        tools = {
+            'wildcard_tool': Mock(config={'available_in_states': ['*']}),
+            'specific_tool': Mock(config={'available_in_states': ['research']})
+        }
+        
+        # Filter for 'analysis' state
+        filtered = filter_tools_by_group_and_state(tools, ['default'], 'analysis')
+        
+        assert 'wildcard_tool' in filtered
+        assert 'specific_tool' not in filtered
+
+    def test_filter_tools_combined_group_and_state(self):
+        """Test combined group and state filtering."""
+        tools = {
+            'valid_tool': Mock(config={
+                'group': ['read-only'],
+                'available_in_states': ['analysis']
+            }),
+            'wrong_group': Mock(config={
+                'group': ['admin'],
+                'available_in_states': ['analysis']
+            }),
+            'wrong_state': Mock(config={
+                'group': ['read-only'],
+                'available_in_states': ['research']
+            }),
+            'wrong_both': Mock(config={
+                'group': ['admin'],
+                'available_in_states': ['research']
+            })
+        }
+        
+        filtered = filter_tools_by_group_and_state(
+            tools, ['read-only'], 'analysis'
+        )
+        
+        assert 'valid_tool' in filtered
+        assert 'wrong_group' not in filtered
+        assert 'wrong_state' not in filtered
+        assert 'wrong_both' not in filtered
+
+    def test_filter_tools_empty_request_groups(self):
+        """Test that empty group list results in no available tools."""
+        tools = {
+            'tool1': Mock(config={'group': ['read-only']}),
+            'tool2': Mock(config={})
+        }
+        
+        filtered = filter_tools_by_group_and_state(tools, [], None)
+        
+        assert len(filtered) == 0
+
+
+class TestStateTransitions:
+    """Test state transition logic."""
+
+    def test_get_next_state_with_transition(self):
+        """Test state transition when tool defines next state."""
+        tool = Mock(config={'state': 'analysis'})
+        
+        next_state = get_next_state(tool, 'undefined')
+        
+        assert next_state == 'analysis'
+
+    def test_get_next_state_no_transition(self):
+        """Test no state change when tool doesn't define next state."""
+        tool = Mock(config={})
+        
+        next_state = get_next_state(tool, 'research')
+        
+        assert next_state == 'research'
+
+    def test_get_next_state_empty_config(self):
+        """Test with tool that has no config."""
+        tool = Mock(config=None)
+        tool.config = None
+        
+        next_state = get_next_state(tool, 'initial')
+        
+        assert next_state == 'initial'
+
+
+class TestConfigValidation:
+    """Test tool configuration validation."""
+
+    def test_validate_valid_config(self):
+        """Test validation of valid configuration."""
+        config = {
+            'group': ['read-only', 'basic'],
+            'state': 'analysis',
+            'available_in_states': ['undefined', 'research']
+        }
+        
+        # Should not raise an exception
+        validate_tool_config(config)
+
+    def test_validate_group_not_list(self):
+        """Test validation fails when group is not a list."""
+        config = {'group': 'read-only'}  # Should be list
+        
+        with pytest.raises(ValueError, match="'group' field must be a list"):
+            validate_tool_config(config)
+
+    def test_validate_group_non_string_elements(self):
+        """Test validation fails when group contains non-strings."""
+        config = {'group': ['read-only', 123]}  # 123 is not string
+        
+        with pytest.raises(ValueError, match="All group names must be strings"):
+            validate_tool_config(config)
+
+    def test_validate_state_not_string(self):
+        """Test validation fails when state is not a string."""
+        config = {'state': 123}  # Should be string
+        
+        with pytest.raises(ValueError, match="'state' field must be a string"):
+            validate_tool_config(config)
+
+    def test_validate_available_in_states_not_list(self):
+        """Test validation fails when available_in_states is not a list."""
+        config = {'available_in_states': 'undefined'}  # Should be list
+        
+        with pytest.raises(ValueError, match="'available_in_states' field must be a list"):
+            validate_tool_config(config)
+
+    def test_validate_available_in_states_non_string_elements(self):
+        """Test validation fails when available_in_states contains non-strings."""
+        config = {'available_in_states': ['undefined', 123]}
+        
+        with pytest.raises(ValueError, match="All state names must be strings"):
+            validate_tool_config(config)
+
+    def test_validate_minimal_config(self):
+        """Test validation of minimal valid configuration."""
+        config = {'name': 'test', 'description': 'Test tool'}
+        
+        # Should not raise an exception
+        validate_tool_config(config)
+
+
+class TestToolAvailability:
+    """Test the internal _is_tool_available function."""
+
+    def test_tool_available_default_groups_and_states(self):
+        """Test tool with default groups and states."""
+        tool = Mock(config={})
+        
+        # Default group request, default state
+        assert _is_tool_available(tool, ['default'], 'undefined')
+        
+        # Non-default group request should fail
+        assert not _is_tool_available(tool, ['admin'], 'undefined')
+
+    def test_tool_available_string_group_conversion(self):
+        """Test that single group string is converted to list."""
+        tool = Mock(config={'group': 'read-only'})  # Single string
+        
+        assert _is_tool_available(tool, ['read-only'], 'undefined')
+        assert not _is_tool_available(tool, ['admin'], 'undefined')
+
+    def test_tool_available_string_state_conversion(self):
+        """Test that single state string is converted to list."""
+        tool = Mock(config={'available_in_states': 'analysis'})  # Single string
+        
+        assert _is_tool_available(tool, ['default'], 'analysis')
+        assert not _is_tool_available(tool, ['default'], 'research')
+
+    def test_tool_no_config_attribute(self):
+        """Test tool without config attribute."""
+        tool = Mock()
+        del tool.config  # Remove config attribute
+        
+        # Should use defaults and be available for default group/state
+        assert _is_tool_available(tool, ['default'], 'undefined')
+        assert not _is_tool_available(tool, ['admin'], 'undefined')
+
+
+class TestWorkflowScenarios:
+    """Test complete workflow scenarios from the tech spec."""
+
+    def test_research_to_analysis_workflow(self):
+        """Test the research -> analysis workflow from tech spec."""
+        tools = {
+            'knowledge_query': Mock(config={
+                'group': ['read-only', 'knowledge'],
+                'state': 'analysis',
+                'available_in_states': ['undefined', 'research']
+            }),
+            'complex_analysis': Mock(config={
+                'group': ['advanced', 'compute'],
+                'state': 'results',
+                'available_in_states': ['analysis']
+            }),
+            'text_completion': Mock(config={
+                'group': ['read-only', 'text', 'basic']
+                # No available_in_states = available in all states
+            })
+        }
+        
+        # Phase 1: Initial research (undefined state)
+        phase1_filtered = filter_tools_by_group_and_state(
+            tools, ['read-only', 'knowledge'], 'undefined'
+        )
+        assert 'knowledge_query' in phase1_filtered
+        assert 'text_completion' in phase1_filtered
+        assert 'complex_analysis' not in phase1_filtered
+        
+        # Simulate tool execution and state transition
+        executed_tool = phase1_filtered['knowledge_query']
+        next_state = get_next_state(executed_tool, 'undefined')
+        assert next_state == 'analysis'
+        
+        # Phase 2: Analysis state (include basic group for text_completion)
+        phase2_filtered = filter_tools_by_group_and_state(
+            tools, ['advanced', 'compute', 'basic'], 'analysis'
+        )
+        assert 'knowledge_query' not in phase2_filtered  # Not available in analysis
+        assert 'complex_analysis' in phase2_filtered
+        assert 'text_completion' in phase2_filtered  # Always available
+        
+        # Simulate complex analysis execution
+        executed_tool = phase2_filtered['complex_analysis']
+        final_state = get_next_state(executed_tool, 'analysis')
+        assert final_state == 'results'

--- a/trustgraph-base/trustgraph/schema/services/agent.py
+++ b/trustgraph-base/trustgraph/schema/services/agent.py
@@ -16,8 +16,8 @@ class AgentStep(Record):
 
 class AgentRequest(Record):
     question = String()
-    plan = String()
     state = String()
+    group = Array(String())
     history = Array(AgentStep())
 
 class AgentResponse(Record):

--- a/trustgraph-cli/trustgraph/cli/set_tool.py
+++ b/trustgraph-cli/trustgraph/cli/set_tool.py
@@ -63,6 +63,9 @@ def set_tool(
         collection : str,
         template : str,
         arguments : List[Argument],
+        group : List[str],
+        state : str,
+        available_in_states : List[str],
 ):
 
     api = Api(url).config()
@@ -92,6 +95,12 @@ def set_tool(
             }
             for a in arguments
         ]
+
+    if group: object["group"] = group
+
+    if state: object["state"] = state
+
+    if available_in_states: object["available_in_states"] = available_in_states
 
     values = api.put([
         ConfigValue(
@@ -179,6 +188,23 @@ def main():
        help=f'Tool arguments in the form: name:type:description (can specify multiple)',
     )
 
+    parser.add_argument(
+        '--group',
+        nargs="*",
+        help=f'Tool groups (e.g., read-only, knowledge, admin)',
+    )
+
+    parser.add_argument(
+        '--state',
+        help=f'State to transition to after successful execution',
+    )
+
+    parser.add_argument(
+        '--available-in-states',
+        nargs="*",
+        help=f'States in which this tool is available',
+    )
+
     args = parser.parse_args()
 
     try:
@@ -219,6 +245,9 @@ def main():
             collection=args.collection,
             template=args.template,
             arguments=arguments,
+            group=args.group or [],
+            state=args.state,
+            available_in_states=getattr(args, 'available_in_states', None) or [],
         )
 
     except Exception as e:

--- a/trustgraph-cli/trustgraph/cli/set_tool.py
+++ b/trustgraph-cli/trustgraph/cli/set_tool.py
@@ -65,7 +65,7 @@ def set_tool(
         arguments : List[Argument],
         group : List[str],
         state : str,
-        available_in_states : List[str],
+        applicable_states : List[str],
 ):
 
     api = Api(url).config()
@@ -100,7 +100,7 @@ def set_tool(
 
     if state: object["state"] = state
 
-    if available_in_states: object["available_in_states"] = available_in_states
+    if applicable_states: object["applicable-states"] = applicable_states
 
     values = api.put([
         ConfigValue(
@@ -200,8 +200,8 @@ def main():
     )
 
     parser.add_argument(
-        '--available-in-states',
-        nargs="*",
+        '--applicable-states',
+        nargs="*", 
         help=f'States in which this tool is available',
     )
 
@@ -247,7 +247,7 @@ def main():
             arguments=arguments,
             group=args.group or [],
             state=args.state,
-            available_in_states=getattr(args, 'available_in_states', None) or [],
+            applicable_states=getattr(args, 'applicable_states', None) or [],
         )
 
     except Exception as e:


### PR DESCRIPTION
This PR adds a tool grouping system for TrustGraph agents that allows fine-grained control over which tools are available for specific requests. The system introduces group-based tool filtering through configuration and request-level specification, enabling better security boundaries, resource management, and functional partitioning of agent capabilities.

This change implements the TrustGraph Tool Group System, enabling fine-grained control over which  tools are available to agents based on group membership and execution state. Tools can now be  tagged with groups (e.g., ["read-only", "knowledge", "admin"]) and state availability (e.g.,  "applicable-states": ["undefined", "research"]), while agent requests specify allowed groups to  filter available tools at runtime. The system supports multi-step workflows with state transitions    (tools can specify a next state after execution), wildcard access ("*"), and multi-tenant  scenarios where different users have access to different tool sets. Key components include:  updated AgentRequest schema with group field, enhanced CLI tool with --group and  --applicable-states arguments, core filtering logic in tool_filter.py, integration with the ReAct  agent service, and comprehensive test coverage (34 tests). The implementation maintains full  backward compatibility - tools without groups default to "default" group, and existing requests  work unchanged.