### PR TITLE
fix: repair broken imports in OntoRAG query module

### DIFF
--- a/tests/unit/test_query/test_ontology_monitoring.py
+++ b/tests/unit/test_query/test_ontology_monitoring.py
@@ -2,27 +2,10 @@
 Tests for ontology monitoring metrics.
 """
 
-import importlib.util
-import sys
-from pathlib import Path
-
-
-MODULE_PATH = (
-    Path(__file__).resolve().parents[3]
-    / "trustgraph-flow"
-    / "trustgraph"
-    / "query"
-    / "ontology"
-    / "monitoring.py"
+from trustgraph.query.ontology.monitoring import (
+    PerformanceMonitor,
+    _extract_metric_label,
 )
-spec = importlib.util.spec_from_file_location("ontology_monitoring", MODULE_PATH)
-assert spec is not None and spec.loader is not None
-monitoring = importlib.util.module_from_spec(spec)
-sys.modules[spec.name] = monitoring
-spec.loader.exec_module(monitoring)
-
-PerformanceMonitor = monitoring.PerformanceMonitor
-_extract_metric_label = monitoring._extract_metric_label
 
 
 def test_extract_metric_label_reads_unquoted_label_value():

--- a/trustgraph-flow/trustgraph/query/ontology/__init__.py
+++ b/trustgraph-flow/trustgraph/query/ontology/__init__.py
@@ -7,7 +7,7 @@ Provides semantic query understanding, ontology matching, and answer generation.
 
 from .query_service import OntoRAGQueryService, QueryRequest, QueryResponse
 from .question_analyzer import QuestionAnalyzer, QuestionComponents, QuestionType
-from .ontology_matcher import OntologyMatcher, QueryOntologySubset
+from .ontology_matcher import OntologyMatcherForQueries, QueryOntologySubset
 from .backend_router import BackendRouter, BackendType, QueryRoute
 from .sparql_generator import SPARQLGenerator, SPARQLQuery
 from .sparql_cassandra import SPARQLCassandraEngine, SPARQLResult
@@ -27,7 +27,7 @@ __all__ = [
     'QuestionType',
 
     # Ontology matching
-    'OntologyMatcher',
+    'OntologyMatcherForQueries',
     'QueryOntologySubset',
 
     # Backend routing

--- a/trustgraph-flow/trustgraph/query/ontology/ontology_matcher.py
+++ b/trustgraph-flow/trustgraph/query/ontology/ontology_matcher.py
@@ -7,10 +7,10 @@ import logging
 from typing import List, Dict, Any, Set, Optional
 from dataclasses import dataclass
 
-from ...extract.kg.ontology.ontology_loader import Ontology, OntologyLoader
-from ...extract.kg.ontology.ontology_embedder import OntologyEmbedder
-from ...extract.kg.ontology.text_processor import TextSegment
-from ...extract.kg.ontology.ontology_selector import OntologySelector, OntologySubset
+from trustgraph.extract.kg.ontology.ontology_loader import Ontology, OntologyLoader
+from trustgraph.extract.kg.ontology.ontology_embedder import OntologyEmbedder
+from trustgraph.extract.kg.ontology.text_processor import TextSegment
+from trustgraph.extract.kg.ontology.ontology_selector import OntologySelector, OntologySubset
 from .question_analyzer import QuestionComponents, QuestionType
 
 logger = logging.getLogger(__name__)

--- a/trustgraph-flow/trustgraph/query/ontology/query_service.py
+++ b/trustgraph-flow/trustgraph/query/ontology/query_service.py
@@ -8,13 +8,13 @@ from typing import Dict, Any, List, Optional, Union
 from dataclasses import dataclass
 from datetime import datetime
 
-from ....flow.flow_processor import FlowProcessor
-from ....tables.config import ConfigTableStore
-from ...extract.kg.ontology.ontology_loader import OntologyLoader
-from ...extract.kg.ontology.vector_store import InMemoryVectorStore
+from trustgraph.base.flow_processor import FlowProcessor
+from trustgraph.tables.config import ConfigTableStore
+from trustgraph.extract.kg.ontology.ontology_loader import OntologyLoader
+from trustgraph.extract.kg.ontology.vector_store import InMemoryVectorStore
 
 from .question_analyzer import QuestionAnalyzer, QuestionComponents
-from .ontology_matcher import OntologyMatcher, QueryOntologySubset
+from .ontology_matcher import OntologyMatcherForQueries, QueryOntologySubset
 from .backend_router import BackendRouter, QueryRoute, BackendType
 from .sparql_generator import SPARQLGenerator, SPARQLQuery
 from .sparql_cassandra import SPARQLCassandraEngine, SPARQLResult
@@ -105,7 +105,7 @@ class OntoRAGQueryService(FlowProcessor):
 
         # Initialize ontology matcher
         matcher_config = self.config.get('ontology_matcher', {})
-        self.ontology_matcher = OntologyMatcher(
+        self.ontology_matcher = OntologyMatcherForQueries(
             vector_store=self.vector_store,
             embedding_service=self.embedding_service,
             config=matcher_config

--- a/trustgraph-flow/trustgraph/query/ontology/sparql_cassandra.py
+++ b/trustgraph-flow/trustgraph/query/ontology/sparql_cassandra.py
@@ -28,7 +28,7 @@ try:
 except ImportError:
     CASSANDRA_AVAILABLE = False
 
-from ....tables.config import ConfigTableStore
+from trustgraph.tables.config import ConfigTableStore
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Replaced relative imports with correct absolute imports across the ontology query package, and fix OntologyMatcher reference to match the actual class name OntologyMatcherForQueries. Simplify test to use standard imports instead of importlib hack.

Cosmetic, but simpler imports provides undeterministic imports in a dev environment, and also means we're properly testing linkage