### PR TITLE
fix: replace deprecated asyncio.iscoroutinefunction with inspect equivalent

### DIFF
--- a/trustgraph-base/trustgraph/base/prompt_client.py
+++ b/trustgraph-base/trustgraph/base/prompt_client.py
@@ -1,6 +1,7 @@
 
 import json
 import asyncio
+import inspect
 from dataclasses import dataclass
 from typing import Optional, Any
 
@@ -80,7 +81,7 @@ class PromptClient(RequestResponse):
 
                 if resp.text is not None:
                     if chunk_callback:
-                        if asyncio.iscoroutinefunction(chunk_callback):
+                        if inspect.iscoroutinefunction(chunk_callback):
                             await chunk_callback(resp.text, end_stream)
                         else:
                             chunk_callback(resp.text, end_stream)

--- a/trustgraph-flow/trustgraph/query/ontology/error_handling.py
+++ b/trustgraph-flow/trustgraph/query/ontology/error_handling.py
@@ -6,6 +6,7 @@ Provides comprehensive error handling, retry logic, and graceful degradation.
 import logging
 import time
 import asyncio
+import inspect
 from typing import Dict, Any, List, Optional, Callable, Union, Type
 from dataclasses import dataclass
 from enum import Enum
@@ -244,7 +245,7 @@ class ErrorRecoveryStrategy:
         await asyncio.sleep(delay)
 
         try:
-            if asyncio.iscoroutinefunction(operation):
+            if inspect.iscoroutinefunction(operation):
                 return await operation(*args, **kwargs)
             else:
                 return operation(*args, **kwargs)
@@ -260,7 +261,7 @@ class ErrorRecoveryStrategy:
         if fallback_func:
             logger.info(f"Executing fallback for {context.category.value}")
             try:
-                if asyncio.iscoroutinefunction(fallback_func):
+                if inspect.iscoroutinefunction(fallback_func):
                     return await fallback_func(context, *args, **kwargs)
                 else:
                     return fallback_func(context, *args, **kwargs)
@@ -420,7 +421,7 @@ def with_error_handling(category: ErrorCategory,
         @wraps(func)
         async def async_wrapper(*args, **kwargs):
             try:
-                if asyncio.iscoroutinefunction(func):
+                if inspect.iscoroutinefunction(func):
                     return await func(*args, **kwargs)
                 else:
                     return func(*args, **kwargs)
@@ -469,7 +470,7 @@ def with_error_handling(category: ErrorCategory,
                     cause=e
                 )
 
-        if asyncio.iscoroutinefunction(func):
+        if inspect.iscoroutinefunction(func):
             return async_wrapper
         else:
             return sync_wrapper

--- a/trustgraph-flow/trustgraph/query/ontology/monitoring.py
+++ b/trustgraph-flow/trustgraph/query/ontology/monitoring.py
@@ -6,6 +6,7 @@ Provides comprehensive monitoring of system performance, query patterns, and res
 import logging
 import time
 import asyncio
+import inspect
 import threading
 from typing import Dict, Any, List, Optional, Callable
 from dataclasses import dataclass, field
@@ -579,7 +580,7 @@ def monitor_performance(component: str,
 
         async def async_wrapper(*args, **kwargs):
             if not monitor or not monitor.monitoring_enabled:
-                if asyncio.iscoroutinefunction(func):
+                if inspect.iscoroutinefunction(func):
                     return await func(*args, **kwargs)
                 else:
                     return func(*args, **kwargs)
@@ -591,7 +592,7 @@ def monitor_performance(component: str,
 
             success = True
             try:
-                if asyncio.iscoroutinefunction(func):
+                if inspect.iscoroutinefunction(func):
                     result = await func(*args, **kwargs)
                 else:
                     result = func(*args, **kwargs)
@@ -603,7 +604,7 @@ def monitor_performance(component: str,
                 duration = monitor.metrics_collector.stop_timer(timer)
                 monitor.record_request(component, operation, duration, success)
 
-        if asyncio.iscoroutinefunction(func):
+        if inspect.iscoroutinefunction(func):
             return async_wrapper
         else:
             return wrapper


### PR DESCRIPTION
## Summary

Closes one of the deprecation warnings listed in #818.

`asyncio.iscoroutinefunction` is deprecated since Python 3.14 and slated for removal in 3.16. The deprecation message itself points to `inspect.iscoroutinefunction` as the replacement, which has an identical signature and return behaviour.

## Changes

Replaces 8 call sites across 3 modules and adds `import inspect` where needed:

- `trustgraph-base/trustgraph/base/prompt_client.py` — 1 site (streaming chunk-callback dispatch; this alone accounted for 17 of the warnings cited in #818)
- `trustgraph-flow/trustgraph/query/ontology/error_handling.py` — 4 sites (retry, fallback, and `@with_error_recovery` decorator)
- `trustgraph-flow/trustgraph/query/ontology/monitoring.py` — 3 sites (`@monitor_performance` decorator)

`import asyncio` is kept in every file — in `error_handling.py` it's still used for `asyncio.sleep`; in the other two it becomes unused but is left in place to keep this PR strictly scoped to the warning fix. Happy to remove it in a follow-up if preferred.

## Why the substitution is safe

The Python docs explicitly describe `asyncio.iscoroutinefunction` as a wrapper that returns the same result as `inspect.iscoroutinefunction`, with the legacy `@asyncio.coroutine` path gone since Python 3.11. No behavioural change expected.

## Test plan

- [x] AST parse of all three modified files
- [x] `pytest tests/unit/test_base/test_prompt_client_streaming.py -v -W default` — 7/7 pass, **zero** DeprecationWarnings in the summary (vs. 17 previously from line 83)
- [x] Full CI run on this PR (skipped locally — `pip install -e .` blocked by a chicken-and-egg between dynamic `version = {attr = "trustgraph.base_version.__version__"}` and package build isolation; CI should not hit this)

## Notes

- Targeted at `release/v2.3` as requested in the issue body.
- Does not touch `tests/unit/test_agent/test_tool_coordination.py` — it already uses `inspect.iscoroutinefunction` on this branch.
- The other warnings listed in #818 (langchain-core Pydantic V1, SwigPy* from `importlib._bootstrap`, google-genai `_UnionGenericAlias`) originate from third-party packages and can't be fixed here.