### PR TITLE
fix: producer send loop reconnects after failure instead of using None

### DIFF
--- a/trustgraph-base/trustgraph/base/producer.py
+++ b/trustgraph-base/trustgraph/base/producer.py
@@ -42,23 +42,24 @@ class Producer:
 
         if not self.running: return
 
-        while self.running and self.producer is None:
+        while self.running:
 
-            try:
-                logger.info(f"Connecting publisher to {self.topic}...")
-                self.producer = self.backend.create_producer(
-                    topic = self.topic,
-                    schema = self.schema,
-                    chunking_enabled = self.chunking_enabled,
-                )
-                logger.info(f"Connected publisher to {self.topic}")
-            except Exception as e:
-                logger.error(f"Exception connecting publisher: {e}", exc_info=True)
-                await asyncio.sleep(2)
+            # Reconnect if needed
+            while self.running and self.producer is None:
+
+                try:
+                    logger.info(f"Connecting publisher to {self.topic}...")
+                    self.producer = self.backend.create_producer(
+                        topic = self.topic,
+                        schema = self.schema,
+                        chunking_enabled = self.chunking_enabled,
+                    )
+                    logger.info(f"Connected publisher to {self.topic}")
+                except Exception as e:
+                    logger.error(f"Exception connecting publisher: {e}", exc_info=True)
+                    await asyncio.sleep(2)
 
             if not self.running: break
-
-        while self.running:
 
             try:
 
@@ -75,6 +76,7 @@ class Producer:
 
             except Exception as e:
                 logger.error(f"Exception sending message: {e}", exc_info=True)
-                self.producer.close()
+                if self.producer:
+                    self.producer.close()
                 self.producer = None
 


### PR DESCRIPTION
The send method had two sequential while loops: one for connecting and one for sending. After a send failure the producer was closed and set to None, but control stayed in the send loop rather than returning to the connect loop. The next iteration called .send() on None, then .close() on None in the except block, propagating an AttributeError that masked the original error (e.g. MessageTooBig).

Nest the connect loop inside the send loop so failures trigger reconnection, and guard the .close() call against None.