### PR TITLE
fix: avoid swallowing sample document cache errors

### DIFF
--- a/trustgraph-cli/trustgraph/cli/load_sample_documents.py
+++ b/trustgraph-cli/trustgraph/cli/load_sample_documents.py
@@ -4,9 +4,10 @@ Loads a PDF document into the library
 
 import argparse
 import os
-import uuid
 import datetime
 import requests
+from requests.adapters import HTTPAdapter
+from urllib3.response import HTTPResponse
 
 from trustgraph.api import Api
 from trustgraph.api.types import hash, Uri, Literal, Triple
@@ -15,9 +16,6 @@ default_url = os.getenv("TRUSTGRAPH_URL", 'http://localhost:8088/')
 default_token = os.getenv("TRUSTGRAPH_TOKEN", None)
 default_workspace = os.getenv("TRUSTGRAPH_WORKSPACE", "default")
 
-
-from requests.adapters import HTTPAdapter
-from urllib3.response import HTTPResponse
 
 class FileAdapter(HTTPAdapter):
     def send(self, request, *args, **kwargs):
@@ -28,10 +26,7 @@ session = requests.session()
 
 session.mount('file://', FileAdapter())
 
-try:
-    os.mkdir("doc-cache")
-except:
-    pass
+os.makedirs("doc-cache", exist_ok=True)
 
 documents = [
 


### PR DESCRIPTION
Fixes #869.

## Summary
- Replace the bare `except` around `os.mkdir("doc-cache")` with `os.makedirs(..., exist_ok=True)`.
- Remove an unused import and keep request adapter imports at module import scope so the touched file passes Ruff.

## Tests
- `python3 -m py_compile trustgraph-cli/trustgraph/cli/load_sample_documents.py`
- `ruff check trustgraph-cli/trustgraph/cli/load_sample_documents.py`
- `git diff --check`
