### PR TITLE
fix: replace deprecated datetime.utcnow() with timezone-aware datetime.now(timezone.utc)

### DIFF
--- a/trustgraph-base/trustgraph/provenance/agent.py
+++ b/trustgraph-base/trustgraph/provenance/agent.py
@@ -13,7 +13,7 @@ Agent provenance tracks the reasoning trace of agent sessions:
 """
 
 import json
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import List, Optional, Dict, Any
 
 from .. schema import Triple, Term, IRI, LITERAL
@@ -87,7 +87,7 @@ def agent_session_triples(
         List of Triple objects
     """
     if timestamp is None:
-        timestamp = datetime.utcnow().isoformat() + "Z"
+        timestamp = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
 
     triples = [
         _triple(session_uri, RDF_TYPE, _iri(PROV_ENTITY)),

--- a/trustgraph-base/trustgraph/provenance/triples.py
+++ b/trustgraph-base/trustgraph/provenance/triples.py
@@ -2,7 +2,7 @@
 Helper functions to build PROV-O triples for extraction-time provenance.
 """
 
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import List, Optional
 
 from .. schema import Triple, Term, IRI, LITERAL, TRIPLE
@@ -192,7 +192,7 @@ def derived_entity_triples(
         List of Triple objects
     """
     if timestamp is None:
-        timestamp = datetime.utcnow().isoformat() + "Z"
+        timestamp = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
 
     act_uri = activity_uri()
     agt_uri = agent_uri(component_name)
@@ -309,7 +309,7 @@ def subgraph_provenance_triples(
         List of Triple objects for the provenance
     """
     if timestamp is None:
-        timestamp = datetime.utcnow().isoformat() + "Z"
+        timestamp = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
 
     act_uri = activity_uri()
     agt_uri = agent_uri(component_name)
@@ -386,7 +386,7 @@ def question_triples(
         List of Triple objects
     """
     if timestamp is None:
-        timestamp = datetime.utcnow().isoformat() + "Z"
+        timestamp = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
 
     triples = [
         _triple(question_uri, RDF_TYPE, _iri(PROV_ENTITY)),
@@ -640,7 +640,7 @@ def docrag_question_triples(
         List of Triple objects
     """
     if timestamp is None:
-        timestamp = datetime.utcnow().isoformat() + "Z"
+        timestamp = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
 
     triples = [
         _triple(question_uri, RDF_TYPE, _iri(PROV_ENTITY)),

--- a/trustgraph-flow/trustgraph/agent/orchestrator/pattern_base.py
+++ b/trustgraph-flow/trustgraph/agent/orchestrator/pattern_base.py
@@ -9,7 +9,7 @@ librarian integration.
 import json
 import logging
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 
 from ... schema import AgentRequest, AgentResponse, AgentStep, Error
 from ... schema import Triples, Metadata
@@ -253,7 +253,7 @@ class PatternBase:
                                    collection, respond, streaming,
                                    parent_uri=None):
         """Emit provenance triples for a new session."""
-        timestamp = datetime.utcnow().isoformat() + "Z"
+        timestamp = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
         triples = set_graph(
             agent_session_triples(
                 session_uri, question, timestamp,

--- a/trustgraph-flow/trustgraph/agent/react/service.py
+++ b/trustgraph-flow/trustgraph/agent/react/service.py
@@ -10,7 +10,7 @@ import sys
 import functools
 import logging
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 
 # Module logger
 logger = logging.getLogger(__name__)
@@ -452,7 +452,7 @@ class Processor(AgentService):
 
             # On first iteration, emit session triples
             if iteration_num == 1:
-                timestamp = datetime.utcnow().isoformat() + "Z"
+                timestamp = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
                 triples = set_graph(
                     agent_session_triples(session_uri, request.question, timestamp),
                     GRAPH_RETRIEVAL

--- a/trustgraph-flow/trustgraph/retrieval/document_rag/document_rag.py
+++ b/trustgraph-flow/trustgraph/retrieval/document_rag/document_rag.py
@@ -2,7 +2,7 @@
 import asyncio
 import logging
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 
 # Provenance imports
 from trustgraph.provenance import (
@@ -199,7 +199,7 @@ class DocumentRag:
         exp_uri = docrag_exploration_uri(session_id)
         syn_uri = docrag_synthesis_uri(session_id)
 
-        timestamp = datetime.utcnow().isoformat() + "Z"
+        timestamp = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
 
         # Emit question explainability immediately
         if explain_callback:

--- a/trustgraph-flow/trustgraph/retrieval/graph_rag/graph_rag.py
+++ b/trustgraph-flow/trustgraph/retrieval/graph_rag/graph_rag.py
@@ -7,7 +7,7 @@ import math
 import time
 import uuid
 from collections import OrderedDict
-from datetime import datetime
+from datetime import datetime, timezone
 
 from ... schema import Term, Triple as SchemaTriple, IRI, LITERAL, TRIPLE
 from ... knowledge import Uri, Literal
@@ -643,7 +643,7 @@ class GraphRag:
         foc_uri = make_focus_uri(session_id)
         syn_uri = make_synthesis_uri(session_id)
 
-        timestamp = datetime.utcnow().isoformat() + "Z"
+        timestamp = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
 
         # Emit question explainability immediately
         if explain_callback:


### PR DESCRIPTION
## Summary

Replace all 9 uses of `datetime.utcnow()` with timezone-aware `datetime.now(timezone.utc)` and normalize the output to preserve the existing `...Z` ISO-8601 format. Addresses the `DeprecationWarning`s surfaced by issue #814.

## Why

Python 3.14 marks `datetime.utcnow()` as deprecated (scheduled for removal), which is why the test suite now emits `DeprecationWarning` for every provenance/agent timestamp. The warning message recommends `datetime.now(datetime.UTC)`, but `trustgraph-base/pyproject.toml` pins `requires-python = ">=3.8"`, so this PR uses `timezone.utc` instead (available since 3.2, identical semantics, no 3.11+ dependency).

`grep -rn 'datetime\.utcnow()' --include='*.py'` found 9 call sites, all of the exact form:

```python
timestamp = datetime.utcnow().isoformat() + "Z"
```

Files touched:
- `trustgraph-base/trustgraph/provenance/agent.py:90`
- `trustgraph-base/trustgraph/provenance/triples.py:195, 312, 389, 643`
- `trustgraph-flow/trustgraph/agent/orchestrator/pattern_base.py:256`
- `trustgraph-flow/trustgraph/agent/react/service.py:455`
- `trustgraph-flow/trustgraph/retrieval/document_rag/document_rag.py:202`
- `trustgraph-flow/trustgraph/retrieval/graph_rag/graph_rag.py:646`

## Changes

Each call site is rewritten identically:

```python
# Before
timestamp = datetime.utcnow().isoformat() + "Z"
# After
timestamp = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
```

The `.replace("+00:00", "Z")` keeps the emitted timestamp string byte-for-byte compatible with the old format, so any downstream code parsing a trailing `Z` continues to work without change.

Each touched file's `from datetime import datetime` import was extended to `from datetime import datetime, timezone`.

## Testing

- `grep -rn 'datetime\.utcnow()' --include='*.py'` now returns zero matches.
- `python3 -c 'import ast; ast.parse(open(f).read())'` passes for all 6 modified files.
- Output format verified equal: old `2026-04-16T08:55:00.123456Z`, new `2026-04-16T08:55:00.123456Z`.

Fixes #814

This contribution was developed with AI assistance (Codex).

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
