### PR TITLE
fix: propagate api-gateway --timeout flag to per-service dispatchers

### DIFF
--- a/trustgraph-flow/trustgraph/gateway/dispatch/manager.py
+++ b/trustgraph-flow/trustgraph/gateway/dispatch/manager.py
@@ -135,13 +135,19 @@ class DispatcherWrapper:
 class DispatcherManager:
 
     def __init__(self, backend, config_receiver, auth,
-                 prefix="api-gateway", queue_overrides=None):
+                 prefix="api-gateway", queue_overrides=None,
+                 timeout=120):
         """
         ``auth`` is required.  It flows into the Mux for first-frame
         WebSocket authentication and into downstream dispatcher
         construction.  There is no permissive default — constructing
         a DispatcherManager without an authenticator would be a
         silent downgrade to no-auth on the socket path.
+
+        ``timeout`` is the API request timeout in seconds for
+        per-service dispatchers.  Must be propagated from the
+        gateway ``--timeout`` flag; defaults to 120 for backward
+        compatibility with callers that do not pass the argument.
         """
         if auth is None:
             raise ValueError(
@@ -158,6 +164,9 @@ class DispatcherManager:
         # auth and by any dispatcher that needs to resolve caller
         # identity out-of-band.
         self.auth = auth
+
+        # Timeout for per-service dispatcher requests.
+        self.timeout = timeout
 
         # Store queue overrides for global services
         # Format: {"config": {"request": "...", "response": "..."}, ...}
@@ -291,7 +300,7 @@ class DispatcherManager:
 
                     dispatcher = global_dispatchers[kind](
                         backend = self.backend,
-                        timeout = 120,
+                        timeout = self.timeout,
                         consumer = consumer_name,
                         subscriber = consumer_name,
                         request_queue = request_queue,
@@ -448,7 +457,7 @@ class DispatcherManager:
                             backend = self.backend,
                             request_queue = qconfig["request"],
                             response_queue = qconfig["response"],
-                            timeout = 120,
+                            timeout = self.timeout,
                             consumer = f"{self.prefix}-{workspace}-{flow}-{kind}-request",
                             subscriber = f"{self.prefix}-{workspace}-{flow}-{kind}-request",
                         )

--- a/trustgraph-flow/trustgraph/gateway/service.py
+++ b/trustgraph-flow/trustgraph/gateway/service.py
@@ -119,6 +119,7 @@ class Api:
             prefix = "gateway",
             queue_overrides = queue_overrides,
             auth = self.auth,
+            timeout = self.timeout,
         )
 
         self.endpoint_manager = EndpointManager(


### PR DESCRIPTION
## Summary

The api-gateway accepts a `--timeout` flag (default 600) documented as "API request timeout in seconds", but the value is silently dropped before reaching per-service dispatchers. `DispatcherManager` constructs every dispatcher (graph-rag, document-rag, text-completion, embeddings, librarian, etc.) with a hardcoded `timeout=120`.

This means any request taking longer than 120 seconds returns a timeout error at exactly the 2-minute mark, regardless of the `--timeout` value set on the gateway. This is easy to hit on graph-rag with default parameters on a single-node deployment.

## Root Cause

In `trustgraph-flow/trustgraph/gateway/service.py`:
- `Api.__init__` stores `self.timeout` from the CLI flag
- It passes `timeout = self.timeout` to `EndpointManager` ✅
- But does NOT pass `timeout` to `DispatcherManager` ❌

In `trustgraph-flow/trustgraph/gateway/dispatch/manager.py`:
- `DispatcherManager.__init__` has no `timeout` parameter
- `invoke_global_service()` uses hardcoded `timeout = 120` (line ~294)
- `invoke_flow_service()` uses hardcoded `timeout = 120` (line ~451)

## Solution

Three small, non-breaking changes:

1. **`manager.py`**: Add `timeout=120` parameter to `DispatcherManager.__init__` and store as `self.timeout`
2. **`manager.py`**: Replace both hardcoded `timeout = 120` with `timeout = self.timeout`
3. **`service.py`**: Pass `timeout = self.timeout` when constructing `DispatcherManager`

The default of 120 is preserved for backward compatibility — callers that do not pass the argument get the same behavior as before.

## Testing

- Verified the change is a clean diff: 2 files, 13 insertions, 3 deletions
- No syntax errors introduced
- The fix follows the same pattern already used by `EndpointManager` which correctly receives `timeout = self.timeout`

Fixes: #894