### PR TITLE
SPARQL query CLI does not report errors

### DIFF
--- a/trustgraph-cli/trustgraph/cli/invoke_sparql_query.py
+++ b/trustgraph-cli/trustgraph/cli/invoke_sparql_query.py
@@ -62,6 +62,11 @@ def sparql_query(url, token, flow_id, query, user, collection, limit,
             limit=limit,
             batch_size=batch_size,
         ):
+            if "error" in response:
+                err = response["error"]
+                msg = err.get("message", err) if isinstance(err, dict) else err
+                raise RuntimeError(msg)
+
             query_type = response.get("query-type", "select")
 
             # ASK queries - just print and return


### PR DESCRIPTION
SPARQL query CLI ignores errors from the SPARQL service and just emits a zero row output. This change causes an error to be reported