### PR TITLE
Fix erroneous handling of __template__ and __system__ workspaces

### DIFF
--- a/trustgraph-base/trustgraph/base/async_processor.py
+++ b/trustgraph-base/trustgraph/base/async_processor.py
@@ -209,6 +209,8 @@ class AsyncProcessor:
 
                         # Call the handler once per workspace
                         for ws, config in per_ws.items():
+                            if ws.startswith("_"):
+                                continue
                             await entry["handler"](ws, config, version)
 
                     logger.info(
@@ -310,6 +312,8 @@ class AsyncProcessor:
                             per_ws.setdefault(ws, {})[t] = kv
 
                     for ws, config in per_ws.items():
+                        if ws.startswith("_"):
+                            continue
                         await entry["handler"](
                             ws, config, notify_version,
                         )


### PR DESCRIPTION
`__template__` and `__system__` are not real workspace but config zones for workspace template and init handling.  They should not be processed as workspaces.

Now ignores workspace beginning with '_' prefix.