### PR TITLE
Fix Minio incompatible library change

### DIFF
--- a/trustgraph-flow/trustgraph/librarian/blob_store.py
+++ b/trustgraph-flow/trustgraph/librarian/blob_store.py
@@ -19,7 +19,7 @@ class BlobStore:
 
 
         self.minio = Minio(
-            minio_host,
+            endpoint = minio_host,
             access_key = minio_access_key,
             secret_key = minio_secret_key,
             secure = False,


### PR DESCRIPTION
Newer MinIO library (v8.x) changed the Minio constructor to only accept keyword arguments.