### PR TITLE
Fix a circular dependency causing bootstrap to fail

### DIFF
--- a/trustgraph-flow/trustgraph/bootstrap/initialisers/template_seed.py
+++ b/trustgraph-flow/trustgraph/bootstrap/initialisers/template_seed.py
@@ -39,6 +39,8 @@ TEMPLATE_WORKSPACE = "__template__"
 
 class TemplateSeed(Initialiser):
 
+    wait_for_services = False
+
     def __init__(self, config_file, overwrite=False, **kwargs):
         super().__init__(**kwargs)
         if not config_file:

--- a/trustgraph-flow/trustgraph/bootstrap/initialisers/workspace_init.py
+++ b/trustgraph-flow/trustgraph/bootstrap/initialisers/workspace_init.py
@@ -33,6 +33,8 @@ TEMPLATE_WORKSPACE = "__template__"
 
 class WorkspaceInit(Initialiser):
 
+    wait_for_services = False
+
     def __init__(
             self,
             workspace="default",


### PR DESCRIPTION
TemplateSeed and WorkspaceInit now run pre-gate. They'll write templates and register the default workspace before the gate checks flow-svc, breaking the circular dependency.