### PR TITLE
fix(cli): use os.makedirs(exist_ok=True) in load_sample_documents

### DIFF
--- a/trustgraph-cli/trustgraph/cli/load_sample_documents.py
+++ b/trustgraph-cli/trustgraph/cli/load_sample_documents.py
@@ -28,10 +28,7 @@ session = requests.session()
 
 session.mount('file://', FileAdapter())
 
-try:
-    os.mkdir("doc-cache")
-except:
-    pass
+os.makedirs("doc-cache", exist_ok=True)
 
 documents = [
 


### PR DESCRIPTION
Fixes #869.

The bare `except:` around `os.mkdir("doc-cache")` silently swallows permission errors, read-only filesystem errors, and any other OS failure. Switching to `os.makedirs("doc-cache", exist_ok=True)` handles the "already exists" case explicitly and lets real errors propagate.