### PR TITLE
Remove Cossmology badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,6 @@
 [![Discord](https://img.shields.io/discord/1251652173201149994
 )](https://discord.gg/sQMwkRz5GX) [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/trustgraph-ai/trustgraph)
 
-[![trustgraph on Cossmology](https://vpxherzezesqifjloaxx.supabase.co/functions/v1/generate-badge?shortname=trustgraph&siteUrl=https%3A%2F%2Fcossmology.com&v=2)](https://cossmology.com/organizations/trustgraph)
-
 [**Website**](https://trustgraph.ai) | [**Docs**](https://docs.trustgraph.ai) | [**YouTube**](https://www.youtube.com/@TrustGraphAI?sub_confirmation=1) | [**Configuration Terminal**](https://config-ui.demo.trustgraph.ai/) | [**Discord**](https://discord.gg/sQMwkRz5GX) | [**Blog**](https://blog.trustgraph.ai/subscribe)
 
 <a href="https://trendshift.io/repositories/17291" target="_blank"><img src="https://trendshift.io/api/badge/repositories/17291" alt="trustgraph-ai%2Ftrustgraph | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>


### PR DESCRIPTION
Removed the badge for trustgraph on Cossmology from the README.