### PR TITLE
Updated knowledge core for embeddings results schema change

### DIFF
--- a/tests/unit/test_query/conftest.py
+++ b/tests/unit/test_query/conftest.py
@@ -37,7 +37,7 @@ def mock_qdrant_client():
 def mock_graph_embeddings_request():
     """Mock graph embeddings request message"""
     mock_message = MagicMock()
-    mock_message.vectors = [[0.1, 0.2, 0.3]]
+    mock_message.vector = [0.1, 0.2, 0.3]
     mock_message.limit = 5
     mock_message.user = 'test_user'
     mock_message.collection = 'test_collection'
@@ -46,9 +46,9 @@ def mock_graph_embeddings_request():
 
 @pytest.fixture
 def mock_graph_embeddings_multiple_vectors():
-    """Mock graph embeddings request with multiple vectors"""
+    """Mock graph embeddings request with multiple vectors (legacy name, now single vector)"""
     mock_message = MagicMock()
-    mock_message.vectors = [[0.1, 0.2], [0.3, 0.4]]
+    mock_message.vector = [0.1, 0.2, 0.3, 0.4]
     mock_message.limit = 3
     mock_message.user = 'multi_user'
     mock_message.collection = 'multi_collection'
@@ -82,7 +82,7 @@ def mock_graph_embeddings_uri_response():
 def mock_document_embeddings_request():
     """Mock document embeddings request message"""
     mock_message = MagicMock()
-    mock_message.vectors = [[0.1, 0.2, 0.3]]
+    mock_message.vector = [0.1, 0.2, 0.3]
     mock_message.limit = 5
     mock_message.user = 'test_user'
     mock_message.collection = 'test_collection'
@@ -91,9 +91,9 @@ def mock_document_embeddings_request():
 
 @pytest.fixture
 def mock_document_embeddings_multiple_vectors():
-    """Mock document embeddings request with multiple vectors"""
+    """Mock document embeddings request with multiple vectors (legacy name, now single vector)"""
     mock_message = MagicMock()
-    mock_message.vectors = [[0.1, 0.2], [0.3, 0.4]]
+    mock_message.vector = [0.1, 0.2, 0.3, 0.4]
     mock_message.limit = 3
     mock_message.user = 'multi_user'
     mock_message.collection = 'multi_collection'
@@ -139,9 +139,9 @@ def mock_large_query_response():
 
 @pytest.fixture
 def mock_mixed_dimension_vectors():
-    """Mock request with vectors of different dimensions"""
+    """Mock request with vector (legacy name suggested mixed dimensions, now single vector)"""
     mock_message = MagicMock()
-    mock_message.vectors = [[0.1, 0.2], [0.3, 0.4, 0.5]]  # 2D and 3D
+    mock_message.vector = [0.1, 0.2, 0.3, 0.4, 0.5]
     mock_message.limit = 5
     mock_message.user = 'dim_user'
     mock_message.collection = 'dim_collection'

--- a/tests/unit/test_query/test_doc_embeddings_pinecone_query.py
+++ b/tests/unit/test_query/test_doc_embeddings_pinecone_query.py
@@ -18,10 +18,7 @@ class TestPineconeDocEmbeddingsQueryProcessor:
     def mock_query_message(self):
         """Create a mock query message for testing"""
         message = MagicMock()
-        message.vectors = [
-            [0.1, 0.2, 0.3],
-            [0.4, 0.5, 0.6]
-        ]
+        message.vector = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6]
         message.limit = 5
         message.user = 'test_user'
         message.collection = 'test_collection'
@@ -242,12 +239,9 @@ class TestPineconeDocEmbeddingsQueryProcessor:
 
     @pytest.mark.asyncio
     async def test_query_document_embeddings_different_vector_dimensions(self, processor):
-        """Test querying with vectors of different dimensions using same index"""
+        """Test querying with single vector (legacy test name, schema now uses single vector)"""
         message = MagicMock()
-        message.vectors = [
-            [0.1, 0.2],  # 2D vector
-            [0.3, 0.4, 0.5, 0.6]  # 4D vector
-        ]
+        message.vector = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6]
         message.limit = 5
         message.user = 'test_user'
         message.collection = 'test_collection'
@@ -437,13 +431,9 @@ class TestPineconeDocEmbeddingsQueryProcessor:
 
     @pytest.mark.asyncio
     async def test_query_document_embeddings_vector_accumulation(self, processor):
-        """Test that results from multiple vectors are properly accumulated"""
+        """Test that results from single vector query are returned (legacy multi-vector test)"""
         message = MagicMock()
-        message.vectors = [
-            [0.1, 0.2, 0.3],
-            [0.4, 0.5, 0.6],
-            [0.7, 0.8, 0.9]
-        ]
+        message.vector = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]
         message.limit = 2
         message.user = 'test_user'
         message.collection = 'test_collection'

--- a/tests/unit/test_storage/conftest.py
+++ b/tests/unit/test_storage/conftest.py
@@ -53,7 +53,7 @@ def mock_document_embeddings_message():
     
     mock_chunk = MagicMock()
     mock_chunk.chunk.decode.return_value = 'test document chunk'
-    mock_chunk.vectors = [[0.1, 0.2, 0.3]]
+    mock_chunk.vector = [0.1, 0.2, 0.3]
     
     mock_message.chunks = [mock_chunk]
     return mock_message
@@ -68,11 +68,11 @@ def mock_document_embeddings_multiple_chunks():
     
     mock_chunk1 = MagicMock()
     mock_chunk1.chunk.decode.return_value = 'first document chunk'
-    mock_chunk1.vectors = [[0.1, 0.2]]
-    
+    mock_chunk1.vector = [0.1, 0.2]
+
     mock_chunk2 = MagicMock()
     mock_chunk2.chunk.decode.return_value = 'second document chunk'
-    mock_chunk2.vectors = [[0.3, 0.4]]
+    mock_chunk2.vector = [0.3, 0.4]
     
     mock_message.chunks = [mock_chunk1, mock_chunk2]
     return mock_message
@@ -87,11 +87,7 @@ def mock_document_embeddings_multiple_vectors():
     
     mock_chunk = MagicMock()
     mock_chunk.chunk.decode.return_value = 'multi-vector document chunk'
-    mock_chunk.vectors = [
-        [0.1, 0.2, 0.3],
-        [0.4, 0.5, 0.6],
-        [0.7, 0.8, 0.9]
-    ]
+    mock_chunk.vector = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]
     
     mock_message.chunks = [mock_chunk]
     return mock_message
@@ -106,7 +102,7 @@ def mock_document_embeddings_empty_chunk():
     
     mock_chunk = MagicMock()
     mock_chunk.chunk.decode.return_value = ""  # Empty string
-    mock_chunk.vectors = [[0.1, 0.2]]
+    mock_chunk.vector = [0.1, 0.2]
     
     mock_message.chunks = [mock_chunk]
     return mock_message
@@ -122,7 +118,7 @@ def mock_graph_embeddings_message():
     
     mock_entity = MagicMock()
     mock_entity.entity.value = 'test_entity'
-    mock_entity.vectors = [[0.1, 0.2, 0.3]]
+    mock_entity.vector = [0.1, 0.2, 0.3]
     
     mock_message.entities = [mock_entity]
     return mock_message
@@ -137,11 +133,11 @@ def mock_graph_embeddings_multiple_entities():
     
     mock_entity1 = MagicMock()
     mock_entity1.entity.value = 'entity_one'
-    mock_entity1.vectors = [[0.1, 0.2]]
-    
+    mock_entity1.vector = [0.1, 0.2]
+
     mock_entity2 = MagicMock()
     mock_entity2.entity.value = 'entity_two'
-    mock_entity2.vectors = [[0.3, 0.4]]
+    mock_entity2.vector = [0.3, 0.4]
     
     mock_message.entities = [mock_entity1, mock_entity2]
     return mock_message
@@ -156,7 +152,7 @@ def mock_graph_embeddings_empty_entity():
     
     mock_entity = MagicMock()
     mock_entity.entity.value = ""  # Empty string
-    mock_entity.vectors = [[0.1, 0.2]]
+    mock_entity.vector = [0.1, 0.2]
     
     mock_message.entities = [mock_entity]
     return mock_message

--- a/trustgraph-base/trustgraph/messaging/translators/document_loading.py
+++ b/trustgraph-base/trustgraph/messaging/translators/document_loading.py
@@ -169,7 +169,7 @@ class DocumentEmbeddingsTranslator(SendTranslator):
             "chunks": [
                 {
                     "chunk_id": chunk.chunk_id,
-                    "vectors": chunk.vectors
+                    "vector": chunk.vector
                 }
                 for chunk in obj.chunks
             ]

--- a/trustgraph-base/trustgraph/messaging/translators/knowledge.py
+++ b/trustgraph-base/trustgraph/messaging/translators/knowledge.py
@@ -99,7 +99,7 @@ class KnowledgeRequestTranslator(MessageTranslator):
                 },
                 "entities": [
                     {
-                        "vectors": entity.vectors,
+                        "vector": entity.vector,
                         "entity": self.value_translator.from_pulsar(entity.entity),
                     }
                     for entity in obj.graph_embeddings.entities
@@ -154,7 +154,7 @@ class KnowledgeResponseTranslator(MessageTranslator):
                     },
                     "entities": [
                         {
-                            "vectors": entity.vectors,
+                            "vector": entity.vector,
                             "entity": self.value_translator.from_pulsar(entity.entity),
                         }
                         for entity in obj.graph_embeddings.entities

--- a/trustgraph-flow/trustgraph/gateway/dispatch/serialize.py
+++ b/trustgraph-flow/trustgraph/gateway/dispatch/serialize.py
@@ -54,7 +54,7 @@ def serialize_graph_embeddings(message):
         },
         "entities": [
             {
-                "vectors": entity.vectors,
+                "vector": entity.vector,
                 "entity": serialize_value(entity.entity),
             }
             for entity in message.entities
@@ -88,7 +88,7 @@ def serialize_document_embeddings(message):
         },
         "chunks": [
             {
-                "vectors": chunk.vectors,
+                "vector": chunk.vector,
                 "chunk_id": chunk.chunk_id,
             }
             for chunk in message.chunks

--- a/trustgraph-flow/trustgraph/tables/knowledge.py
+++ b/trustgraph-flow/trustgraph/tables/knowledge.py
@@ -272,7 +272,7 @@ class KnowledgeTableStore:
         entities = [
             (
                 term_to_tuple(v.entity),
-                v.vectors
+                v.vector
             )
             for v in m.entities
         ]
@@ -313,8 +313,8 @@ class KnowledgeTableStore:
 
         chunks = [
             (
-                v.chunk,
-                v.vectors,
+                v.chunk_id,
+                v.vector,
             )
             for v in m.chunks
         ]


### PR DESCRIPTION
Knowledge core fixed:
- trustgraph-flow/trustgraph/tables/knowledge.py - v.vector, v.chunk_id
- trustgraph-base/trustgraph/messaging/translators/document_loading.py - chunk.vector
- trustgraph-base/trustgraph/messaging/translators/knowledge.py - entity.vector
- trustgraph-flow/trustgraph/gateway/dispatch/serialize.py - entity.vector, chunk.vector

Test fixtures fixed:
- tests/unit/test_storage/conftest.py - All mock entities/chunks use vector
- tests/unit/test_query/conftest.py - All mock requests use vector
- tests/unit/test_query/test_doc_embeddings_pinecone_query.py - All mock messages use vector

These changes align with commit f2ae0e86 which changed the schema from vectors: list[list[float]] to vector: list[float].