### PR TITLE
fix: Publisher not cleaned up on error in librarian submit_d...

### DIFF
--- a/trustgraph-flow/trustgraph/librarian/service.py
+++ b/trustgraph-flow/trustgraph/librarian/service.py
@@ -418,14 +418,11 @@ class Processor(AsyncProcessor):
             self.pubsub, q, schema=schema
         )
 
-        await pub.start()
-
-        # FIXME: Time wait kludge?
-        await asyncio.sleep(1)
-
-        await pub.send(None, doc)
-
-        await pub.stop()
+        try:
+            await pub.start()
+            await pub.send(None, doc)
+        finally:
+            await pub.stop()
 
         logger.debug("Document submitted")
 


### PR DESCRIPTION
Closes #871

### Description
Fix publisher resource leak when `submit_document` fails during send. The publisher and its underlying connection are now guaranteed to be cleaned up on error.

### Special notes for your reviewer(s)
- trustgraph-flow/trustgraph/librarian/service.py: Wrap publisher lifecycle in try/finally to guarantee `pub.stop()` is called even if `send()` raises an exception.

### Checklist
- [x] Backwards compatible?