### PR TITLE
chore(mcp): remove unused imports in trustgraph-mcp

### DIFF
--- a/trustgraph-mcp/trustgraph/mcp_server/mcp.py
+++ b/trustgraph-mcp/trustgraph/mcp_server/mcp.py
@@ -1,20 +1,14 @@
 from contextlib import asynccontextmanager
-from typing import Optional
 import os
-import time
-from typing import AsyncGenerator, Any, Dict, List
-import asyncio
+from typing import Any, Dict, List
 import logging
 import json
-import uuid
 import argparse
 from dataclasses import dataclass
 from collections.abc import AsyncIterator
 from functools import partial
 
 from mcp.server.fastmcp import FastMCP, Context
-from mcp.types import TextContent
-from websockets.asyncio.client import connect
 
 from trustgraph.base.logging import add_logging_args, setup_logging
 

--- a/trustgraph-mcp/trustgraph/mcp_server/tg_socket.py
+++ b/trustgraph-mcp/trustgraph/mcp_server/tg_socket.py
@@ -1,12 +1,10 @@
 
-from dataclasses import dataclass
 from websockets.asyncio.client import connect
 from urllib.parse import urlencode, urlparse, urlunparse, parse_qs
 import asyncio
 import logging
 import json
 import uuid
-import time
 
 class WebSocketManager:
 


### PR DESCRIPTION
## Summary

Closes #784.

Ran `ruff check --select F401` on `trustgraph-mcp/trustgraph/mcp_server/` and removed the unused imports it flagged.

## Changes

- `tg_socket.py` — the example called out in the issue. Drops:
  - `from dataclasses import dataclass`
  - `import time`
  
  Neither symbol is referenced anywhere in the file.

- `mcp.py` — same directory, also flagged by ruff. Drops seven more:
  - `typing.Optional`, `typing.AsyncGenerator`
  - `time`, `asyncio`, `uuid`
  - `mcp.types.TextContent`
  - `websockets.asyncio.client.connect`

## Scope

Kept to the one directory the issue called out. 7 ruff F401 hits, all autofixable. Other packages in the monorepo also have F401 warnings that can be cleaned up in follow-up PRs to keep this one reviewable.

## Verification

- `ruff check --select F401 trustgraph-mcp/trustgraph/mcp_server/` - clean after change
- Both files still parse (`ast.parse`)