### PR TITLE
Sanitize workspace name used as Cassandra keyspace (#1043)

### DIFF
--- a/trustgraph-flow/trustgraph/direct/cassandra_kg.py
+++ b/trustgraph-flow/trustgraph/direct/cassandra_kg.py
@@ -1,6 +1,7 @@
 
 import datetime
 import os
+import re
 import logging
 
 from cassandra.cluster import Cluster
@@ -548,7 +549,7 @@ class EntityCentricKnowledgeGraph:
         if hosts is None:
             hosts = ["localhost"]
 
-        self.keyspace = keyspace
+        self.keyspace = self.sanitize_name(keyspace)
         self.replication_factor = replication_factor
         self.username = username
 
@@ -572,6 +573,14 @@ class EntityCentricKnowledgeGraph:
 
         self.init()
         self.prepare_statements()
+
+        def sanitize_name(self, name: str) -> str:
+            """Sanitize names for Cassandra compatibility"""
+            safe_name = re.sub(r'[^a-zA-Z0-9_]', '_', name)
+            # Ensure it starts with a letter
+            if safe_name and not safe_name[0].isalpha():
+                safe_name = 'r_' + safe_name
+            return safe_name.lower()
 
     def clear(self):
         self.session.execute(f"""


### PR DESCRIPTION
# What this fixes

Fixes #1043 — Cassandra keyspace creation failed intermittently when a workspace name contained characters outside [a-zA-Z0-9_] (e.g. hyphens), since the raw workspace string was interpolated unquoted into CQL.

# Changes
Added `sanitize_name()` to `EntityCentricKnowledgeGraph`, matching the same pattern already used in `rows/cassandra` and `row_embeddings/qdrant`. `self.keyspace` is now sanitized at assignment time, so all CQL statements referencing it (create/drop/set keyspace) are safe.

# Note
cybermaggedon mentioned this affects Qdrant too,happy to look at that as a follow-up if this approach looks right.

Fixes #1043