### PR TITLE
Fix stray log messages caused by librarian messages

### DIFF
--- a/trustgraph-base/trustgraph/base/chunking_service.py
+++ b/trustgraph-base/trustgraph/base/chunking_service.py
@@ -96,8 +96,6 @@ class ChunkingService(FlowProcessor):
         if request_id and request_id in self.pending_requests:
             future = self.pending_requests.pop(request_id)
             future.set_result(response)
-        else:
-            logger.warning(f"Received unexpected librarian response: {request_id}")
 
     async def fetch_document_content(self, document_id, user, timeout=120):
         """

--- a/trustgraph-flow/trustgraph/agent/react/service.py
+++ b/trustgraph-flow/trustgraph/agent/react/service.py
@@ -189,8 +189,6 @@ class Processor(AgentService):
         if request_id in self.pending_librarian_requests:
             future = self.pending_librarian_requests.pop(request_id)
             future.set_result(response)
-        else:
-            logger.warning(f"Received unexpected librarian response: {request_id}")
 
     async def save_answer_content(self, doc_id, user, content, title=None, timeout=120):
         """

--- a/trustgraph-flow/trustgraph/decoding/mistral_ocr/processor.py
+++ b/trustgraph-flow/trustgraph/decoding/mistral_ocr/processor.py
@@ -162,8 +162,6 @@ class Processor(FlowProcessor):
         if request_id and request_id in self.pending_requests:
             future = self.pending_requests.pop(request_id)
             future.set_result(response)
-        else:
-            logger.warning(f"Received unexpected librarian response: {request_id}")
 
     async def fetch_document_metadata(self, document_id, user, timeout=120):
         """

--- a/trustgraph-flow/trustgraph/decoding/pdf/pdf_decoder.py
+++ b/trustgraph-flow/trustgraph/decoding/pdf/pdf_decoder.py
@@ -126,8 +126,6 @@ class Processor(FlowProcessor):
         if request_id and request_id in self.pending_requests:
             future = self.pending_requests.pop(request_id)
             future.set_result(response)
-        else:
-            logger.warning(f"Received unexpected librarian response: {request_id}")
 
     async def fetch_document_metadata(self, document_id, user, timeout=120):
         """

--- a/trustgraph-flow/trustgraph/retrieval/document_rag/rag.py
+++ b/trustgraph-flow/trustgraph/retrieval/document_rag/rag.py
@@ -139,8 +139,6 @@ class Processor(FlowProcessor):
         if request_id in self.pending_requests:
             future = self.pending_requests.pop(request_id)
             future.set_result(response)
-        else:
-            logger.warning(f"Received unexpected librarian response: {request_id}")
 
     async def fetch_chunk_content(self, chunk_id, user, timeout=120):
         """Fetch chunk content from librarian/Garage."""

--- a/trustgraph-flow/trustgraph/retrieval/graph_rag/rag.py
+++ b/trustgraph-flow/trustgraph/retrieval/graph_rag/rag.py
@@ -169,8 +169,6 @@ class Processor(FlowProcessor):
         if request_id and request_id in self.pending_librarian_requests:
             future = self.pending_librarian_requests.pop(request_id)
             future.set_result(response)
-        else:
-            logger.warning(f"Received unexpected librarian response: {request_id}")
 
     async def save_answer_content(self, doc_id, user, content, title=None, timeout=120):
         """

--- a/trustgraph-ocr/trustgraph/decoding/ocr/pdf_decoder.py
+++ b/trustgraph-ocr/trustgraph/decoding/ocr/pdf_decoder.py
@@ -124,8 +124,6 @@ class Processor(FlowProcessor):
         if request_id and request_id in self.pending_requests:
             future = self.pending_requests.pop(request_id)
             future.set_result(response)
-        else:
-            logger.warning(f"Received unexpected librarian response: {request_id}")
 
     async def fetch_document_metadata(self, document_id, user, timeout=120):
         """

--- a/trustgraph-unstructured/trustgraph/decoding/universal/processor.py
+++ b/trustgraph-unstructured/trustgraph/decoding/universal/processor.py
@@ -218,10 +218,6 @@ class Processor(FlowProcessor):
         if request_id and request_id in self.pending_requests:
             future = self.pending_requests.pop(request_id)
             future.set_result(response)
-        else:
-            logger.warning(
-                f"Received unexpected librarian response: {request_id}"
-            )
 
     async def _librarian_request(self, request, timeout=120):
         """Send a request to the librarian and wait for response."""


### PR DESCRIPTION
Warning generated by librarian responses meant for other services (chunker, embeddings, etc.) arriving on the shared response queue. The decoder's subscription picks them up, can't match them to a pending request, and logs a warning.

Removed the warnings, as not serving a purpose.