### PR TITLE
Replace bare except with specific exceptions in api layer (#783)

### DIFF
--- a/trustgraph-base/trustgraph/api/api.py
+++ b/trustgraph-base/trustgraph/api/api.py
@@ -25,7 +25,7 @@ def check_error(response):
         try:
             msg = response["error"]["message"]
             tp = response["error"]["type"]
-        except:
+        except KeyError:
             raise ApplicationException(response["error"])
 
         raise ApplicationException(f"{tp}: {msg}")
@@ -208,7 +208,7 @@ class Api:
         try:
             # Parse the response as JSON
             object = resp.json()
-        except:
+        except ValueError:
             raise ProtocolException(f"Expected JSON response")
 
         check_error(object)

--- a/trustgraph-base/trustgraph/api/async_flow.py
+++ b/trustgraph-base/trustgraph/api/async_flow.py
@@ -24,7 +24,7 @@ def check_error(response):
         try:
             msg = response["error"]["message"]
             tp = response["error"]["type"]
-        except:
+        except KeyError:
             raise ApplicationException(response["error"])
 
         raise ApplicationException(f"{tp}: {msg}")
@@ -87,7 +87,7 @@ class AsyncFlow:
 
                 try:
                     obj = await resp.json()
-                except:
+                except (ValueError, aiohttp.ContentTypeError):
                     raise ProtocolException(f"Expected JSON response")
 
                 check_error(obj)

--- a/trustgraph-base/trustgraph/api/async_socket_client.py
+++ b/trustgraph-base/trustgraph/api/async_socket_client.py
@@ -141,7 +141,7 @@ class AsyncSocketClient:
             for queue in self._pending.values():
                 try:
                     await queue.put({"error": str(e)})
-                except:
+                except asyncio.CancelledError :
                     pass
         finally:
             self._connected = False

--- a/trustgraph-base/trustgraph/api/bulk_client.py
+++ b/trustgraph-base/trustgraph/api/bulk_client.py
@@ -201,7 +201,7 @@ class BulkClient:
         finally:
             try:
                 loop.run_until_complete(async_gen.aclose())
-            except:
+            except Exception:
                 pass
 
     async def _export_triples_async(self, flow: str) -> Iterator[Triple]:
@@ -299,7 +299,7 @@ class BulkClient:
         finally:
             try:
                 loop.run_until_complete(async_gen.aclose())
-            except:
+            except Exception:
                 pass
 
     async def _export_graph_embeddings_async(self, flow: str) -> Iterator[Dict[str, Any]]:
@@ -393,7 +393,7 @@ class BulkClient:
         finally:
             try:
                 loop.run_until_complete(async_gen.aclose())
-            except:
+            except Exception:
                 pass
 
     async def _export_document_embeddings_async(self, flow: str) -> Iterator[Dict[str, Any]]:
@@ -517,7 +517,7 @@ class BulkClient:
         finally:
             try:
                 loop.run_until_complete(async_gen.aclose())
-            except:
+            except Exception:
                 pass
 
     async def _export_entity_contexts_async(self, flow: str) -> Iterator[Dict[str, Any]]:

--- a/trustgraph-base/trustgraph/api/config.py
+++ b/trustgraph-base/trustgraph/api/config.py
@@ -254,7 +254,7 @@ class Config:
                 )
                 for v in object["values"]
             ]
-        except:
+        except (KeyError, TypeError):
             raise ProtocolException(f"Response not formatted correctly")
 
     def get_values_all_workspaces(self, type):
@@ -330,6 +330,6 @@ class Config:
 
         try:
             return object["config"], object["version"]
-        except:
+        except KeyError:
             raise ProtocolException(f"Response not formatted correctly")
 


### PR DESCRIPTION
## What this fixes
Replaces bare `except:` clauses with specific exception types across the API client layer, as requested in #783. Bare excepts silently swallow all errors also including KeyboardInterrupt and SystemExit — which makes debugging harder and can mask real bugs.
## Changes
- api.py: KeyError (missing response fields), ValueError (invalid JSON response)
- async_flow.py: KeyError, (ValueError, aiohttp.ContentTypeError) for async JSON parsing
- async_socket_client.py: asyncio.CancelledError for queue cleanup during shutdown
- bulk_client.py: Exception for generator cleanup in finally blocks (4 occurrences)
- config.py: KeyError for missing config response fields

## Testing
Verified with `git grep -n "except:" -- trustgraph-base/trustgraph/api/` that no bare excepts remain in this scope. Each replacement targets the specific exception the original try block could realistically raise, based on the surrounding code.

Relates to #783 (partial — happy to follow up with the remaining files in the CLI/extract modules in a separate PR if this approach looks good).