### PR TITLE
gateway: thread --timeout flag into DispatcherManager (fixes #894)

### DIFF
--- a/trustgraph-flow/trustgraph/gateway/dispatch/manager.py
+++ b/trustgraph-flow/trustgraph/gateway/dispatch/manager.py
@@ -135,13 +135,19 @@ class DispatcherWrapper:
 class DispatcherManager:
 
     def __init__(self, backend, config_receiver, auth,
-                 prefix="api-gateway", queue_overrides=None):
+                 prefix="api-gateway", queue_overrides=None,
+                 timeout=120):
         """
         ``auth`` is required.  It flows into the Mux for first-frame
         WebSocket authentication and into downstream dispatcher
         construction.  There is no permissive default — constructing
         a DispatcherManager without an authenticator would be a
         silent downgrade to no-auth on the socket path.
+
+        ``timeout`` is the per-request timeout (seconds) applied to
+        every dispatcher this manager constructs (global services
+        and per-flow request/response paths).  The api-gateway CLI
+        flag ``--timeout`` (default 600s) is plumbed in here.
         """
         if auth is None:
             raise ValueError(
@@ -162,6 +168,10 @@ class DispatcherManager:
         # Store queue overrides for global services
         # Format: {"config": {"request": "...", "response": "..."}, ...}
         self.queue_overrides = queue_overrides or {}
+
+        # Per-request timeout applied to all dispatchers; sourced
+        # from the api-gateway --timeout flag.
+        self.timeout = timeout
 
         # Flows keyed by (workspace, flow_id)
         self.flows = {}
@@ -291,7 +301,7 @@ class DispatcherManager:
 
                     dispatcher = global_dispatchers[kind](
                         backend = self.backend,
-                        timeout = 120,
+                        timeout = self.timeout,
                         consumer = consumer_name,
                         subscriber = consumer_name,
                         request_queue = request_queue,
@@ -448,7 +458,7 @@ class DispatcherManager:
                             backend = self.backend,
                             request_queue = qconfig["request"],
                             response_queue = qconfig["response"],
-                            timeout = 120,
+                            timeout = self.timeout,
                             consumer = f"{self.prefix}-{workspace}-{flow}-{kind}-request",
                             subscriber = f"{self.prefix}-{workspace}-{flow}-{kind}-request",
                         )

--- a/trustgraph-flow/trustgraph/gateway/service.py
+++ b/trustgraph-flow/trustgraph/gateway/service.py
@@ -119,6 +119,7 @@ class Api:
             prefix = "gateway",
             queue_overrides = queue_overrides,
             auth = self.auth,
+            timeout = self.timeout,
         )
 
         self.endpoint_manager = EndpointManager(


### PR DESCRIPTION
Fixes #894.

## Problem

The `api-gateway` accepts a `--timeout` flag (default `600`,
[`gateway/service.py:36`](trustgraph-flow/trustgraph/gateway/service.py#L36))
documented as *"API request timeout in seconds"*, but the value
never reaches `DispatcherManager`, which constructs every per-service
dispatcher with a hardcoded `timeout = 120`. So `--timeout 600` (or
any other value) had no effect on graph-rag, document-rag, librarian,
text-completion, or any other request/response path. Long-running
requests deterministically returned
`{"error":{"type":"gateway-error","message":"Timeout"}}` at exactly
2:00 wallclock, regardless of the gateway flag.

The WebSocket endpoint manager already received `self.timeout`
correctly; only the dispatcher manager was missing the wiring.

## Change

- Add `timeout=120` parameter to `DispatcherManager.__init__`
  (default preserves prior behaviour for any external caller).
- Store on `self.timeout`.
- Use `self.timeout` in both dispatcher construction sites
  (`global_dispatchers` at line ~301 and `request_response_dispatchers`
  at line ~458) instead of the literal `120`.
- Pass `timeout=self.timeout` from `Api` in
  `gateway/service.py:116-122` so the existing `--timeout` CLI flag
  finally reaches the dispatchers.

## Compatibility

Non-breaking: default of `120` is preserved on the new parameter, so
any caller that doesn't pass `timeout` keeps the previous behaviour.

## Test plan

- [x] Syntax-check both files (`python -m py_compile`).
- [x] Manual repro before fix on TG 2.3.21 with `--timeout 600`:
      `curl … /api/v1/flow/default/service/graph-rag …` returns
      `gateway-error: Timeout` at 120s.
- [x] After patch (verified by patching the same files in the
      running container before forking), the same query is allowed
      to run to completion (~25s server-side) and returns the
      grounded answer.
- [ ] Maintainers: please confirm the existing dispatcher unit
      tests still pass; I haven't run the suite locally because
      this is targeted at `release/v2.4` which I don't have a
      complete test env for.

## Related

- Issue #894 (this PR fixes it).
- Issue #874 *"Hardcoded timeout values should be configurable"* —
  adjacent. The gateway side is now done; bootstrapper / librarian /
  config-client items in #874 remain.
