### PR TITLE
feat: preserve RDF language tags and datatypes through ingestion and query

### DIFF
--- a/trustgraph-base/trustgraph/api/async_bulk_client.py
+++ b/trustgraph-base/trustgraph/api/async_bulk_client.py
@@ -4,6 +4,7 @@ import websockets
 from typing import Optional, AsyncIterator, Dict, Any, Iterator
 
 from . types import Triple
+from . bulk_client import _string_to_term
 
 
 class AsyncBulkClient:
@@ -45,9 +46,13 @@ class AsyncBulkClient:
         async with websockets.connect(ws_url, ping_interval=20, ping_timeout=self.timeout) as websocket:
             async for triple in triples:
                 message = {
-                    "s": triple.s,
-                    "p": triple.p,
-                    "o": triple.o
+                    "s": _string_to_term(triple.s),
+                    "p": _string_to_term(triple.p),
+                    "o": _string_to_term(
+                        triple.o,
+                        datatype=triple.o_datatype,
+                        language=triple.o_language,
+                    ),
                 }
                 await websocket.send(json.dumps(message))
 

--- a/trustgraph-base/trustgraph/api/bulk_client.py
+++ b/trustgraph-base/trustgraph/api/bulk_client.py
@@ -15,13 +15,19 @@ from . types import Triple
 from . exceptions import ProtocolException
 
 
-def _string_to_term(value: str) -> Dict[str, Any]:
+def _string_to_term(
+    value: str, datatype: str = "", language: str = ""
+) -> Dict[str, Any]:
     """Convert a string value to Term format for the gateway."""
-    # Treat URIs as IRI type, otherwise as literal
     if value.startswith("http://") or value.startswith("https://") or "://" in value:
         return {"t": "i", "i": value}
     else:
-        return {"t": "l", "v": value}
+        result: Dict[str, Any] = {"t": "l", "v": value}
+        if datatype:
+            result["dt"] = datatype
+        if language:
+            result["ln"] = language
+        return result
 
 
 class BulkClient:
@@ -141,7 +147,11 @@ class BulkClient:
                 batch.append({
                     "s": _string_to_term(triple.s),
                     "p": _string_to_term(triple.p),
-                    "o": _string_to_term(triple.o)
+                    "o": _string_to_term(
+                        triple.o,
+                        datatype=triple.o_datatype,
+                        language=triple.o_language,
+                    ),
                 })
                 if len(batch) >= batch_size:
                     message = {

--- a/trustgraph-base/trustgraph/api/types.py
+++ b/trustgraph-base/trustgraph/api/types.py
@@ -19,10 +19,14 @@ class Triple:
         s: Subject (entity URI or value)
         p: Predicate (relationship URI)
         o: Object (entity URI, literal value, or typed value)
+        o_datatype: XSD datatype URI for literal objects (e.g. "xsd:string")
+        o_language: Language tag for literal objects (e.g. "en", "lt")
     """
     s : str
     p : str
     o : str
+    o_datatype : str = ""
+    o_language : str = ""
 
 @dataclasses.dataclass
 class ConfigKey:

--- a/trustgraph-base/trustgraph/base/triples_client.py
+++ b/trustgraph-base/trustgraph/base/triples_client.py
@@ -58,7 +58,7 @@ class TriplesClient(RequestResponse):
                 raise RuntimeError(resp.error.message)
 
             batch = [
-                Triple(to_value(v.s), to_value(v.p), to_value(v.o))
+                Triple(v.s, v.p, v.o)
                 for v in resp.triples
             ]
             await queue.put(batch)

--- a/trustgraph-cli/trustgraph/cli/load_knowledge.py
+++ b/trustgraph-cli/trustgraph/cli/load_knowledge.py
@@ -44,15 +44,21 @@ class KnowledgeLoader:
         for e in g:
             s_value = str(e[0])
             p_value = str(e[1])
+            o_value = str(e[2])
 
-            if isinstance(e[2], rdflib.term.URIRef):
-                o_value = str(e[2])
-                o_is_uri = True
-            else:
-                o_value = str(e[2])
-                o_is_uri = False
+            o_datatype = ""
+            o_language = ""
 
-            yield Triple(s=s_value, p=p_value, o=o_value)
+            if isinstance(e[2], rdflib.term.Literal):
+                if e[2].language:
+                    o_language = str(e[2].language)
+                if e[2].datatype:
+                    o_datatype = str(e[2].datatype)
+
+            yield Triple(
+                s=s_value, p=p_value, o=o_value,
+                o_datatype=o_datatype, o_language=o_language,
+            )
 
     def load_entity_contexts_from_file(self, file) -> Iterator[Tuple[str, str]]:
         """Generator that yields (entity, context) tuples from a Turtle file"""

--- a/trustgraph-cli/trustgraph/cli/load_turtle.py
+++ b/trustgraph-cli/trustgraph/cli/load_turtle.py
@@ -44,13 +44,21 @@ class Loader:
         for e in g:
             s_value = str(e[0])
             p_value = str(e[1])
+            o_value = str(e[2])
 
-            if isinstance(e[2], rdflib.term.URIRef):
-                o_value = str(e[2])
-            else:
-                o_value = str(e[2])
+            o_datatype = ""
+            o_language = ""
 
-            yield Triple(s=s_value, p=p_value, o=o_value)
+            if isinstance(e[2], rdflib.term.Literal):
+                if e[2].language:
+                    o_language = str(e[2].language)
+                if e[2].datatype:
+                    o_datatype = str(e[2].datatype)
+
+            yield Triple(
+                s=s_value, p=p_value, o=o_value,
+                o_datatype=o_datatype, o_language=o_language,
+            )
 
     def run(self):
         """Load triples using Python API"""


### PR DESCRIPTION
## Summary

- RDF language tags and XSD datatypes on literals were silently dropped during ingestion (`load_knowledge.py`, `load_turtle.py`) and lost in the SPARQL query path (`TriplesClient.query_gen()`)
- Ingestion now extracts `.language` and `.datatype` from rdflib Literals and sends them via `"ln"`/`"dt"` wire format keys through the bulk import API
- SPARQL `query_gen()` preserves `Term` objects directly instead of converting through `Uri`/`Literal` str subclasses, enabling `FILTER(LANG(?x) = "en")` queries to work

## Test plan

- [x] Verified language tags populate in Cassandra `lang` column after re-ingestion
- [x] SPARQL `FILTER(LANG(...))` queries return correct results for multilingual datasets
- [x] Existing triple query functionality unaffected (`query()` and `query_stream()` unchanged)
