### PR TITLE
Add missing pdf extra to unstructured dependency

### DIFF
--- a/containers/Containerfile.unstructured
+++ b/containers/Containerfile.unstructured
@@ -7,7 +7,7 @@ FROM docker.io/fedora:42 AS base
 
 ENV PIP_BREAK_SYSTEM_PACKAGES=1
 
-RUN dnf install -y python3.13 && \
+RUN dnf install -y python3.13 libxcb mesa-libGL && \
   alternatives --install /usr/bin/python python /usr/bin/python3.13 1 && \
   python -m ensurepip --upgrade && \
   pip3 install --no-cache-dir build wheel aiohttp && \

--- a/containers/Containerfile.unstructured
+++ b/containers/Containerfile.unstructured
@@ -38,6 +38,11 @@ RUN ls /root/wheels
 
 FROM base
 
+# Pre-install CPU-only PyTorch so that unstructured[pdf]'s torch
+# dependency is satisfied without pulling in CUDA (~190MB vs ~2GB+)
+RUN pip3 install --no-cache-dir torch==2.11.0+cpu \
+    --index-url https://download.pytorch.org/whl/cpu
+
 COPY --from=build /root/wheels /root/wheels
 
 RUN \

--- a/trustgraph-unstructured/pyproject.toml
+++ b/trustgraph-unstructured/pyproject.toml
@@ -14,7 +14,10 @@ dependencies = [
     "pulsar-client",
     "prometheus-client",
     "python-magic",
-    "unstructured[csv,docx,epub,md,odt,pdf,pptx,rst,rtf,tsv,xlsx]",
+    "unstructured[csv,docx,epub,md,odt,pptx,rst,rtf,tsv,xlsx]",
+    "pdfminer.six",
+    "pdf2image",
+    "pikepdf",
 ]
 classifiers = [
     "Programming Language :: Python :: 3",

--- a/trustgraph-unstructured/pyproject.toml
+++ b/trustgraph-unstructured/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "pulsar-client",
     "prometheus-client",
     "python-magic",
-    "unstructured[csv,docx,epub,md,odt,pptx,rst,rtf,tsv,xlsx]",
+    "unstructured[csv,docx,epub,md,odt,pdf,pptx,rst,rtf,tsv,xlsx]",
 ]
 classifiers = [
     "Programming Language :: Python :: 3",

--- a/trustgraph-unstructured/pyproject.toml
+++ b/trustgraph-unstructured/pyproject.toml
@@ -18,6 +18,9 @@ dependencies = [
     "pdfminer.six",
     "pdf2image",
     "pikepdf",
+    "pi_heif",
+    "pypdfium2",
+    "unstructured.pytesseract",
 ]
 classifiers = [
     "Programming Language :: Python :: 3",

--- a/trustgraph-unstructured/pyproject.toml
+++ b/trustgraph-unstructured/pyproject.toml
@@ -14,13 +14,7 @@ dependencies = [
     "pulsar-client",
     "prometheus-client",
     "python-magic",
-    "unstructured[csv,docx,epub,md,odt,pptx,rst,rtf,tsv,xlsx]",
-    "pdfminer.six",
-    "pdf2image",
-    "pikepdf",
-    "pi_heif",
-    "pypdfium2",
-    "unstructured.pytesseract",
+    "unstructured[csv,docx,epub,md,odt,pdf,pptx,rst,rtf,tsv,xlsx]",
 ]
 classifiers = [
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
The universal decoder failed when processing PDF documents because the unstructured package was installed without the pdf extra.
