### PR TITLE
fix: use max_completion_tokens instead of deprecated max_tokens

### DIFF
--- a/trustgraph-flow/trustgraph/model/text_completion/azure_openai/llm.py
+++ b/trustgraph-flow/trustgraph/model/text_completion/azure_openai/llm.py
@@ -90,7 +90,7 @@ class Processor(LlmService):
                     }
                 ],
                 temperature=effective_temperature,
-                max_tokens=self.max_output,
+                max_completion_tokens=self.max_output,
                 top_p=1,
             )
 
@@ -159,7 +159,7 @@ class Processor(LlmService):
                     }
                 ],
                 temperature=effective_temperature,
-                max_tokens=self.max_output,
+                max_completion_tokens=self.max_output,
                 top_p=1,
                 stream=True,
                 stream_options={"include_usage": True}

--- a/trustgraph-flow/trustgraph/model/text_completion/openai/llm.py
+++ b/trustgraph-flow/trustgraph/model/text_completion/openai/llm.py
@@ -86,7 +86,7 @@ class Processor(LlmService):
                     }
                 ],
                 temperature=effective_temperature,
-                max_tokens=self.max_output,
+                max_completion_tokens=self.max_output,
             )
             
             inputtokens = resp.usage.prompt_tokens
@@ -152,7 +152,7 @@ class Processor(LlmService):
                     }
                 ],
                 temperature=effective_temperature,
-                max_tokens=self.max_output,
+                max_completion_tokens=self.max_output,
                 stream=True,
                 stream_options={"include_usage": True}
             )


### PR DESCRIPTION
## Summary

The OpenAI API deprecated `max_tokens` in favor of `max_completion_tokens` for chat completion endpoints. Newer models (gpt-4o, o1, o3, gpt-5.x) reject `max_tokens` with:

```
Unsupported parameter: 'max_tokens' is not supported with this model.
Use 'max_completion_tokens' instead.
```

This updates both the OpenAI and Azure OpenAI text completion providers to use the new parameter name in both streaming and non-streaming code paths.

## Files Changed

- `trustgraph-flow/trustgraph/model/text_completion/openai/llm.py` — 2 occurrences
- `trustgraph-flow/trustgraph/model/text_completion/azure_openai/llm.py` — 2 occurrences

## How to Reproduce

1. Configure TrustGraph with `gpt-4o` or any newer OpenAI model
2. Run any query that triggers LLM text completion
3. Observe: `Error code: 400 - Unsupported parameter: 'max_tokens'`

## Test Plan

- [x] Tested locally with gpt-4o — queries succeed after this change
- [ ] Verify Azure OpenAI path with a newer Azure model