### PR TITLE
Add missing websockets dep

### DIFF
--- a/trustgraph-base/pyproject.toml
+++ b/trustgraph-base/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "pika",
     "confluent-kafka",
     "pyyaml",
+    "websockets",
 ]
 classifiers = [
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
The API in trustgraph_base needs `websockets` to function.  Added to `pyproject.toml`