### PR TITLE
fix: update tg-dump-queues defaults for in-cluster use

### DIFF
--- a/trustgraph-cli/trustgraph/cli/dump_queues.py
+++ b/trustgraph-cli/trustgraph/cli/dump_queues.py
@@ -331,7 +331,8 @@ IMPORTANT:
         help='Append to output file instead of overwriting'
     )
 
-    add_pubsub_args(parser, standalone=True)
+    add_pubsub_args(parser)
+    parser.set_defaults(pulsar_listener='external')
 
     parser.add_argument(
         '--subscriber',


### PR DESCRIPTION
The tool now runs via exec into a running cluster, so default to in-cluster Pulsar host (pulsar://pulsar:6650) and external listener.