### PR TITLE
fix: handle missing time field in library API responses

### DIFF
--- a/trustgraph-base/trustgraph/api/library.py
+++ b/trustgraph-base/trustgraph/api/library.py
@@ -363,7 +363,7 @@ class Library:
             return [
                 DocumentMetadata(
                     id = v["id"],
-                    time = datetime.datetime.fromtimestamp(v["time"]),
+                    time = datetime.datetime.fromtimestamp(v["time"]) if "time" in v else None,
                     kind = v["kind"],
                     title = v.get("title", ""),
                     comments = v.get("comments", ""),
@@ -678,7 +678,7 @@ class Library:
                 ProcessingMetadata(
                     id = v["id"],
                     document_id = v["document-id"],
-                    time = datetime.datetime.fromtimestamp(v["time"]),
+                    time = datetime.datetime.fromtimestamp(v["time"]) if "time" in v else None,
                     flow = v["flow"],
                     collection = v["collection"],
                     tags = v["tags"],
@@ -983,7 +983,7 @@ class Library:
             return [
                 DocumentMetadata(
                     id=v["id"],
-                    time=datetime.datetime.fromtimestamp(v["time"]),
+                    time=datetime.datetime.fromtimestamp(v["time"]) if "time" in v else None,
                     kind=v["kind"],
                     title=v["title"],
                     comments=v.get("comments", ""),


### PR DESCRIPTION
## Summary
- `get_documents`, `list_children`, and `list_processing` in the library API client crash with `KeyError: 'time'` when a document or processing record has no stored `time` field
- Changed all three occurrences from `v["time"]` to optional access, resolving to `None` instead of crashing
- Surfaced by `tg-export-workspace` but is a pre-existing bug in the API client

## Test plan
- [ ] Run `tg-export-workspace` against a workspace with documents missing the `time` field — previously crashed, now exports successfully
