### PR TITLE
Fix missing auth header in verify_system_status processor check

### DIFF
--- a/trustgraph-cli/trustgraph/cli/verify_system_status.py
+++ b/trustgraph-cli/trustgraph/cli/verify_system_status.py
@@ -178,7 +178,11 @@ def check_processors(url: str, min_processors: int, timeout: int, token: Optiona
             url += '/'
         metrics_url = f"{url}api/metrics/query?query=processor_info"
 
-        resp = requests.get(metrics_url, timeout=timeout)
+        headers = {}
+        if token:
+            headers["Authorization"] = f"Bearer {token}"
+
+        resp = requests.get(metrics_url, timeout=timeout, headers=headers)
         if resp.status_code == 200:
             data = resp.json()
             processor_count = len(data.get("data", {}).get("result", []))


### PR DESCRIPTION
The check_processors function received the token parameter but did not include it in the Authorization header when calling the metrics endpoint, causing 401 errors when gateway auth is enabled.            
