### PR TITLE
fix: CLI tools ignoring -w flag for workspace routing

### DIFF
--- a/trustgraph-cli/trustgraph/cli/load_structured_data.py
+++ b/trustgraph-cli/trustgraph/cli/load_structured_data.py
@@ -293,7 +293,7 @@ def load_structured_data(
 
         # Send to TrustGraph
         print(f"🚀 Importing {len(output_records)} records to TrustGraph...")
-        imported_count = _send_to_trustgraph(output_records, api_url, flow, batch_size, token=token)
+        imported_count = _send_to_trustgraph(output_records, api_url, flow, batch_size, token=token, workspace=workspace)
         
         # Get summary info from descriptor
         format_info = descriptor.get('format', {})

--- a/trustgraph-cli/trustgraph/cli/set_prompt.py
+++ b/trustgraph-cli/trustgraph/cli/set_prompt.py
@@ -119,7 +119,8 @@ def main():
                 raise RuntimeError("Can't use --system with other args")
 
             set_system(
-                url=args.api_url, system=args.system, token=args.token
+                url=args.api_url, system=args.system, token=args.token,
+                workspace=args.workspace,
             )
 
         else:

--- a/trustgraph-cli/trustgraph/cli/show_flow_blueprints.py
+++ b/trustgraph-cli/trustgraph/cli/show_flow_blueprints.py
@@ -105,7 +105,7 @@ async def fetch_data(client, workspace):
     return blueprint_names, blueprints, param_type_defs
 
 async def _show_flow_blueprints_async(url, token=None, workspace="default"):
-    async with AsyncSocketClient(url, timeout=60, token=token) as client:
+    async with AsyncSocketClient(url, timeout=60, token=token, workspace=workspace) as client:
         return await fetch_data(client, workspace)
 
 def show_flow_blueprints(url, token=None, workspace="default"):

--- a/trustgraph-cli/trustgraph/cli/show_flows.py
+++ b/trustgraph-cli/trustgraph/cli/show_flows.py
@@ -213,7 +213,7 @@ async def fetch_show_flows(client, workspace):
 
 async def _show_flows_async(url, token=None, workspace="default"):
 
-    async with AsyncSocketClient(url, timeout=60, token=token) as client:
+    async with AsyncSocketClient(url, timeout=60, token=token, workspace=workspace) as client:
         return await fetch_show_flows(client, workspace)
 
 def show_flows(url, token=None, workspace="default"):

--- a/trustgraph-cli/trustgraph/cli/show_parameter_types.py
+++ b/trustgraph-cli/trustgraph/cli/show_parameter_types.py
@@ -15,6 +15,7 @@ import json
 
 default_url = os.getenv("TRUSTGRAPH_URL", 'http://localhost:8088/')
 default_token = os.getenv("TRUSTGRAPH_TOKEN", None)
+default_workspace = os.getenv("TRUSTGRAPH_WORKSPACE", "default")
 
 def format_enum_values(enum_list):
     """
@@ -125,11 +126,11 @@ async def fetch_single_param_type(client, param_type_name):
         return json.loads(values[0].get("value", "{}"))
     return None
 
-def show_parameter_types(url, token=None):
+def show_parameter_types(url, token=None, workspace="default"):
     """Show all parameter type definitions."""
 
     async def _fetch():
-        async with AsyncSocketClient(url, timeout=60, token=token) as client:
+        async with AsyncSocketClient(url, timeout=60, token=token, workspace=workspace) as client:
             return await fetch_all_param_types(client)
 
     param_type_names, param_type_defs = asyncio.run(_fetch())
@@ -153,11 +154,11 @@ def show_parameter_types(url, token=None):
         ))
         print()
 
-def show_specific_parameter_type(url, param_type_name, token=None):
+def show_specific_parameter_type(url, param_type_name, token=None, workspace="default"):
     """Show a specific parameter type definition."""
 
     async def _fetch():
-        async with AsyncSocketClient(url, timeout=60, token=token) as client:
+        async with AsyncSocketClient(url, timeout=60, token=token, workspace=workspace) as client:
             return await fetch_single_param_type(client, param_type_name)
 
     param_type_def = asyncio.run(_fetch())
@@ -194,6 +195,12 @@ def main():
     )
 
     parser.add_argument(
+        '-w', '--workspace',
+        default=default_workspace,
+        help=f'Workspace (default: {default_workspace})',
+    )
+
+    parser.add_argument(
         '-t', '--type',
         help='Show only the specified parameter type',
     )
@@ -202,9 +209,9 @@ def main():
 
     try:
         if args.type:
-            show_specific_parameter_type(args.api_url, args.type, args.token)
+            show_specific_parameter_type(args.api_url, args.type, args.token, workspace=args.workspace)
         else:
-            show_parameter_types(args.api_url, args.token)
+            show_parameter_types(args.api_url, args.token, workspace=args.workspace)
 
     except Exception as e:
         print("Exception:", e, flush=True)


### PR DESCRIPTION
Several CLI commands silently routed requests to the default workspace regardless of the -w flag: show-flows, show-flow-blueprints, show-parameter-types, set-prompt --system, and load-structured-data. The workspace was sent in the inner request body but not on the WebSocket envelope or API client constructor, so the gateway always dispatched to the default workspace queue.