### PR TITLE
fix(ontology): guard against missing cache_type label in metric parsing

### DIFF
--- a/trustgraph-flow/trustgraph/query/ontology/monitoring.py
+++ b/trustgraph-flow/trustgraph/query/ontology/monitoring.py
@@ -474,9 +474,11 @@ class PerformanceMonitor:
         # Cache performance
         cache_types = set()
         for metric_name in self.metrics_collector.counters.keys():
-            if 'cache_type=' in metric_name:
-                cache_type = metric_name.split('cache_type=')[1].split(',')[0].split('}')[0]
-                cache_types.add(cache_type)
+            parts = metric_name.split('cache_type=')
+            if len(parts) < 2:
+                continue
+            cache_type = parts[1].split(',')[0].split('}')[0]
+            cache_types.add(cache_type)
 
         for cache_type in cache_types:
             labels = {'cache_type': cache_type}


### PR DESCRIPTION
Fixes #873.

If a metric name in the counters dict lacks a `cache_type=` label, the chained `split('cache_type=')[1]...` raises `IndexError`. The current `if 'cache_type=' in metric_name` guard at line 477 prevents the crash today, but the fragile parsing pattern is one refactor away from re-introducing it.

Replaced the chained-split with an explicit length check so the parsing is safe regardless of the surrounding guard.