### PR TITLE
feat: make config-service request timeouts configurable

### DIFF
--- a/tests/unit/test_base/test_async_processor_config.py
+++ b/tests/unit/test_base/test_async_processor_config.py
@@ -9,8 +9,7 @@ import pytest
 from unittest.mock import AsyncMock, MagicMock, patch, Mock
 
 
-@pytest.fixture
-def processor():
+def _make_processor(**extra):
     """Create an AsyncProcessor with mocked dependencies."""
     with patch('trustgraph.base.async_processor.get_pubsub') as mock_pubsub, \
          patch('trustgraph.base.async_processor.Consumer') as mock_consumer, \
@@ -23,11 +22,16 @@ def processor():
         mock_cm.return_value = MagicMock()
 
         from trustgraph.base.async_processor import AsyncProcessor
-        p = AsyncProcessor(
+        return AsyncProcessor(
             id="test-processor",
             taskgroup=AsyncMock(),
+            **extra,
         )
-        return p
+
+
+@pytest.fixture
+def processor():
+    return _make_processor()
 
 
 class TestRegisterConfigHandler:
@@ -308,3 +312,37 @@ class TestFetchAndApplyConfig:
         h.assert_called_once_with(
             "default", {"prompt": {"k": "v"}}, 5
         )
+
+
+class TestConfigTimeout:
+    """--config-timeout threads from params into the config client."""
+
+    def test_default(self, processor):
+        assert processor.config_timeout == 60
+
+    def test_param_override(self):
+        p = _make_processor(config_timeout=25)
+        assert p.config_timeout == 25
+
+    def test_create_config_client_uses_config_timeout(self):
+        p = _make_processor(config_timeout=25)
+
+        with patch(
+            'trustgraph.base.async_processor.RequestResponse'
+        ) as mock_rr:
+            p._create_config_client()
+
+        assert mock_rr.call_args.kwargs["default_timeout"] == 25
+
+    def test_add_args(self):
+        import argparse
+        from trustgraph.base.async_processor import AsyncProcessor
+
+        parser = argparse.ArgumentParser()
+        AsyncProcessor.add_args(parser)
+
+        args = parser.parse_args([])
+        assert args.config_timeout == 60
+
+        args = parser.parse_args(["--config-timeout", "120"])
+        assert args.config_timeout == 120

--- a/tests/unit/test_base/test_config_client.py
+++ b/tests/unit/test_base/test_config_client.py
@@ -1,0 +1,58 @@
+"""
+Unit tests for trustgraph.base.config_client
+Testing configurable timeout behaviour
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+from unittest import IsolatedAsyncioTestCase
+
+from trustgraph.base.config_client import ConfigClient, CONFIG_TIMEOUT
+
+
+def _empty_response():
+    resp = MagicMock()
+    resp.error = None
+    resp.values = []
+    return resp
+
+
+class TestConfigClientTimeout(IsolatedAsyncioTestCase):
+    """Constructor timeout becomes the client default; per-call overrides."""
+
+    @patch('trustgraph.base.request_response_spec.RequestResponse.__init__')
+    async def test_default_timeout_passed_to_parent(self, mock_parent_init):
+        mock_parent_init.return_value = None
+        ConfigClient(backend=MagicMock(), subscription="s")
+
+        assert mock_parent_init.call_args.kwargs["default_timeout"] \
+            == CONFIG_TIMEOUT
+
+    @patch('trustgraph.base.request_response_spec.RequestResponse.__init__')
+    async def test_constructor_timeout_passed_to_parent(
+            self, mock_parent_init):
+        mock_parent_init.return_value = None
+        ConfigClient(timeout=45, backend=MagicMock(), subscription="s")
+
+        assert mock_parent_init.call_args.kwargs["default_timeout"] == 45
+
+    @patch('trustgraph.base.request_response_spec.RequestResponse.__init__')
+    async def test_no_timeout_defers_to_client_default(
+            self, mock_parent_init):
+        mock_parent_init.return_value = None
+        client = ConfigClient(timeout=45)
+        client.request = AsyncMock(return_value=_empty_response())
+
+        await client.get("ws", "prompt", "k")
+
+        # None reaches request(), which resolves it to default_timeout
+        assert client.request.call_args.kwargs["timeout"] is None
+
+    @patch('trustgraph.base.request_response_spec.RequestResponse.__init__')
+    async def test_per_call_timeout_overrides(self, mock_parent_init):
+        mock_parent_init.return_value = None
+        client = ConfigClient(timeout=45)
+        client.request = AsyncMock(return_value=_empty_response())
+
+        await client.get("ws", "prompt", "k", timeout=7)
+
+        assert client.request.call_args.kwargs["timeout"] == 7

--- a/tests/unit/test_base/test_request_response.py
+++ b/tests/unit/test_base/test_request_response.py
@@ -1,0 +1,53 @@
+"""
+Unit tests for trustgraph.base.request_response_spec RequestResponse
+Testing default_timeout resolution in request()
+"""
+
+import inspect
+from unittest.mock import AsyncMock, MagicMock, patch
+from unittest import IsolatedAsyncioTestCase
+
+from trustgraph.base.request_response_spec import RequestResponse
+
+
+def _bare_client(default_timeout):
+    """RequestResponse with the pub/sub machinery stubbed out."""
+    rr = RequestResponse.__new__(RequestResponse)
+    rr.default_timeout = default_timeout
+    rr.subscribe = AsyncMock(return_value=MagicMock())
+    rr.unsubscribe = AsyncMock()
+    rr.producer = AsyncMock()
+    return rr
+
+
+class TestRequestResponseTimeout(IsolatedAsyncioTestCase):
+
+    def test_constructor_default_preserves_prior_behaviour(self):
+        sig = inspect.signature(RequestResponse.__init__)
+        assert sig.parameters["default_timeout"].default == 300
+
+    async def test_request_resolves_none_to_default_timeout(self):
+        rr = _bare_client(default_timeout=45)
+
+        with patch(
+            'trustgraph.base.request_response_spec.asyncio.wait_for',
+            new_callable=AsyncMock,
+            return_value="resp",
+        ) as mock_wait:
+            result = await rr.request("req")
+
+        assert result == "resp"
+        assert mock_wait.call_args.kwargs["timeout"] == 45
+
+    async def test_request_explicit_timeout_wins(self):
+        rr = _bare_client(default_timeout=45)
+
+        with patch(
+            'trustgraph.base.request_response_spec.asyncio.wait_for',
+            new_callable=AsyncMock,
+            return_value="resp",
+        ) as mock_wait:
+            result = await rr.request("req", timeout=7)
+
+        assert result == "resp"
+        assert mock_wait.call_args.kwargs["timeout"] == 7

--- a/trustgraph-base/trustgraph/base/async_processor.py
+++ b/trustgraph-base/trustgraph/base/async_processor.py
@@ -31,6 +31,7 @@ from . metrics import SubscriberMetrics
 from . logging import add_logging_args, setup_logging
 
 default_config_queue = config_push_queue
+default_config_timeout = 60
 
 # Module logger
 logger = logging.getLogger(__name__)
@@ -66,6 +67,11 @@ class AsyncProcessor:
         self.config_push_queue = params.get(
             "config_push_queue", default_config_queue
         )
+
+        # Timeout for config service requests
+        self.config_timeout = int(params.get(
+            "config_timeout", default_config_timeout
+        ))
 
         # This records registered configuration handlers, each entry is:
         # { "handler": async_fn, "types": set_or_none }
@@ -121,6 +127,7 @@ class AsyncProcessor:
         return RequestResponse(
             backend = self.pubsub_backend,
             subscription = f"{self.id}--config--{config_rr_id}",
+            default_timeout = self.config_timeout,
             consumer_name = self.id,
             request_topic = config_request_queue,
             request_schema = ConfigRequest,
@@ -139,7 +146,6 @@ class AsyncProcessor:
                 workspace=workspace,
                 type=config_type,
             ),
-            timeout=60,
         )
         if resp.error:
             raise RuntimeError(f"Config error: {resp.error.message}")
@@ -156,7 +162,6 @@ class AsyncProcessor:
                 operation="getkeys-all-ws",
                 type=config_type,
             ),
-            timeout=60,
         )
         if resp.error:
             raise RuntimeError(f"Config error: {resp.error.message}")
@@ -513,6 +518,14 @@ class AsyncProcessor:
             '--config-push-queue',
             default=default_config_queue,
             help=f'Config push queue (default: {default_config_queue})',
+        )
+
+        parser.add_argument(
+            '--config-timeout',
+            type=int,
+            default=default_config_timeout,
+            help=f'Config request timeout in seconds '
+                 f'(default: {default_config_timeout})',
         )
 
         parser.add_argument(

--- a/trustgraph-base/trustgraph/base/config_client.py
+++ b/trustgraph-base/trustgraph/base/config_client.py
@@ -7,7 +7,10 @@ CONFIG_TIMEOUT = 10
 
 class ConfigClient(RequestResponse):
 
-    async def _request(self, timeout=CONFIG_TIMEOUT, **kwargs):
+    def __init__(self, timeout=CONFIG_TIMEOUT, **kwargs):
+        super(ConfigClient, self).__init__(default_timeout=timeout, **kwargs)
+
+    async def _request(self, timeout=None, **kwargs):
         resp = await self.request(
             ConfigRequest(**kwargs),
             timeout=timeout,
@@ -18,7 +21,7 @@ class ConfigClient(RequestResponse):
             )
         return resp
 
-    async def get(self, workspace, type, key, timeout=CONFIG_TIMEOUT):
+    async def get(self, workspace, type, key, timeout=None):
         """Get a single config value. Returns the value string or None."""
         resp = await self._request(
             operation="get",
@@ -30,7 +33,7 @@ class ConfigClient(RequestResponse):
             return resp.values[0].value
         return None
 
-    async def put(self, workspace, type, key, value, timeout=CONFIG_TIMEOUT):
+    async def put(self, workspace, type, key, value, timeout=None):
         """Put a single config value."""
         await self._request(
             operation="put",
@@ -39,7 +42,7 @@ class ConfigClient(RequestResponse):
             timeout=timeout,
         )
 
-    async def put_many(self, workspace, values, timeout=CONFIG_TIMEOUT):
+    async def put_many(self, workspace, values, timeout=None):
         """Put multiple config values in a single request within a
         single workspace. values is a list of (type, key, value) tuples."""
         await self._request(
@@ -52,7 +55,7 @@ class ConfigClient(RequestResponse):
             timeout=timeout,
         )
 
-    async def delete(self, workspace, type, key, timeout=CONFIG_TIMEOUT):
+    async def delete(self, workspace, type, key, timeout=None):
         """Delete a single config key."""
         await self._request(
             operation="delete",
@@ -61,7 +64,7 @@ class ConfigClient(RequestResponse):
             timeout=timeout,
         )
 
-    async def delete_many(self, workspace, keys, timeout=CONFIG_TIMEOUT):
+    async def delete_many(self, workspace, keys, timeout=None):
         """Delete multiple config keys in a single request within a
         single workspace. keys is a list of (type, key) tuples."""
         await self._request(
@@ -74,7 +77,7 @@ class ConfigClient(RequestResponse):
             timeout=timeout,
         )
 
-    async def keys(self, workspace, type, timeout=CONFIG_TIMEOUT):
+    async def keys(self, workspace, type, timeout=None):
         """List all keys for a config type within a workspace."""
         resp = await self._request(
             operation="list",
@@ -84,7 +87,7 @@ class ConfigClient(RequestResponse):
         )
         return resp.directory
 
-    async def get_all(self, workspace, timeout=CONFIG_TIMEOUT):
+    async def get_all(self, workspace, timeout=None):
         """Return every config entry in ``workspace`` as a nested dict
         ``{type: {key: value}}``.  Values are returned as the raw
         strings stored by config-svc (typically JSON); callers parse
@@ -96,7 +99,7 @@ class ConfigClient(RequestResponse):
         )
         return resp.config
 
-    async def workspaces_for_type(self, type, timeout=CONFIG_TIMEOUT):
+    async def workspaces_for_type(self, type, timeout=None):
         """Return the set of distinct workspaces with any config of
         the given type."""
         resp = await self._request(

--- a/trustgraph-base/trustgraph/base/request_response_spec.py
+++ b/trustgraph-base/trustgraph/base/request_response_spec.py
@@ -21,7 +21,10 @@ class RequestResponse(Subscriber):
             request_metrics,
             response_topic, response_schema,
             response_metrics,
+            default_timeout=300,
     ):
+
+        self.default_timeout = default_timeout
 
         super(RequestResponse, self).__init__(
             backend = backend,
@@ -47,7 +50,10 @@ class RequestResponse(Subscriber):
         await self.producer.stop()
         await super(RequestResponse, self).stop()
 
-    async def request(self, req, timeout=300, recipient=None):
+    async def request(self, req, timeout=None, recipient=None):
+
+        if timeout is None:
+            timeout = self.default_timeout
 
         id = str(uuid.uuid4())
 

--- a/trustgraph-flow/trustgraph/bootstrap/bootstrapper/service.py
+++ b/trustgraph-flow/trustgraph/bootstrap/bootstrapper/service.py
@@ -167,6 +167,7 @@ class Processor(AsyncProcessor):
     def _make_config_client(self):
         rr_id = str(uuid.uuid4())
         return ConfigClient(
+            timeout=self.config_timeout,
             backend=self.pubsub_backend,
             subscription=f"{self.id}--config--{rr_id}",
             consumer_name=self.id,

--- a/trustgraph-flow/trustgraph/flow/service/service.py
+++ b/trustgraph-flow/trustgraph/flow/service/service.py
@@ -63,6 +63,7 @@ class Processor(WorkspaceProcessor):
 
         config_rr_id = str(uuid.uuid4())
         self.config_client = ConfigClient(
+            timeout=self.config_timeout,
             backend=self.pubsub,
             subscription=f"{self.id}--config--{config_rr_id}",
             consumer_name=self.id,


### PR DESCRIPTION
First slice of #874, covering the config request path.

## Changes

- `RequestResponse` gains a `default_timeout` constructor parameter (default 300, matching the previous hardcoded `request()` default). `request()` now resolves `timeout=None` to the instance default; explicit per-call timeouts behave as before.
- `AsyncProcessor` gains a `--config-timeout` CLI argument (default 60, preserving the values set in #1062), available to every processor through the shared `add_args` stack, and threads it into the config client used by the startup fetch and notify paths.
- `ConfigClient` gains a constructor `timeout` parameter (default `CONFIG_TIMEOUT` = 10) which sets the client-wide default; per-call `timeout=` arguments still override.
- The bootstrapper and flow service pass their processor-level `--config-timeout` into their `ConfigClient` instances. Note this raises the effective default at those two sites from 10 to 60: they now follow the single processor-wide knob rather than the client fallback. This is deliberate, one knob for all config-service requests.

The base-level `default_timeout` is what makes the remaining #874 sites cheap: later slices for the other client classes (librarian, prompt, embeddings and friends) reduce to passing one constructor value, including Spec-instantiated clients once the spec layer threads it.

## Behaviour

No change out of the box: all defaults match the current hardcoded values.

## Tests

New unit tests cover the CLI argument, the param threading into the config client, constructor and per-call resolution, and the `request()` default resolution. Verified in both directions: 9 of the new tests fail without the source change. The flag surfaces in the real console entry points (`flow-svc --help`, `bootstrap --help`). tests/unit, tests/integration and tests/contract pass locally.

## Follow-up

Configurator/template exposure of the knob is left as a follow-up. Happy to wire it in trustgraph-templates, either as a global setting or per-service, whichever you prefer.
