### PR TITLE
Fix deadlink in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ The default Grafana dashboard tracks the following:
 
 ## Contributing
 
-[Developer's Guide](https://docs.trustgraph.ai/community/developer.html)
+[Developer's Guide](https://docs.trustgraph.ai/guides/building/introduction.html)
 
 ## License
 


### PR DESCRIPTION
Hi @cybermaggedon & @JackColquitt,

It's me again :-)

I wanted to check out the developer docs, but the current README has a dead-link (404) to `https://docs.trustgraph.ai/community/developer.html` - so I replaced it with `https://docs.trustgraph.ai/guides/building/introduction.html`. Please feel free to further change as needed, this was just the one I saw that was closest to whatever `/community/developer.html` was from the slug name.

Best! 🫡 