### PR TITLE
Add chunk content ID to explain trace provenance output

### DIFF
--- a/trustgraph-cli/trustgraph/cli/show_explain_trace.py
+++ b/trustgraph-cli/trustgraph/cli/show_explain_trace.py
@@ -214,6 +214,12 @@ def print_graphrag_text(trace, explain_client, flow, user, collection, api=None,
                     chain_str = format_provenance_chain(chain)
                     if chain_str:
                         print(f"     Source: {chain_str}")
+                        # Show content ID for the chunk (second item in chain)
+                        for item in chain:
+                            uri = item.get("uri", "")
+                            if uri.startswith("urn:chunk:"):
+                                print(f"     Content: {uri}")
+                                break
 
             print()
     else:


### PR DESCRIPTION
When --show-provenance is used with tg-show-explain-trace, display the chunk URI on a Content: line below each Source: chain. This allows the user to easily fetch the source text with tg-get-document-content.