### PR TITLE
Fix docstring breakage in type hint change

### DIFF
--- a/trustgraph-base/trustgraph/base/agent_service.py
+++ b/trustgraph-base/trustgraph/base/agent_service.py
@@ -1,10 +1,10 @@
-from __future__ import annotations
-
-from argparse import ArgumentParser
-
 """
 Agent manager service completion base class
 """
+
+from __future__ import annotations
+
+from argparse import ArgumentParser
 
 import time
 import logging

--- a/trustgraph-base/trustgraph/base/document_embeddings_query_service.py
+++ b/trustgraph-base/trustgraph/base/document_embeddings_query_service.py
@@ -1,11 +1,11 @@
-from __future__ import annotations
-
-from argparse import ArgumentParser
-
 """
 Document embeddings query service.  Input is vectors.  Output is list of
 embeddings.
 """
+
+from __future__ import annotations
+
+from argparse import ArgumentParser
 
 import logging
 

--- a/trustgraph-base/trustgraph/base/document_embeddings_store_service.py
+++ b/trustgraph-base/trustgraph/base/document_embeddings_store_service.py
@@ -1,10 +1,10 @@
-from __future__ import annotations
-
-from argparse import ArgumentParser
-
 """
 Document embeddings store base class
 """
+
+from __future__ import annotations
+
+from argparse import ArgumentParser
 
 import logging
 

--- a/trustgraph-base/trustgraph/base/dynamic_tool_service.py
+++ b/trustgraph-base/trustgraph/base/dynamic_tool_service.py
@@ -1,7 +1,3 @@
-from __future__ import annotations
-
-from argparse import ArgumentParser
-
 """
 Base class for dynamically pluggable tool services.
 
@@ -13,6 +9,10 @@ Uses direct Pulsar topics (no flow configuration required):
 - Request: non-persistent://tg/request/{topic}
 - Response: non-persistent://tg/response/{topic}
 """
+
+from __future__ import annotations
+
+from argparse import ArgumentParser
 
 import json
 import logging

--- a/trustgraph-base/trustgraph/base/embeddings_service.py
+++ b/trustgraph-base/trustgraph/base/embeddings_service.py
@@ -1,10 +1,10 @@
-from __future__ import annotations
-
-from argparse import ArgumentParser
-
 """
 Embeddings resolution base class
 """
+
+from __future__ import annotations
+
+from argparse import ArgumentParser
 
 import time
 import logging

--- a/trustgraph-base/trustgraph/base/graph_embeddings_query_service.py
+++ b/trustgraph-base/trustgraph/base/graph_embeddings_query_service.py
@@ -1,11 +1,11 @@
-from __future__ import annotations
-
-from argparse import ArgumentParser
-
 """
 Graph embeddings query service.  Input is vectors.  Output is list of
 embeddings.
 """
+
+from __future__ import annotations
+
+from argparse import ArgumentParser
 
 import logging
 

--- a/trustgraph-base/trustgraph/base/graph_embeddings_store_service.py
+++ b/trustgraph-base/trustgraph/base/graph_embeddings_store_service.py
@@ -1,10 +1,10 @@
-from __future__ import annotations
-
-from argparse import ArgumentParser
-
 """
 Graph embeddings store base class
 """
+
+from __future__ import annotations
+
+from argparse import ArgumentParser
 
 import logging
 

--- a/trustgraph-base/trustgraph/base/llm_service.py
+++ b/trustgraph-base/trustgraph/base/llm_service.py
@@ -1,10 +1,10 @@
-from __future__ import annotations
-
-from argparse import ArgumentParser
-
 """
 LLM text completion base class
 """
+
+from __future__ import annotations
+
+from argparse import ArgumentParser
 
 import time
 import logging

--- a/trustgraph-base/trustgraph/base/tool_service.py
+++ b/trustgraph-base/trustgraph/base/tool_service.py
@@ -1,10 +1,10 @@
-from __future__ import annotations
-
-from argparse import ArgumentParser
-
 """
 Tool invocation base class
 """
+
+from __future__ import annotations
+
+from argparse import ArgumentParser
 
 import json
 import logging

--- a/trustgraph-base/trustgraph/base/triples_query_service.py
+++ b/trustgraph-base/trustgraph/base/triples_query_service.py
@@ -1,11 +1,11 @@
-from __future__ import annotations
-
-from argparse import ArgumentParser
-
 """
 Triples query service.  Input is a (s, p, o) triple, some values may be
 null.  Output is a list of triples.
 """
+
+from __future__ import annotations
+
+from argparse import ArgumentParser
 
 import logging
 

--- a/trustgraph-base/trustgraph/base/triples_store_service.py
+++ b/trustgraph-base/trustgraph/base/triples_store_service.py
@@ -1,10 +1,10 @@
-from __future__ import annotations
-
-from argparse import ArgumentParser
-
 """
 Triples store base class
 """
+
+from __future__ import annotations
+
+from argparse import ArgumentParser
 
 import logging
 


### PR DESCRIPTION
Moved...
```
from __future__ import annotations
from argparse import ArgumentParser
```
to re-enable docstrings