### PR TITLE
fix: align HF embeddings provider with batch embeddings interface

### DIFF
--- a/trustgraph-embeddings-hf/trustgraph/embeddings/hf/hf.py
+++ b/trustgraph-embeddings-hf/trustgraph/embeddings/hf/hf.py
@@ -45,14 +45,17 @@ class Processor(EmbeddingsService):
         else:
             logger.debug(f"Using cached model: {model_name}")
 
-    async def on_embeddings(self, text, model=None):
+    async def on_embeddings(self, texts, model=None):
+
+        if not texts:
+            return []
 
         use_model = model or self.default_model
 
         # Reload model if it has changed
         self._load_model(use_model)
 
-        embeds = self.embeddings.embed_documents([text])
+        embeds = self.embeddings.embed_documents(texts)
         logger.debug("Embeddings generation complete")
         return embeds
 


### PR DESCRIPTION
## Summary

The batch embeddings refactor (PR #668) changed `EmbeddingsRequest` from `text: str` to `texts: list[str]` and updated the base class to call `on_embeddings(request.texts, model=model)`.

The **Ollama** and **FastEmbed** providers were updated to match, but the **HuggingFace** provider was missed:

- Parameter still named `text` (singular) instead of `texts`
- `embed_documents([text])` wraps the already-list input in another list
- Result: `embed_documents([["text1", "text2"]])` — list of lists instead of list of strings

## Error

```
File "langchain_huggingface/embeddings/huggingface.py", line 121, in <lambda>
    texts = list(map(lambda x: x.replace("\n", " "), texts))
                               ^^^^^^^^^
AttributeError: 'list' object has no attribute 'replace'
```

## Fix

Aligns the HF provider with Ollama/FastEmbed:
1. Rename param `text` → `texts`
2. Remove redundant `[text]` wrapping — pass `texts` directly
3. Add empty-list guard (consistent with other providers)

## Files Changed

- `trustgraph-embeddings-hf/trustgraph/embeddings/hf/hf.py`

## How to Reproduce

1. Deploy TrustGraph with HuggingFace embeddings (default config)
2. Load a document and trigger knowledge extraction
3. Run a GraphRAG query (which calls the embeddings service)
4. Observe: `AttributeError: 'list' object has no attribute 'replace'`

## Test Plan

- [x] Tested locally — GraphRAG queries succeed after this fix
- [x] Verified Ollama and FastEmbed providers use the same pattern