### PR TITLE
feat: add GLM (Zhipu AI) variant for OpenAI processor

### DIFF
--- a/trustgraph-flow/trustgraph/model/text_completion/openai/variants.py
+++ b/trustgraph-flow/trustgraph/model/text_completion/openai/variants.py
@@ -129,6 +129,28 @@ class MistralVariant(Variant):
         return {"reasoning_effort": effort}
 
 
+class GlmVariant(Variant):
+    """GLM / Zhipu AI API (GLM-4, GLM-4.7, etc.)."""
+
+    name = "glm"
+    token_param = "max_tokens"
+    temperature_with_thinking = True
+
+    def completion_kwargs(self, max_output, temperature, thinking):
+        enabled = "enabled" if thinking != "off" else "disabled"
+        kwargs = {
+            self.token_param: max_output,
+            "temperature": temperature,
+            "extra_body": {
+                "thinking": {"type": enabled},
+            },
+        }
+        return kwargs
+
+    def thinking_kwargs(self, effort):
+        return {}
+
+
 class LlamaVariant(Variant):
     """Llama models via OpenAI-compatible servers (vLLM, Ollama, etc.).
 
@@ -159,6 +181,7 @@ VARIANTS = {
     "deepseek": DeepSeekVariant,
     "qwen": QwenVariant,
     "mistral": MistralVariant,
+    "glm": GlmVariant,
     "llama": LlamaVariant,
 }
 


### PR DESCRIPTION
## Summary
- Adds a `GlmVariant` to the OpenAI text-completion processor for Zhipu AI's GLM models
- Uses the same `thinking.type` pattern as DeepSeek but with `max_tokens` instead of `max_completion_tokens`
- Registered in the VARIANTS dict so `--variant glm` works from the CLI automatically

## Test plan
- [x] Verify `--variant glm` is accepted by the CLI arg parser
- [x] Test thinking enabled/disabled against a GLM endpoint