### PR TITLE
feat: replace thread-per-consumer pub/sub with async receive pool

### DIFF
--- a/containers/Containerfile.base
+++ b/containers/Containerfile.base
@@ -13,7 +13,7 @@ RUN dnf install -y python3.13 && \
   python -m ensurepip --upgrade && \
   pip3 install --no-cache-dir --upgrade 'pip>=26.0' 'setuptools>=78.1.1' && \
   pip3 install --no-cache-dir build wheel aiohttp && \
-  pip3 install --no-cache-dir pulsar-client==3.11.0 && \
+  pip3 install --no-cache-dir pulsar-client==3.13.0 && \
   dnf clean all
 
 # ----------------------------------------------------------------------------

--- a/docs/tech-specs/async-receive-threading.md
+++ b/docs/tech-specs/async-receive-threading.md
@@ -1,0 +1,992 @@
+---
+layout: default
+title: "Async Receive: Eliminating Thread-per-Consumer Architecture"
+parent: "Tech Specs"
+---
+
+# Async Receive: Eliminating Thread-per-Consumer Architecture
+
+## Problem
+
+TrustGraph's pub/sub Consumer and Subscriber classes use a
+thread-per-connection model that does not scale. Each Consumer and each
+Subscriber creates a dedicated `ThreadPoolExecutor(max_workers=1)` to
+run Pulsar's blocking `receive()` call off the asyncio event loop.
+This means every consumer-side object in the system costs one OS
+thread that sits in a blocking receive loop for the lifetime of the
+object.
+
+### 1. Thread count grows linearly with flows
+
+A typical FlowProcessor creates 2-3 consumer-side objects per flow
+(input Consumer, Subscriber for RequestResponse, Consumer for
+LibrarianClient). With 40 workspaces and 4 flows per workspace, a
+single processor group creates ~480 OS threads just for receive loops.
+At this scale, containers hit the OS thread limit and fail with
+`RuntimeError: can't start new thread`.
+
+### 2. Flow lifecycle is heavyweight
+
+Starting a flow means creating Pulsar consumers, each with a dedicated
+thread and executor. Stopping a flow means tearing them down. This
+makes workspace and flow provisioning an expensive operation —
+creating a Pulsar subscription is a broker roundtrip, and spawning an
+OS thread has kernel overhead. What should be a lightweight routing
+change (start listening on a new topic) becomes a heavyweight
+infrastructure operation.
+
+### 3. Sequential startup amplifies the cost
+
+Flows are started sequentially: workspaces are processed one at a
+time, and within each workspace, flows are started one at a time.
+`Subscriber.start()` blocks until the underlying Pulsar consumer is
+ready (a synchronous `client.subscribe()` wrapped in
+`run_in_executor`). This serialises hundreds of broker roundtrips that
+are independent of each other. The result is progressive slowdown:
+early workspaces start in under a second, later workspaces take tens
+of seconds each, because the event loop is increasingly loaded by
+background receive loops from already-started flows.
+
+### 4. Producer creation blocks the event loop
+
+`Producer.send()` lazily creates the Pulsar producer on first call via
+a synchronous `self.backend.create_producer()` directly on the asyncio
+event loop — unlike Consumer and Subscriber, which at least use
+`run_in_executor`. Every Producer's first send blocks the entire event
+loop for the duration of the broker roundtrip. This includes the
+config service sending responses, meaning it blocks config delivery to
+all other services.
+
+### 5. The threading is unnecessary for Pulsar
+
+Pulsar's Python client exposes `consumer.receive_async()`, which
+returns a coroutine that is directly awaitable in asyncio. Using this,
+a consumer receive loop becomes a pure async task with zero OS threads:
+
+```python
+async def consumer_loop(consumer):
+    while running:
+        msg = await consumer.receive_async()
+        await handler(msg)
+```
+
+The current architecture pays the full cost of OS threads and
+executors to work around a blocking API when a non-blocking
+alternative exists. The only operation that genuinely requires a
+thread is the initial `client.subscribe()` call, which is synchronous
+and returns the consumer object.
+
+### Impact
+
+At 10 workspaces (40 flows), the system functions but is already
+running hundreds of threads. At 40 workspaces (160 flows), containers
+fail to start due to thread exhaustion. The target operating range for
+TrustGraph is 50+ workspaces, which is unreachable under the current
+architecture.
+
+## Design Goals
+
+### Goal 1: Eliminate OS threads from the receive path
+
+Consumer and Subscriber receive loops must not require a dedicated OS
+thread per connection. For Pulsar, use `receive_async()` which is
+directly awaitable in asyncio. For RabbitMQ, reduce to the minimum
+thread count the backend requires (pika's `BlockingConnection` is not
+thread-safe, but a single connection can consume from multiple queues
+via multiple `basic_consume()` calls driven by one
+`process_data_events()` loop). The target is O(1) threads per backend,
+not O(n) threads per consumer.
+
+### Goal 2: Work within the existing pub/sub framework
+
+The solution must operate within the existing backend abstraction
+(`PubSubBackend`, `BackendConsumer`, `BackendProducer`). Both the
+Pulsar and RabbitMQ backends must continue to work. The backend
+interface may be extended (e.g. adding an async receive method) but
+the abstraction boundary between application code and broker-specific
+code must be preserved.
+
+### Goal 3: Make flow lifecycle lightweight
+
+Starting or stopping a flow should be a low-cost operation — closer
+to updating a routing table than to creating broker connections and
+spawning threads. The cost of managing 200 flows should not be
+qualitatively different from managing 20.
+
+### Goal 4: Do not block the asyncio event loop with broker I/O
+
+All broker operations that involve network roundtrips — subscribing,
+producing, sending — must be off the event loop. This includes
+producer creation, which currently runs synchronously on the event
+loop in `Producer.send()`.
+
+## Backend API Analysis
+
+The current `BackendConsumer` and `PubSubBackend` protocols
+(`backend.py`) were designed around a synchronous,
+one-connection-per-consumer model. Several aspects are challenged by
+the design goals.
+
+### 1. `BackendConsumer.receive()` is synchronous
+
+The protocol defines `receive(timeout_millis) -> Message` as a
+blocking call. This is the reason Consumer and Subscriber need threads
+in the first place. To use Pulsar's `receive_async()`, we need an
+async receive path. But the protocol can't simply change to async
+because RabbitMQ's pika `BlockingConnection` has no awaitable receive
+— pika requires a thread calling `process_data_events()`.
+
+The backend abstraction needs to express that some backends can deliver
+messages asynchronously (Pulsar) while others require a thread-driven
+pump (RabbitMQ). This could be an optional `receive_async()` method on
+`BackendConsumer`, or the backend could push messages into an
+asyncio queue via `call_soon_threadsafe` and the consumer protocol
+shifts from pull to push.
+
+### 2. `create_consumer` and `create_producer` are synchronous
+
+`PubSubBackend.create_consumer()` and `create_producer()` are sync
+methods that perform broker roundtrips (Pulsar `client.subscribe()`,
+pika `BlockingConnection()`). They are called from async code but
+block the event loop or require `run_in_executor` wrapping at the
+call site. The protocol doesn't express that these are potentially
+expensive I/O operations.
+
+### 3. One consumer per topic, no dynamic subscription management
+
+`create_consumer()` creates a standalone consumer for a single topic.
+There is no way to add or remove topic subscriptions from an existing
+consumer. Starting a flow means creating new consumer objects;
+stopping means destroying them. For the lightweight lifecycle goal,
+and for future wildcard subscriptions, the API would need to support
+either multi-topic consumers or a subscription registry that can be
+modified at runtime.
+
+### 4. Acknowledge threading constraints are implicit
+
+`BackendConsumer.acknowledge()` and `negative_acknowledge()` are sync
+methods with no documented threading requirements. But for RabbitMQ,
+acknowledgement must happen on the same thread that owns the pika
+connection — a constraint that the protocol doesn't express and that
+callers (Consumer, Subscriber) must work around. Moving to a
+push-based model where the backend owns the receive thread would let
+the backend also own acknowledgement, keeping the threading constraint
+internal.
+
+### 5. `BackendProducer.send()` is synchronous
+
+The protocol defines `send()` as sync, but it performs network I/O.
+The application layer wraps it in `asyncio.to_thread` (in
+`Producer.send()`) or calls it bare on the event loop (in
+`Publisher.run()`). An async send at the protocol level would let
+backends optimise — Pulsar could use its native async send, RabbitMQ
+could batch publishes on its connection thread.
+
+### Assessment
+
+The current protocol assumes a pull-based, one-thread-per-consumer
+model. Goals 1 and 3 require moving toward either a push-based model
+(backend delivers messages into async queues) or an async-capable
+protocol (optional `receive_async`). Goal 5 requires the concept of
+dynamic subscription management, which the current one-consumer-per-
+topic API does not support. The protocol needs extension, but the
+changes can be additive — existing sync methods remain for backends
+that need them, with new async methods for backends that can use them.
+
+### Goal 5: Support future wildcard subscriptions
+
+The design should accommodate a future extension where a consumer can
+subscribe to a topic pattern (e.g. all flows for a workspace, or all
+workspaces for a processor type) rather than individual topics. This
+is not in scope for the initial implementation, but the architecture
+should not preclude it.
+
+## Technical Design: Backend API
+
+The backend API is refactored to be async-first. The backend is
+responsible for broker communication only — connecting, subscribing,
+sending, acknowledging. Threading and concurrency management belong in
+the `base/` layer, not the backend.
+
+### Principles
+
+1. All methods that perform broker I/O are `async`. The backend
+   handles its own threading internally (Pulsar uses
+   `receive_async()`, RabbitMQ runs a single pika thread) — the
+   application layer never creates threads for broker operations.
+
+2. `receive()` is awaitable. The caller does
+   `msg = await consumer.receive()` with no timeout. Shutdown is
+   handled by cancelling the task, not by polling with timeouts.
+
+3. `acknowledge()` and `negative_acknowledge()` are async. For
+   Pulsar these are near-instant. For RabbitMQ the backend routes the
+   ack to the pika connection thread and awaits confirmation. Either
+   way, the threading constraint is the backend's problem, not the
+   caller's.
+
+4. The factory methods `create_consumer()` and `create_producer()` are
+   async, since both perform broker roundtrips.
+
+### `BackendConsumer` protocol
+
+```python
+@runtime_checkable
+class BackendConsumer(Protocol):
+
+    async def receive(self) -> Message:
+        """Await the next message.
+
+        Blocks until a message is available. Does not time out —
+        shutdown is signalled by cancelling the awaiting task.
+
+        Pulsar: delegates to consumer.receive_async().
+        RabbitMQ: awaits an asyncio.Queue fed by the pika thread.
+        """
+        ...
+
+    async def acknowledge(self, message: Message) -> None:
+        """Acknowledge successful processing.
+
+        Pulsar: calls consumer.acknowledge() (thread-safe).
+        RabbitMQ: routes basic_ack to the pika thread.
+        """
+        ...
+
+    async def negative_acknowledge(self, message: Message) -> None:
+        """Negative acknowledge — triggers redelivery.
+
+        Pulsar: calls consumer.negative_acknowledge() (thread-safe).
+        RabbitMQ: routes basic_nack to the pika thread.
+        """
+        ...
+
+    async def close(self) -> None:
+        """Close the consumer and release broker resources."""
+        ...
+```
+
+The synchronous `ensure_connected()` and `unsubscribe()` methods are
+removed. Connection readiness is guaranteed by `create_consumer()`
+returning only when the subscription is active.  Unsubscription is
+handled by `close()`.
+
+The `timeout_millis` parameter on `receive()` is removed. The current
+architecture uses timeouts as a polling mechanism to check shutdown
+flags — with async tasks, cancellation replaces polling. This
+eliminates the 250ms/2000ms wake-up cycles that generate thousands of
+no-op callbacks per second on the event loop.
+
+### `BackendProducer` protocol
+
+```python
+@runtime_checkable
+class BackendProducer(Protocol):
+
+    async def send(self, message: Any, properties: dict = {}) -> None:
+        """Send a message.
+
+        Pulsar: uses async send or asyncio.to_thread.
+        RabbitMQ: routes publish to the pika thread.
+        """
+        ...
+
+    async def close(self) -> None:
+        """Close the producer and release broker resources."""
+        ...
+```
+
+`flush()` is removed as a separate method — `close()` flushes before
+closing. The sync `send()` that blocked the event loop is replaced by
+an async method; the backend owns the decision of how to get the
+bytes to the broker without blocking the event loop.
+
+### `PubSubBackend` protocol
+
+```python
+@runtime_checkable
+class PubSubBackend(Protocol):
+
+    async def create_consumer(
+        self, topic: str, subscription: str, schema: type,
+        initial_position: str = 'latest', **options,
+    ) -> BackendConsumer:
+        """Create a consumer subscribed to a topic.
+
+        Returns only when the subscription is active and ready to
+        receive messages. The broker roundtrip is off the event loop.
+        """
+        ...
+
+    async def create_producer(
+        self, topic: str, schema: type, **options,
+    ) -> BackendProducer:
+        """Create a producer bound to a topic.
+
+        Returns only when the producer is ready to send. The broker
+        roundtrip is off the event loop.
+        """
+        ...
+
+    async def create_topic(self, topic: str) -> None: ...
+    async def delete_topic(self, topic: str) -> None: ...
+    async def topic_exists(self, topic: str) -> bool: ...
+    async def ensure_topic(self, topic: str) -> None: ...
+    async def close(self) -> None: ...
+```
+
+`create_consumer()` and `create_producer()` become async. For Pulsar,
+these wrap the synchronous `client.subscribe()` /
+`client.create_producer()` in `asyncio.to_thread`. For RabbitMQ, they
+schedule queue declaration and binding on the pika connection thread.
+
+`close()` becomes async to allow clean shutdown of backend-internal
+threads (e.g. the RabbitMQ pika pump thread).
+
+### Backend-internal threading
+
+Everything in the runtime layer — receiver tasks, workers, sender
+tasks — is async. The `base/` layer never creates OS threads. If a
+backend needs an OS thread to bridge a blocking client library, that
+is the backend's internal concern, invisible to the application layer.
+
+**Pulsar**: Zero OS threads. `receive_async()` is natively awaitable.
+`client.subscribe()` and `client.create_producer()` are wrapped in
+`asyncio.to_thread` for the initial setup call; the thread is
+released immediately after. Acknowledgement calls are thread-safe in
+the Pulsar C++ client and can run directly.
+
+**RabbitMQ**: One OS thread, owned by the backend. A single pika
+`BlockingConnection` drives `process_data_events()` in a loop. All
+consumer subscriptions (`basic_consume`) are registered on this
+connection. Incoming messages are pushed to per-consumer
+`asyncio.Queue` instances via `loop.call_soon_threadsafe()`.
+Acknowledgement and publish commands are submitted to the pika thread
+via a thread-safe command queue and executed during the next
+`process_data_events()` cycle. From the `base/` layer's perspective,
+the RabbitMQ backend's `receive()` is just another awaitable — the OS
+thread is an implementation detail.
+
+### Message protocol
+
+`Message` is unchanged:
+
+```python
+@runtime_checkable
+class Message(Protocol):
+    def value(self) -> Any: ...
+    def properties(self) -> dict: ...
+```
+
+Backend-specific acknowledgement state (Pulsar message ID, RabbitMQ
+delivery tag) is carried internally by the backend's `Message`
+implementation. The application layer never interacts with it
+directly — it passes the opaque `Message` back to `acknowledge()` or
+`negative_acknowledge()`.
+
+### Migration path
+
+The existing sync protocol methods can coexist with the new async
+methods during migration. Consumer and Subscriber can be updated
+incrementally to use the async API while the sync path remains
+available for any code that hasn't been migrated. Once all callers use
+the async API, the sync methods can be removed.
+
+## Technical Design: Runtime Layer
+
+The backend API describes how to talk to the broker. This section
+describes the runtime components in `base/` that sit between the
+backend and application handlers — who creates what, when, and how
+messages flow from broker to handler and back.
+
+There are two managed runtimes: one for receiving (consumer side) and
+one for sending (producer side). The processor's base class starts
+these runtimes and application code interacts with them by adding and
+removing registrations.
+
+### Component overview
+
+```
+                          ┌─────────────┐
+                          │  Processor  │
+                          │  (base class)│
+                          └──────┬──────┘
+                     starts      │      starts
+                ┌────────────────┼────────────────┐
+                ▼                                  ▼
+        ┌───────────────┐                 ┌───────────────┐
+        │ ReceiverPool  │                 │  SenderPool   │
+        └───────┬───────┘                 └───────┬───────┘
+                │                                  │
+     add/remove │ consumer                add/remove│ producer
+     registrations│                      registrations│
+                │                                  │
+        ┌───────┴───────┐                 ┌────────┴──────┐
+        │  receiver     │                 │   sender      │
+        │  tasks (async)│                 │   task (async) │
+        └───┬───────┬───┘                 └────────┬──────┘
+            │       ▲                              │
+    messages│       │ack/nack              ┌───────┴───────┐
+            │       │(completion queue)    │   Backend     │
+            ▼       │                     │   Producer    │
+        ┌───────────┴───┐                 │   .send()     │
+        │  work queue   │                 └───────────────┘
+        └───────┬───────┘
+                │
+        ┌───────┴───────┐
+        │ worker tasks  │
+        │ (concurrency) │
+        └───────┬───────┘
+                │
+        ┌───────┴───────┐
+        │   Backend     │
+        │   Consumer    │
+        │   .receive()  │
+        └───────────────┘
+```
+
+### Message flow and acknowledgement
+
+Workers must not perform any pub/sub communication. The receiver
+task owns both receiving and acknowledging for its consumer — this
+is required by some pub/sub systems where ack must happen in the
+same context as receive.
+
+The flow for each message:
+
+1. **Receiver task** calls `await backend_consumer.receive()`, gets a
+   message.
+2. **Receiver task** creates an `asyncio.Future` for this message and
+   puts `(message, handler, future)` on the **work queue**. The
+   receiver immediately loops back to `receive()` — it does not wait.
+3. **Worker task** pulls from the work queue, calls the handler, and
+   sets the future result (success) or exception (failure). The worker
+   never touches the backend.
+4. **Receiver task** also monitors a **completion queue** fed by
+   resolved futures. When a future completes, the receiver calls
+   `acknowledge()` or `negative_acknowledge()` on its own backend
+   consumer.
+
+The receiver task multiplexes between receiving new messages and
+processing completions. If ack and receive can happen in separate
+coroutines (to be validated per backend), the completion handling
+is a spawned coroutine. If they must be in the same coroutine, the
+receiver selects between both using `asyncio.wait`:
+
+```python
+async def receiver_loop(self, backend_consumer, handler):
+    pending_acks = set()
+    receive_task = asyncio.create_task(backend_consumer.receive())
+
+    while self.running:
+        # Wait for either a new message or a completed worker
+        wait_set = {receive_task} | pending_acks
+        done, _ = await asyncio.wait(
+            wait_set, return_when=asyncio.FIRST_COMPLETED,
+        )
+
+        for task in done:
+            if task is receive_task:
+                # New message — dispatch to worker
+                msg = task.result()
+                future = asyncio.Future()
+                await self.work_queue.put((msg, handler, future))
+
+                # Track the future for ack/nack
+                ack_task = asyncio.create_task(
+                    self._wait_for_completion(future, msg)
+                )
+                pending_acks.add(ack_task)
+
+                # Immediately request next message
+                receive_task = asyncio.create_task(
+                    backend_consumer.receive()
+                )
+            else:
+                # Worker completed — ack or nack
+                pending_acks.discard(task)
+                msg, success = task.result()
+                if success:
+                    await backend_consumer.acknowledge(msg)
+                else:
+                    await backend_consumer.negative_acknowledge(msg)
+
+async def _wait_for_completion(self, future, msg):
+    try:
+        await future
+        return (msg, True)
+    except Exception:
+        return (msg, False)
+```
+
+This keeps all broker communication in the receiver coroutine. The
+worker's only responsibility is to process the message and resolve
+the future.
+
+### ReceiverPool
+
+The ReceiverPool is started once by the processor base class. It
+manages the consumer side: broker subscriptions, message routing, and
+worker dispatch.
+
+#### 1. Starting the pool
+
+The processor calls `await receiver_pool.start()` during
+initialisation. This creates the worker tasks (async coroutines,
+number set by the concurrency parameter) which immediately begin
+waiting on the shared work queue. No broker connections are created
+at this point — those happen when consumers are registered.
+
+#### 2. Adding a consumer registration
+
+Application code (e.g. flow startup) calls:
+
+```python
+registration = await receiver_pool.add_consumer(
+    topic="flow:tg:text-completion-request:ws1:default",
+    subscription="text-completion",
+    schema=TextCompletionRequest,
+    handler=self.on_request,
+)
+```
+
+This does the following:
+- Calls `backend.create_consumer()` to create the broker subscription
+  (async — no event loop blocking).
+- Creates an asyncio task that loops on
+  `await backend_consumer.receive()`, placing received messages onto
+  an internal work queue along with the handler and consumer reference
+  (needed for ack/nack).
+- The receiver task is a lightweight coroutine, not an OS thread.
+
+Multiple registrations can be added concurrently. Each gets its own
+receiver task and its own broker consumer, but they all feed into the
+same work queue.
+
+With wildcard subscriptions (future), `add_consumer` could subscribe
+once to a pattern topic. Adding a second consumer on a matching topic
+would update the routing table without creating a new broker
+subscription. The receiver task inspects the topic on each message
+and dispatches to the right handler. This is not in scope for the
+initial implementation, but the add/remove registration model supports
+it.
+
+#### 3. Worker dispatch
+
+The pool runs a fixed number of worker tasks (set by a concurrency
+parameter). Each worker loops:
+
+```python
+async def worker(self):
+    while self.running:
+        msg, handler, future = await self.work_queue.get()
+        try:
+            await handler(msg, ...)
+            future.set_result(None)
+        except Exception as e:
+            future.set_exception(e)
+```
+
+Workers pull from the shared work queue, call the handler, and
+signal completion by resolving the future. Workers never interact
+with the backend — acknowledgement is handled by the receiver task
+that owns the backend consumer (see Message flow above).
+
+The number of workers controls how many messages are processed
+concurrently across all consumers in the pool. This replaces the
+per-Consumer concurrency setting with a pool-wide setting.
+
+#### 4. Removing a consumer registration
+
+Application code (e.g. flow shutdown) calls:
+
+```python
+await receiver_pool.remove_consumer(registration)
+```
+
+This:
+- Cancels the receiver task for that consumer (the `await
+  backend_consumer.receive()` is cancelled, the task exits cleanly).
+- Calls `backend_consumer.close()` to release the broker subscription.
+- Any in-flight messages from this consumer that are already on the
+  work queue are still processed and acknowledged normally.
+
+No threads are created or destroyed. No heavyweight teardown.
+
+#### 5. Stopping the pool
+
+The processor calls `receiver_pool.stop()` during shutdown. This:
+- Cancels all receiver tasks.
+- Waits for workers to drain the work queue (with a timeout).
+- Closes all backend consumers.
+- Cancels worker tasks.
+
+### SenderPool
+
+The SenderPool is started once by the processor base class. It
+manages the producer side: broker connections and async send dispatch.
+
+#### 1. Starting the pool
+
+The processor calls `await sender_pool.start()` during initialisation.
+This creates the sender task (an async coroutine that pulls from the
+send queue and dispatches to backend producers). No broker connections
+are created at this point — those happen when producers are
+registered.
+
+#### 2. Adding a producer registration
+
+Application code calls:
+
+```python
+producer = await sender_pool.add_producer(
+    topic="flow:tg:text-completion-response:ws1:default",
+    schema=TextCompletionResponse,
+)
+```
+
+This:
+- Calls `backend.create_producer()` to create the broker producer
+  (async — no event loop blocking).
+- Returns a handle that the application uses to send messages.
+
+#### 3. Sending a message
+
+The application calls:
+
+```python
+await producer.send(message, properties={"id": request_id})
+```
+
+This places the message on an internal asyncio send queue. A sender
+task pulls from this queue and calls `backend_producer.send()`. The
+send queue decouples the application's send call from the broker I/O,
+so the application never blocks on broker latency.
+
+For low-latency request-response patterns where the caller needs to
+know the send succeeded before waiting for a response, the send can
+optionally await completion:
+
+```python
+await producer.send(message, properties={"id": id}, wait=True)
+```
+
+#### 4. Removing a producer registration
+
+```python
+await sender_pool.remove_producer(producer)
+```
+
+This:
+- Drains any pending messages on the send queue for this producer.
+- Calls `backend_producer.close()` to release the broker connection.
+
+#### 5. Stopping the pool
+
+The processor calls `sender_pool.stop()` during shutdown. This:
+- Drains all send queues (with a timeout).
+- Closes all backend producers.
+
+### Flow lifecycle under the new model
+
+With the pool model, starting and stopping a flow becomes:
+
+```python
+async def start_flow(self, workspace, flow, defn):
+    registrations = []
+    for spec in self.specifications:
+        reg = await spec.register(
+            self.receiver_pool, self.sender_pool,
+            workspace, flow, defn,
+        )
+        registrations.append(reg)
+    self.flows[(workspace, flow)] = registrations
+
+async def stop_flow(self, workspace, flow):
+    for reg in self.flows.pop((workspace, flow)):
+        await reg.unregister()
+```
+
+Each spec's `register()` method calls `add_consumer` and/or
+`add_producer` on the pools. No threads are created. No executors.
+The broker subscription is the only heavyweight operation, and it
+happens asynchronously.
+
+Starting 200 flows means 200 `add_consumer` calls, each creating an
+async receiver task. The broker subscriptions can be parallelised
+with `asyncio.gather`. The total startup cost is bounded by the
+broker's ability to process subscriptions, not by Python thread
+creation.
+
+### Extracting Consumer
+
+The current `Consumer` class manages its own receive loop,
+`ThreadPoolExecutor`, and `consume_from_queue`. Under the pool model,
+all of this collapses — the receive loop becomes a receiver task in
+the pool, the executor is eliminated, and message dispatch goes
+through the shared work queue and worker tasks.
+
+## Technical Design: Request/Response
+
+Request/Response is a separate pattern from the consumer/worker
+model. It is used when a processor, while handling a message in a
+worker, needs to call out to another service and wait for a reply.
+Examples: SPARQL querying the triples store, a processor fetching
+config, a handler calling the librarian.
+
+Request/Response does not use the ReceiverPool or worker tasks. It
+has its own lightweight infrastructure: a producer for sending
+requests, a dedicated receiver coroutine for responses, and a routing
+table that matches responses to waiting callers.
+
+### Architecture
+
+```
+    Worker (handling a message)
+        │
+        │ await rr_client.request(req)
+        │
+        ▼
+    ┌──────────────────────┐
+    │  RequestResponse     │
+    │  client              │
+    │                      │
+    │  pending: {          │
+    │    id1: Future,      │
+    │    id2: Future,      │
+    │    ...               │
+    │  }                   │
+    └──┬───────────────┬───┘
+       │               │
+  send │          receive
+  request         response
+       │               │
+       ▼               ▼
+  ┌─────────┐   ┌─────────────┐
+  │ Backend │   │  Backend    │
+  │ Producer│   │  Consumer   │
+  │ .send() │   │  .receive() │
+  └─────────┘   └─────────────┘
+```
+
+### How it works
+
+#### 1. Setup
+
+When a flow starts and includes a RequestResponseSpec, the spec
+creates a RequestResponse client:
+
+```python
+rr_client = await RequestResponseClient.create(
+    backend=backend,
+    request_topic="request:tg:triples:ws1:default",
+    response_topic="response:tg:triples:ws1:default",
+    request_schema=TriplesRequest,
+    response_schema=TriplesResponse,
+)
+```
+
+This:
+- Creates a backend producer for the request topic (async).
+- Creates a backend consumer for the response topic (async).
+- Starts a receiver coroutine that loops on
+  `await backend_consumer.receive()` and routes responses by ID.
+
+The receiver coroutine is a pure async task — no OS thread, no
+worker pool involvement.
+
+#### 2. Making a request
+
+A worker calls:
+
+```python
+response = await rr_client.request(my_request, timeout=60)
+```
+
+This:
+- Generates a UUID for the request.
+- Creates an `asyncio.Future` and adds it to the pending dict:
+  `self.pending[id] = future`.
+- Sends the request via the backend producer with the ID in message
+  properties.
+- Awaits the future with a timeout.
+
+The worker is suspended (but the event loop continues — other
+workers, receivers, and coroutines keep running).
+
+#### 3. Receiving the response
+
+The receiver coroutine runs independently:
+
+```python
+async def _response_loop(self):
+    while self.running:
+        msg = await self.backend_consumer.receive()
+        id = msg.properties().get("id")
+        future = self.pending.pop(id, None)
+        if future is not None:
+            future.set_result(msg.value())
+        await self.backend_consumer.acknowledge(msg)
+```
+
+When a response arrives, the receiver looks up the request ID in the
+pending dict, resolves the corresponding future, and acknowledges the
+message. The worker that was awaiting the future wakes up and
+continues processing.
+
+There is no work queue, no worker dispatch, no completion queue. The
+receiver's only job is matching responses to waiting callers. The
+ack happens in the receiver coroutine, satisfying the same-context
+constraint.
+
+Messages with no matching pending ID (e.g. stale responses after a
+timeout) are acknowledged and discarded.
+
+#### 4. Timeouts
+
+If a response does not arrive within the timeout,
+`asyncio.wait_for` cancels the future. The caller gets a
+`TimeoutError`. The pending entry is cleaned up:
+
+```python
+async def request(self, req, timeout=60):
+    id = str(uuid.uuid4())
+    future = asyncio.Future()
+    self.pending[id] = future
+    await self.producer.send(req, properties={"id": id})
+    try:
+        return await asyncio.wait_for(future, timeout=timeout)
+    except asyncio.TimeoutError:
+        self.pending.pop(id, None)
+        raise
+```
+
+If a response arrives after the timeout, the receiver finds no
+matching entry in the pending dict and discards it.
+
+#### 5. Teardown
+
+When the flow stops:
+
+```python
+await rr_client.close()
+```
+
+This:
+- Cancels the receiver coroutine.
+- Closes the backend consumer and producer.
+- Any pending futures are cancelled (callers get `CancelledError`).
+
+#### Relationship to the consumer/worker model
+
+The two patterns are independent:
+
+- **Consumer pattern** (ReceiverPool + workers): for processing
+  incoming messages that arrive on this processor's input queues.
+  Uses the work queue, worker pool, and completion-based ack flow.
+
+- **Request/Response pattern** (RequestResponseClient): for calling
+  out to other services during message processing. Uses a dedicated
+  receiver coroutine with direct future routing. No worker
+  involvement.
+
+A typical flow has both: a consumer registration in the ReceiverPool
+for its input queue, and one or more RequestResponse clients for
+services it depends on. The worker handles the incoming message and
+calls `await rr_client.request()` as needed during processing.
+
+The LibrarianClient follows the same pattern — it is a specialised
+request/response client with additional logic for streaming responses
+and document assembly. It can be refactored onto the same
+RequestResponseClient infrastructure.
+
+## Backpressure
+
+The work queue in the ReceiverPool is an `asyncio.Queue` with
+`maxsize` set to the number of worker tasks. When all workers are
+busy, the queue is full. The receiver task's
+`await work_queue.put(...)` blocks, which means the receiver stops
+calling `await backend_consumer.receive()`. Messages accumulate in
+the broker, where they have proper persistence, redelivery, and
+backpressure mechanisms.
+
+No messages accumulate in Python memory beyond the worker pool size.
+The broker is the backlog, not the application.
+
+The same applies to the SenderPool: the send queue has a bounded
+size. If the broker is slow to accept messages, `await
+send_queue.put(...)` blocks the caller, applying backpressure up
+to the worker or application code.
+
+## Reconnection and Error Handling
+
+Reconnection is the backend's responsibility. If the broker
+connection drops, the backend's `receive()` implementation handles
+reconnection internally and resumes delivering messages. The
+receiver task in the `base/` layer just sees `await receive()` take
+longer than usual — it does not need retry logic.
+
+The same applies to `send()`: the backend reconnects and retries
+transparently.
+
+For errors that are not recoverable by the backend (e.g. the topic
+has been deleted, authentication revoked), `receive()` or `send()`
+raises an exception. The receiver task or sender task logs the error
+and can be restarted by the pool, or the error propagates up to the
+processor for a full restart.
+
+## Config Fetch at Startup
+
+`AsyncProcessor.fetch_and_apply_config()` creates short-lived
+RequestResponse clients to fetch configuration from the config
+service before flows are started. Under the new model, these become
+short-lived `RequestResponseClient` instances:
+
+```python
+async def fetch_and_apply_config(self):
+    rr_client = await RequestResponseClient.create(
+        backend=self.backend,
+        request_topic=config_request_queue,
+        response_topic=config_response_queue,
+        request_schema=ConfigRequest,
+        response_schema=ConfigResponse,
+    )
+    try:
+        resp = await rr_client.request(
+            ConfigRequest(operation="getkeys-all-ws", ...),
+            timeout=60,
+        )
+        # ... process config ...
+    finally:
+        await rr_client.close()
+```
+
+This works naturally with the new architecture. The client creates a
+backend producer and consumer (async, no threads), runs a receiver
+coroutine for the duration of the fetch, and tears down cleanly.
+The retry loop in `fetch_and_apply_config` continues to handle the
+case where the config service is not yet available on cold start.
+
+## Assumptions
+
+- **`receive_async()` is available**: Pulsar's Python client exposes
+  `receive_async()` on consumer objects, returning an awaitable
+  coroutine. This is confirmed in the Pulsar documentation.
+
+- **Ack can happen in a different coroutine**: Pulsar's
+  `consumer.acknowledge()` does not need to be called from the same
+  asyncio coroutine that called `receive_async()`. All coroutines
+  run on the same OS thread (the event loop thread), and the Pulsar
+  C++ client is thread-safe, so acknowledgement from any coroutine
+  is valid. If this assumption proves wrong, the fallback is the
+  `asyncio.wait` multiplexing pattern described in the Message Flow
+  section, where the receiver coroutine handles acks directly.
+
+## Open Questions
+
+- **Shared vs per-flow RequestResponse clients**: Some processors
+  create one RequestResponse client per flow (e.g. TriplesClient).
+  If multiple flows in the same workspace call the same service,
+  they could potentially share a single RequestResponseClient.
+  This is an optimisation, not a requirement — individual clients
+  work correctly and can be consolidated later if needed.

--- a/trustgraph-base/trustgraph/base/__init__.py
+++ b/trustgraph-base/trustgraph/base/__init__.py
@@ -1,5 +1,5 @@
 
-from . pubsub import get_pubsub, add_pubsub_args
+from . pubsub import get_pubsub, get_async_pubsub, add_pubsub_args
 from . async_processor import AsyncProcessor
 from . consumer import Consumer
 from . producer import Producer
@@ -51,4 +51,11 @@ from . row_embeddings_query_client import RowEmbeddingsQueryClientSpec
 from . collection_config_handler import CollectionConfigHandler
 from . audit_publisher import AuditPublisher
 from . schema_compatibility import is_strict_mode_compatible
+from . async_backend import (
+    AsyncPubSubBackend, AsyncBackendConsumer, AsyncBackendProducer, Message,
+)
+from . receiver_pool import ReceiverPool, ConsumerRegistration
+from . sender_pool import SenderPool, ProducerHandle
+from . request_response_client import RequestResponseClient
+from . async_librarian_client import AsyncLibrarianClient
 

--- a/trustgraph-base/trustgraph/base/async_backend.py
+++ b/trustgraph-base/trustgraph/base/async_backend.py
@@ -1,0 +1,119 @@
+"""
+Async backend abstraction interfaces for pub/sub systems.
+
+These protocols replace the synchronous protocols in backend.py.
+All methods that perform broker I/O are async. The backend handles
+its own threading internally — the application layer never creates
+threads for broker operations.
+"""
+
+from typing import Protocol, Any, runtime_checkable
+
+
+@runtime_checkable
+class Message(Protocol):
+    """Protocol for a received message."""
+
+    def value(self) -> Any:
+        """Get the deserialized message content."""
+        ...
+
+    def properties(self) -> dict:
+        """Get message properties/metadata."""
+        ...
+
+
+@runtime_checkable
+class AsyncBackendConsumer(Protocol):
+    """Protocol for an async backend consumer.
+
+    receive() is awaitable with no timeout — shutdown is signalled
+    by cancelling the awaiting task. acknowledge() and
+    negative_acknowledge() are async so that backends with threading
+    constraints (e.g. RabbitMQ) can route ack calls internally.
+    """
+
+    async def receive(self) -> Message:
+        """Await the next message.
+
+        Does not time out. Shutdown is signalled by cancelling the
+        awaiting task.
+        """
+        ...
+
+    async def acknowledge(self, message: Message) -> None:
+        """Acknowledge successful processing of a message."""
+        ...
+
+    async def negative_acknowledge(self, message: Message) -> None:
+        """Negative acknowledge — triggers redelivery."""
+        ...
+
+    async def close(self) -> None:
+        """Close the consumer and release broker resources."""
+        ...
+
+
+@runtime_checkable
+class AsyncBackendProducer(Protocol):
+    """Protocol for an async backend producer.
+
+    send() is async so the backend can perform broker I/O without
+    blocking the event loop.
+    """
+
+    async def send(self, message: Any, properties: dict = {}) -> None:
+        """Send a message with optional properties."""
+        ...
+
+    async def close(self) -> None:
+        """Flush pending messages and close the producer."""
+        ...
+
+
+@runtime_checkable
+class AsyncPubSubBackend(Protocol):
+    """Protocol for an async pub/sub backend.
+
+    Factory methods are async since they perform broker roundtrips.
+    """
+
+    async def create_consumer(
+        self, topic: str, subscription: str, schema: type,
+        initial_position: str = 'latest', **options,
+    ) -> AsyncBackendConsumer:
+        """Create a consumer subscribed to a topic.
+
+        Returns only when the subscription is active and ready to
+        receive messages.
+        """
+        ...
+
+    async def create_producer(
+        self, topic: str, schema: type, **options,
+    ) -> AsyncBackendProducer:
+        """Create a producer bound to a topic.
+
+        Returns only when the producer is ready to send.
+        """
+        ...
+
+    async def create_topic(self, topic: str) -> None:
+        """Create broker-side resources for a logical topic."""
+        ...
+
+    async def delete_topic(self, topic: str) -> None:
+        """Delete a topic and discard any in-flight messages."""
+        ...
+
+    async def topic_exists(self, topic: str) -> bool:
+        """Check whether a topic exists."""
+        ...
+
+    async def ensure_topic(self, topic: str) -> None:
+        """Ensure a topic exists, creating it if necessary."""
+        ...
+
+    async def close(self) -> None:
+        """Close the backend and release all resources."""
+        ...

--- a/trustgraph-base/trustgraph/base/async_config_client.py
+++ b/trustgraph-base/trustgraph/base/async_config_client.py
@@ -1,0 +1,121 @@
+
+from .. schema import ConfigRequest, ConfigResponse, ConfigKey, ConfigValue
+from . request_response_client import RequestResponseClient
+
+CONFIG_TIMEOUT = 10
+
+
+class AsyncConfigClient:
+
+    def __init__(self, client):
+        self._client = client
+
+    @classmethod
+    async def create(cls, backend, request_topic, response_topic,
+                     subscription=None):
+        client = await RequestResponseClient.create(
+            backend=backend,
+            request_topic=request_topic,
+            response_topic=response_topic,
+            request_schema=ConfigRequest,
+            response_schema=ConfigResponse,
+            subscription=subscription,
+        )
+        return cls(client)
+
+    async def start(self):
+        pass
+
+    async def stop(self):
+        await self._client.close()
+
+    async def close(self):
+        await self._client.close()
+
+    async def request(self, message, timeout=CONFIG_TIMEOUT):
+        return await self._client.request(message, timeout=timeout)
+
+    async def _request(self, timeout=CONFIG_TIMEOUT, **kwargs):
+        resp = await self._client.request(
+            ConfigRequest(**kwargs),
+            timeout=timeout,
+        )
+        if resp.error:
+            raise RuntimeError(
+                f"{resp.error.type}: {resp.error.message}"
+            )
+        return resp
+
+    async def get(self, workspace, type, key, timeout=CONFIG_TIMEOUT):
+        resp = await self._request(
+            operation="get",
+            workspace=workspace,
+            keys=[ConfigKey(type=type, key=key)],
+            timeout=timeout,
+        )
+        if resp.values and len(resp.values) > 0:
+            return resp.values[0].value
+        return None
+
+    async def put(self, workspace, type, key, value, timeout=CONFIG_TIMEOUT):
+        await self._request(
+            operation="put",
+            workspace=workspace,
+            values=[ConfigValue(type=type, key=key, value=value)],
+            timeout=timeout,
+        )
+
+    async def put_many(self, workspace, values, timeout=CONFIG_TIMEOUT):
+        await self._request(
+            operation="put",
+            workspace=workspace,
+            values=[
+                ConfigValue(type=t, key=k, value=v)
+                for t, k, v in values
+            ],
+            timeout=timeout,
+        )
+
+    async def delete(self, workspace, type, key, timeout=CONFIG_TIMEOUT):
+        await self._request(
+            operation="delete",
+            workspace=workspace,
+            keys=[ConfigKey(type=type, key=key)],
+            timeout=timeout,
+        )
+
+    async def delete_many(self, workspace, keys, timeout=CONFIG_TIMEOUT):
+        await self._request(
+            operation="delete",
+            workspace=workspace,
+            keys=[
+                ConfigKey(type=t, key=k)
+                for t, k in keys
+            ],
+            timeout=timeout,
+        )
+
+    async def keys(self, workspace, type, timeout=CONFIG_TIMEOUT):
+        resp = await self._request(
+            operation="list",
+            workspace=workspace,
+            type=type,
+            timeout=timeout,
+        )
+        return resp.directory
+
+    async def get_all(self, workspace, timeout=CONFIG_TIMEOUT):
+        resp = await self._request(
+            operation="config",
+            workspace=workspace,
+            timeout=timeout,
+        )
+        return resp.config
+
+    async def workspaces_for_type(self, type, timeout=CONFIG_TIMEOUT):
+        resp = await self._request(
+            operation="getvalues-all-ws",
+            type=type,
+            timeout=timeout,
+        )
+        return {v.workspace for v in resp.values if v.workspace}

--- a/trustgraph-base/trustgraph/base/async_librarian_client.py
+++ b/trustgraph-base/trustgraph/base/async_librarian_client.py
@@ -1,0 +1,260 @@
+"""
+Async librarian client using the async pub/sub backend directly.
+
+Replaces LibrarianClient's Consumer+Producer (which create OS threads)
+with async backend producers/consumers and a dedicated receiver
+coroutine. Supports both single-response and streaming operations.
+"""
+
+import asyncio
+import base64
+import logging
+import uuid
+
+from ..schema import LibrarianRequest, LibrarianResponse, DocumentMetadata
+
+logger = logging.getLogger(__name__)
+
+
+class AsyncLibrarianClient:
+
+    def __init__(self):
+        self._producer = None
+        self._consumer = None
+        self._receiver_task = None
+        self._pending = {}
+        self._streams = {}
+        self.running = False
+
+    @classmethod
+    async def create(
+        cls, backend, request_topic, response_topic,
+        subscription=None,
+    ):
+        client = cls()
+
+        client._producer = await backend.create_producer(
+            topic=request_topic,
+            schema=LibrarianRequest,
+        )
+
+        if subscription is None:
+            subscription = f"librarian-{uuid.uuid4().hex[:12]}"
+
+        client._consumer = await backend.create_consumer(
+            topic=response_topic,
+            subscription=subscription,
+            schema=LibrarianResponse,
+            initial_position='latest',
+        )
+
+        client.running = True
+        client._receiver_task = asyncio.create_task(
+            client._response_loop(),
+            name=f"librarian-receiver-{response_topic}",
+        )
+
+        logger.info(
+            f"AsyncLibrarianClient created: "
+            f"req={request_topic}, resp={response_topic}"
+        )
+        return client
+
+    async def start(self):
+        pass
+
+    async def _response_loop(self):
+        try:
+            while self.running:
+                msg = await self._consumer.receive()
+                response = msg.value()
+                request_id = msg.properties().get("id")
+
+                if request_id:
+                    if request_id in self._pending:
+                        future = self._pending.pop(request_id)
+                        if not future.done():
+                            future.set_result(response)
+                    elif request_id in self._streams:
+                        await self._streams[request_id].put(response)
+
+                await self._consumer.acknowledge(msg)
+
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            logger.error(
+                f"Librarian response loop error: {e}", exc_info=True,
+            )
+
+    async def request(self, request, timeout=120):
+        request_id = str(uuid.uuid4())
+
+        future = asyncio.get_event_loop().create_future()
+        self._pending[request_id] = future
+
+        try:
+            await self._producer.send(
+                request, properties={"id": request_id},
+            )
+            response = await asyncio.wait_for(future, timeout=timeout)
+
+            if response.error:
+                raise RuntimeError(
+                    f"Librarian error: {response.error.type}: "
+                    f"{response.error.message}"
+                )
+
+            return response
+
+        except asyncio.TimeoutError:
+            self._pending.pop(request_id, None)
+            raise RuntimeError("Timeout waiting for librarian response")
+
+    async def stream(self, request, timeout=120):
+        request_id = str(uuid.uuid4())
+
+        q = asyncio.Queue()
+        self._streams[request_id] = q
+
+        try:
+            await self._producer.send(
+                request, properties={"id": request_id},
+            )
+
+            chunks = []
+            while True:
+                response = await asyncio.wait_for(
+                    q.get(), timeout=timeout,
+                )
+
+                if response.error:
+                    raise RuntimeError(
+                        f"Librarian error: {response.error.type}: "
+                        f"{response.error.message}"
+                    )
+
+                chunks.append(response)
+
+                if response.is_final:
+                    break
+
+            return chunks
+
+        except asyncio.TimeoutError:
+            self._streams.pop(request_id, None)
+            raise RuntimeError("Timeout waiting for librarian stream")
+        finally:
+            self._streams.pop(request_id, None)
+
+    async def stop(self):
+        self.running = False
+
+        if self._receiver_task:
+            self._receiver_task.cancel()
+            try:
+                await self._receiver_task
+            except asyncio.CancelledError:
+                pass
+
+        for future in self._pending.values():
+            if not future.done():
+                future.cancel()
+        self._pending.clear()
+
+        for q in self._streams.values():
+            await q.put(None)
+        self._streams.clear()
+
+        if self._producer:
+            try:
+                await self._producer.close()
+            except Exception as e:
+                logger.warning(f"Error closing librarian producer: {e}")
+
+        if self._consumer:
+            try:
+                await self._consumer.close()
+            except Exception as e:
+                logger.warning(f"Error closing librarian consumer: {e}")
+
+        logger.info("AsyncLibrarianClient closed")
+
+    async def fetch_document_content(self, document_id, timeout=120):
+        req = LibrarianRequest(
+            operation="stream-document",
+            document_id=document_id,
+        )
+        chunks = await self.stream(req, timeout=timeout)
+
+        raw = b""
+        for chunk in chunks:
+            if chunk.content:
+                if isinstance(chunk.content, bytes):
+                    raw += base64.b64decode(chunk.content)
+                else:
+                    raw += base64.b64decode(
+                        chunk.content.encode("utf-8")
+                    )
+
+        return base64.b64encode(raw)
+
+    async def fetch_document_text(self, document_id, timeout=120):
+        content = await self.fetch_document_content(
+            document_id, timeout=timeout,
+        )
+        return base64.b64decode(content).decode("utf-8")
+
+    async def fetch_document_metadata(self, document_id, timeout=120):
+        req = LibrarianRequest(
+            operation="get-document-metadata",
+            document_id=document_id,
+        )
+        response = await self.request(req, timeout=timeout)
+        return response.document_metadata
+
+    async def save_child_document(self, doc_id, parent_id, content,
+                                  document_type="chunk", title=None,
+                                  kind="text/plain", timeout=120):
+        if isinstance(content, str):
+            content = content.encode("utf-8")
+
+        doc_metadata = DocumentMetadata(
+            id=doc_id,
+            kind=kind,
+            title=title or doc_id,
+            parent_id=parent_id,
+            document_type=document_type,
+        )
+
+        req = LibrarianRequest(
+            operation="add-child-document",
+            document_metadata=doc_metadata,
+            content=base64.b64encode(content).decode("utf-8"),
+        )
+
+        await self.request(req, timeout=timeout)
+        return doc_id
+
+    async def save_document(self, doc_id, content, title=None,
+                            document_type="answer", kind="text/plain",
+                            timeout=120):
+        if isinstance(content, str):
+            content = content.encode("utf-8")
+
+        doc_metadata = DocumentMetadata(
+            id=doc_id,
+            kind=kind,
+            title=title or doc_id,
+            document_type=document_type,
+        )
+
+        req = LibrarianRequest(
+            operation="add-document",
+            document_id=doc_id,
+            document_metadata=doc_metadata,
+            content=base64.b64encode(content).decode("utf-8"),
+        )
+
+        await self.request(req, timeout=timeout)
+        return doc_id

--- a/trustgraph-base/trustgraph/base/async_processor.py
+++ b/trustgraph-base/trustgraph/base/async_processor.py
@@ -3,12 +3,6 @@ from __future__ import annotations
 from argparse import ArgumentParser
 from typing import Any, Callable
 
-# Base class for processors.  Implements:
-# - Pub/sub client, subscribe and consume basic
-# - the async startup logic
-# - Config notify handling with subscribe-then-fetch pattern
-# - Initialising metrics
-
 import asyncio
 import argparse
 import time
@@ -21,118 +15,77 @@ from .. schema import ConfigPush, ConfigRequest, ConfigResponse
 from .. schema import config_push_queue, config_request_queue
 from .. schema import config_response_queue
 from .. log_level import LogLevel
-from . pubsub import get_pubsub, add_pubsub_args
-from . producer import Producer
-from . consumer import Consumer
-from . subscriber import Subscriber
-from . request_response_spec import RequestResponse
-from . metrics import ProcessorMetrics, ConsumerMetrics, ProducerMetrics
-from . metrics import SubscriberMetrics
+from . pubsub import get_async_pubsub, get_pubsub, add_pubsub_args
+from . receiver_pool import ReceiverPool
+from . sender_pool import SenderPool
+from . request_response_client import RequestResponseClient
 from . logging import add_logging_args, setup_logging
 
 default_config_queue = config_push_queue
 
-# Module logger
 logger = logging.getLogger(__name__)
 
-# Async processor
+
 class AsyncProcessor:
 
     def __init__(self, **params):
 
-        # Store the identity
         self.id = params.get("id")
 
-        # Create pub/sub backend via factory
-        self.pubsub_backend = get_pubsub(**params)
+        self.async_backend = get_async_pubsub(**params)
 
-        # Store pulsar_host for backward compatibility
         self._pulsar_host = params.get("pulsar_host", "pulsar://pulsar:6650")
 
-        # Initialise metrics, records the parameters
+        from . metrics import ProcessorMetrics
         ProcessorMetrics(processor = self.id).info({
             k: str(params[k])
             for k in params
             if k != "id"
         })
 
-        # The processor runs all activity in a taskgroup, it's mandatory
-        # that this is provded
         self.taskgroup = params.get("taskgroup")
-        if self.taskgroup is None:
-            raise RuntimeError("Essential taskgroup missing")
 
-        # Get the configuration topic
+        self.concurrency = params.get("concurrency", 1)
+
+        self.receiver_pool = ReceiverPool(
+            backend=self.async_backend,
+            concurrency=self.concurrency,
+        )
+
+        self.sender_pool = SenderPool(
+            backend=self.async_backend,
+        )
+
         self.config_push_queue = params.get(
             "config_push_queue", default_config_queue
         )
 
-        # This records registered configuration handlers, each entry is:
-        # { "handler": async_fn, "types": set_or_none }
         self.config_handlers = []
-
-        # Workspace lifecycle handlers, called when workspaces are
-        # created or deleted.  Each entry is an async callable:
-        # async def handler(workspace_changes: WorkspaceChanges)
         self.workspace_handlers = []
-
-        # Track the current config version for dedup
         self.config_version = 0
 
-        # Create a random ID for this subscription to the configuration
-        # service
-        config_subscriber_id = str(uuid.uuid4())
-
-        config_consumer_metrics = ConsumerMetrics(
-            processor=self.id, consumer="config",
-        )
-
-        # Subscribe to config notify queue
-        self.config_sub_task = Consumer(
-
-            taskgroup = self.taskgroup,
-            backend = self.pubsub_backend,
-            subscriber = config_subscriber_id,
-            flow = None,
-
-            topic = self.config_push_queue,
-            schema = ConfigPush,
-
-            handler = self.on_config_notify,
-
-            metrics = config_consumer_metrics,
-
-            start_of_messages = False,
-        )
+        self._config_consumer_reg = None
 
         self.running = True
 
-    def _create_config_client(self):
-        """Create a short-lived config request/response client."""
-        config_rr_id = str(uuid.uuid4())
+    @property
+    def pubsub(self) -> Any:
+        return self.async_backend
 
-        config_req_metrics = ProducerMetrics(
-            processor=self.id, producer="config-request",
-        )
-        config_resp_metrics = SubscriberMetrics(
-            processor=self.id, subscriber="config-response",
-        )
+    @property
+    def pulsar_host(self) -> str:
+        return self._pulsar_host
 
-        return RequestResponse(
-            backend = self.pubsub_backend,
-            subscription = f"{self.id}--config--{config_rr_id}",
-            consumer_name = self.id,
-            request_topic = config_request_queue,
-            request_schema = ConfigRequest,
-            request_metrics = config_req_metrics,
-            response_topic = config_response_queue,
-            response_schema = ConfigResponse,
-            response_metrics = config_resp_metrics,
+    async def _create_config_client(self):
+        return await RequestResponseClient.create(
+            backend=self.async_backend,
+            request_topic=config_request_queue,
+            response_topic=config_response_queue,
+            request_schema=ConfigRequest,
+            response_schema=ConfigResponse,
         )
 
     async def _fetch_type_workspace(self, client, workspace, config_type):
-        """Fetch config values of a single type within one workspace.
-        Returns dict of {key: value}."""
         resp = await client.request(
             ConfigRequest(
                 operation="getvalues",
@@ -146,11 +99,6 @@ class AsyncProcessor:
         return {v.key: v.value for v in resp.values}
 
     async def _fetch_type_all_workspaces(self, client, config_type):
-        """Fetch config values of a single type across all workspaces.
-        Uses getkeys-all-ws to discover workspaces, then fetches values
-        per-workspace to avoid oversized responses."""
-
-        # Step 1: get workspace/key pairs (small response)
         resp = await client.request(
             ConfigRequest(
                 operation="getkeys-all-ws",
@@ -163,12 +111,10 @@ class AsyncProcessor:
 
         version = resp.version
 
-        # Group keys by workspace
         workspaces = set()
         for v in resp.values:
             workspaces.add(v.workspace)
 
-        # Step 2: fetch values per workspace in parallel
         async def fetch_one(ws):
             kv = await self._fetch_type_workspace(client, ws, config_type)
             return ws, kv
@@ -188,51 +134,43 @@ class AsyncProcessor:
 
         return grouped, version
 
-    # This is called to start dynamic behaviour.
-    # Implements the subscribe-then-fetch pattern to avoid race conditions.
     async def start(self):
 
-        # 1. Start the notify consumer (begins buffering incoming notifys)
-        await self.config_sub_task.start()
+        await self.receiver_pool.start()
+        await self.sender_pool.start()
 
-        # 2. Fetch current config via request/response
+        config_subscriber_id = str(uuid.uuid4())
+
+        async def config_notify_handler(message):
+            await self.on_config_notify(message, None, None)
+
+        self._config_consumer_reg = \
+            await self.receiver_pool.add_consumer(
+                topic=self.config_push_queue,
+                subscription=config_subscriber_id,
+                schema=ConfigPush,
+                handler=config_notify_handler,
+                initial_position='latest',
+            )
+
         await self.fetch_and_apply_config()
 
-        # 3. Any buffered notifys with version > fetched version will be
-        #    processed by on_config_notify, which does the version check
-
     async def fetch_and_apply_config(self):
-        """Startup: for each registered handler, fetch config for all its
-        types across all workspaces and invoke the handler once per
-        workspace. Retries until successful — config service may not be
-        ready yet.
-
-        Tracks which workspaces have already been applied so that
-        retries resume from where they left off rather than re-applying
-        all workspaces from scratch.
-        """
-
-        applied_ws = set()
 
         while self.running:
 
             try:
-                client = self._create_config_client()
+                client = await self._create_config_client()
                 try:
-                    await client.start()
 
                     version = 0
 
                     for entry in self.config_handlers:
                         handler_types = entry["types"]
 
-                        # Handlers registered without types get nothing
-                        # at startup (there is no "all types" fetch).
                         if not handler_types:
                             continue
 
-                        # Group all registered types by workspace:
-                        # {workspace: {type: {key: value}}}
                         per_ws = {}
                         for t in handler_types:
                             type_data, v = \
@@ -243,15 +181,10 @@ class AsyncProcessor:
                             for ws, kv in type_data.items():
                                 per_ws.setdefault(ws, {})[t] = kv
 
-                        # Call the handler once per workspace, skipping
-                        # workspaces already applied in a previous attempt
                         for ws, config in per_ws.items():
                             if ws.startswith("_"):
                                 continue
-                            if ws in applied_ws:
-                                continue
                             await entry["handler"](ws, config, version)
-                            applied_ws.add(ws)
 
                     logger.info(
                         f"Applied startup config version {version}"
@@ -259,50 +192,63 @@ class AsyncProcessor:
                     self.config_version = version
 
                 finally:
-                    await client.stop()
+                    await client.close()
 
                 return
 
-            except Exception as e:
+            except BaseException as e:
+                if isinstance(e, asyncio.CancelledError):
+                    raise
                 logger.warning(
                     f"Config fetch failed: {e}, retrying in 2s...",
                     exc_info=True
                 )
                 await asyncio.sleep(2)
 
-    # This is called to stop all threads.  An over-ride point for extra
-    # functionality
-    def stop(self) -> None:
-        self.pubsub_backend.close()
+    async def stop(self):
         self.running = False
 
-    # Returns the pub/sub backend (new interface)
-    @property
-    def pubsub(self) -> Any: return self.pubsub_backend
+        if self._config_consumer_reg:
+            try:
+                await self._config_consumer_reg.unregister()
+            except BaseException as e:
+                logger.warning(f"Error unregistering config consumer: {e}")
 
-    # Returns the pulsar host (backward compatibility)
-    @property
-    def pulsar_host(self) -> str: return self._pulsar_host
+        try:
+            await self.receiver_pool.stop()
+        except BaseException as e:
+            logger.warning(f"Error stopping receiver pool: {e}")
 
-    # Register a new event handler for configuration change
-    def register_config_handler(self, handler: Callable[..., Any], types: list[type] | None = None) -> None:
+        try:
+            await self.sender_pool.stop()
+        except BaseException as e:
+            logger.warning(f"Error stopping sender pool: {e}")
+
+        try:
+            await self.async_backend.close()
+        except BaseException as e:
+            logger.warning(f"Error closing async backend: {e}")
+
+    def register_config_handler(
+        self, handler: Callable[..., Any],
+        types: list[type] | None = None,
+    ) -> None:
         self.config_handlers.append({
             "handler": handler,
             "types": set(types) if types else None,
         })
 
-    # Register a handler for workspace lifecycle events
-    def register_workspace_handler(self, handler: Callable[..., Any]) -> None:
+    def register_workspace_handler(
+        self, handler: Callable[..., Any],
+    ) -> None:
         self.workspace_handlers.append(handler)
 
-    # Called when a config notify message arrives
     async def on_config_notify(self, message, consumer, flow):
 
         v = message.value()
         notify_version = v.version
-        changes = v.changes  # dict of type -> [workspaces]
+        changes = v.changes
 
-        # Skip if we already have this version or newer
         if notify_version <= self.config_version:
             logger.debug(
                 f"Ignoring config notify v{notify_version}, "
@@ -310,21 +256,19 @@ class AsyncProcessor:
             )
             return
 
-        # Dispatch workspace lifecycle events before config handlers
         if v.workspace_changes and self.workspace_handlers:
             for handler in self.workspace_handlers:
                 try:
                     await handler(v.workspace_changes)
-                except Exception as e:
+                except BaseException as e:
+                    if isinstance(e, asyncio.CancelledError):
+                        raise
                     logger.error(
                         f"Workspace handler failed: {e}", exc_info=True
                     )
 
         notify_types = set(changes.keys())
 
-        # Filter out handlers that don't care about any of the changed
-        # types. A handler registered without types never fires on
-        # notifications (nothing to scope to).
         interested = []
         for entry in self.config_handlers:
             handler_types = entry["types"]
@@ -345,16 +289,12 @@ class AsyncProcessor:
         )
 
         try:
-            client = self._create_config_client()
+            client = await self._create_config_client()
             try:
-                await client.start()
 
                 for entry in interested:
                     handler_types = entry["types"]
 
-                    # Build {workspace: {type: {key: value}}} for types
-                    # this handler cares about, where the workspace was
-                    # affected for that type.
                     per_ws = {}
                     for t in handler_types:
                         if t not in changes:
@@ -373,67 +313,62 @@ class AsyncProcessor:
                         )
 
             finally:
-                await client.stop()
+                await client.close()
 
             self.config_version = notify_version
 
-        except Exception as e:
+        except BaseException as e:
+            if isinstance(e, asyncio.CancelledError):
+                raise
             logger.error(
                 f"Failed to fetch config on notify: {e}", exc_info=True
             )
 
-    # This is the 'main' body of the handler.  It is a point to override
-    # if needed.  By default does nothing.  Processors are implemented
-    # by adding consumer/producer functionality so maybe nothing is needed
-    # in the run() body
     async def run(self):
         while self.running:
             await asyncio.sleep(2)
 
-    # Startup fabric.  This runs in 'async' mode, creates a taskgroup and
-    # runs the producer.
     @classmethod
     async def launch_async(cls, args):
 
+        p = None
+
         try:
 
-            # Create a taskgroup.  This seems complicated, when an exception
-            # occurs, unhandled it looks like it cancels all threads in the
-            # taskgroup.  Needs the exception to be caught in the right
-            # place.
             async with asyncio.TaskGroup() as tg:
 
+                p = cls(**args | {"taskgroup": tg})
 
-                    # Create a processor instance, and include the taskgroup
-                    # as a paramter.  A processor identity ident is used as
-                    # - subscriber name
-                    # - an identifier for flow configuration
-                    p = cls(**args | { "taskgroup": tg })
+                await p.start()
 
-                    # Start the processor
-                    await p.start()
+                task = tg.create_task(p.run())
 
-                    # Run the processor
-                    task = tg.create_task(p.run())
+        except ExceptionGroup as e:
 
-                    # The taskgroup causes everything to wait until
-                    # all threads have stopped
+            logger.error("Exception group:")
 
-        # This is here to output a debug message, shouldn't be needed.
+            for se in e.exceptions:
+                logger.error(f"  Type: {type(se)}")
+                logger.error(f"  Exception: {se}", exc_info=se)
+
         except Exception as e:
-            logger.error("Exception, closing taskgroup", exc_info=True)
+            logger.error("Exception in processor", exc_info=True)
             raise e
+
+        finally:
+            if p:
+                try:
+                    await p.stop()
+                except Exception:
+                    pass
 
     @classmethod
     def setup_logging(cls, args: dict[str, Any]) -> None:
-        """Configure logging for the entire application"""
         setup_logging(args)
 
-    # Startup fabric.  launch calls launch_async in async mode.
     @classmethod
     def launch(cls, ident: str, doc: str) -> None:
 
-        # Start assembling CLI arguments
         parser = argparse.ArgumentParser(
             prog=ident,
             description=doc
@@ -445,32 +380,24 @@ class AsyncProcessor:
             help=f'Configuration identity (default: {ident})',
         )
 
-        # Invoke the class-specific add_args, which manages adding all the
-        # command-line arguments
         cls.add_args(parser)
 
-        # Parse arguments
         args = parser.parse_args()
         args = vars(args)
 
-        # Setup logging before anything else
         cls.setup_logging(args)
 
-        # Debug
         logger.debug(f"Arguments: {args}")
 
-        # Start the Prometheus metrics service if needed
         if args["metrics"]:
             start_http_server(args["metrics_port"])
 
-        # Loop forever, exception handler
         while True:
 
             logger.info("Starting...")
 
             try:
 
-                # Launch the processor in an asyncio handler
                 asyncio.run(cls.launch_async(
                     args
                 ))
@@ -479,30 +406,14 @@ class AsyncProcessor:
                 logger.info("Keyboard interrupt.")
                 return
 
-            except KeyboardInterrupt:
-                logger.info("Interrupted.")
-                return
-
-            # Exceptions from a taskgroup come in as an exception group
-            except ExceptionGroup as e:
-
-                logger.error("Exception group:")
-
-                for se in e.exceptions:
-                    logger.error(f"  Type: {type(se)}")
-                    logger.error(f"  Exception: {se}", exc_info=se)
-
             except Exception as e:
                 logger.error(f"Type: {type(e)}")
                 logger.error(f"Exception: {e}", exc_info=True)
 
-            # Retry occurs here
             logger.warning("Will retry...")
             time.sleep(4)
             logger.info("Retrying...")
 
-    # The command-line arguments are built using a stack of add_args
-    # invocations
     @staticmethod
     def add_args(parser: ArgumentParser) -> None:
 
@@ -516,6 +427,13 @@ class AsyncProcessor:
         )
 
         parser.add_argument(
+            '--concurrency',
+            type=int,
+            default=1,
+            help='Number of concurrent workers (default: 1)',
+        )
+
+        parser.add_argument(
             '--metrics',
             action=argparse.BooleanOptionalAction,
             default=True,
@@ -526,5 +444,5 @@ class AsyncProcessor:
             '-P', '--metrics-port',
             type=int,
             default=8000,
-            help=f'Pulsar host (default: 8000)',
+            help=f'Metrics port (default: 8000)',
         )

--- a/trustgraph-base/trustgraph/base/async_pulsar_backend.py
+++ b/trustgraph-base/trustgraph/base/async_pulsar_backend.py
@@ -1,0 +1,296 @@
+"""
+Async Pulsar backend implementation.
+
+Uses pulsar.asyncio.Client for fully async message receiving,
+producing, and consumer/producer lifecycle. Zero OS threads.
+"""
+
+import pulsar
+import pulsar.asyncio
+import _pulsar
+import asyncio
+import json
+import logging
+import urllib.request
+import urllib.error
+import urllib.parse
+from typing import Any
+
+from .async_backend import AsyncPubSubBackend, AsyncBackendProducer
+from .async_backend import AsyncBackendConsumer, Message
+from .serialization import dataclass_to_dict, dict_to_dataclass
+
+logger = logging.getLogger(__name__)
+
+
+class PulsarMessage:
+    """Wrapper for Pulsar messages to match Message protocol."""
+
+    def __init__(self, pulsar_msg, schema_cls):
+        self._msg = pulsar_msg
+        self._schema_cls = schema_cls
+        self._value = None
+
+    def value(self) -> Any:
+        if self._value is None:
+            json_data = self._msg.data().decode('utf-8')
+            data_dict = json.loads(json_data)
+            self._value = dict_to_dataclass(data_dict, self._schema_cls)
+        return self._value
+
+    def properties(self) -> dict:
+        return self._msg.properties()
+
+
+class AsyncPulsarProducer:
+    """Async Pulsar producer using pulsar.asyncio.Client."""
+
+    def __init__(self, pulsar_producer, schema_cls):
+        self._producer = pulsar_producer
+        self._schema_cls = schema_cls
+
+    async def send(self, message: Any, properties: dict = {}) -> None:
+        data_dict = dataclass_to_dict(message)
+        json_data = json.dumps(data_dict)
+        await self._producer.send(
+            json_data.encode('utf-8'),
+            properties=properties,
+        )
+
+    async def close(self) -> None:
+        try:
+            await self._producer.flush()
+        except BaseException:
+            pass
+        try:
+            await self._producer.close()
+        except BaseException:
+            pass
+
+
+class AsyncPulsarConsumer:
+    """Async Pulsar consumer using pulsar.asyncio.Client."""
+
+    def __init__(self, pulsar_consumer, schema_cls):
+        self._consumer = pulsar_consumer
+        self._schema_cls = schema_cls
+
+    async def receive(self) -> Message:
+        pulsar_msg = await self._consumer.receive()
+        return PulsarMessage(pulsar_msg, self._schema_cls)
+
+    async def acknowledge(self, message: Message) -> None:
+        if isinstance(message, PulsarMessage):
+            await self._consumer.acknowledge(message._msg)
+
+    async def negative_acknowledge(self, message: Message) -> None:
+        if isinstance(message, PulsarMessage):
+            await self._consumer.negative_acknowledge(message._msg)
+
+    async def close(self) -> None:
+        try:
+            await self._consumer.unsubscribe()
+        except BaseException:
+            pass
+        try:
+            await self._consumer.close()
+        except BaseException:
+            pass
+
+
+class AsyncPulsarBackend:
+    """Async Pulsar pub/sub backend using pulsar.asyncio.Client.
+
+    Fully async — zero OS threads for receiving, sending, and
+    consumer/producer lifecycle.
+    """
+
+    def __init__(
+        self, host: str, api_key: str = None, listener: str = None,
+        admin_url: str = None,
+    ):
+        self.host = host
+        self.api_key = api_key
+        self.listener = listener
+        self.admin_url = admin_url
+
+        client_args = {'service_url': host}
+
+        if listener:
+            client_args['listener_name'] = listener
+
+        if api_key:
+            client_args['authentication'] = pulsar.AuthenticationToken(api_key)
+
+        client_args['logger'] = pulsar.ConsoleLogger(
+            _pulsar.LoggerLevel.Error
+        )
+
+        self.client = pulsar.asyncio.Client(**client_args)
+        logger.info(f"Async Pulsar client connected to {host}")
+
+    def _map_topic(self, queue_id: str) -> str:
+        if '://' in queue_id:
+            return queue_id
+
+        parts = queue_id.split(':', 2)
+        if len(parts) != 3:
+            raise ValueError(
+                f"Invalid queue format: {queue_id}, "
+                f"expected class:topicspace:topic"
+            )
+
+        cls, topicspace, topic = parts
+
+        if cls == 'flow':
+            persistence = 'persistent'
+        elif cls in ('request', 'response', 'notify'):
+            persistence = 'non-persistent'
+        else:
+            raise ValueError(
+                f"Invalid queue class: {cls}, "
+                f"expected flow, request, response, or notify"
+            )
+
+        return f"{persistence}://{topicspace}/{cls}/{topic}"
+
+    def _consumer_type(self, topic: str):
+        cls = topic.split(':', 1)[0] if ':' in topic else 'flow'
+        if cls in ('response', 'notify'):
+            return pulsar.ConsumerType.Exclusive
+        return pulsar.ConsumerType.Shared
+
+    async def create_consumer(
+        self, topic: str, subscription: str, schema: type,
+        initial_position: str = 'latest', **options,
+    ) -> AsyncBackendConsumer:
+        pulsar_topic = self._map_topic(topic)
+
+        if initial_position == 'earliest':
+            pos = pulsar.InitialPosition.Earliest
+        else:
+            pos = pulsar.InitialPosition.Latest
+
+        ctype = self._consumer_type(topic)
+
+        consumer_args = {
+            'topic': pulsar_topic,
+            'subscription_name': subscription,
+            'schema': pulsar.schema.BytesSchema(),
+            'initial_position': pos,
+            'consumer_type': ctype,
+        }
+
+        pulsar_consumer = await self.client.subscribe(**consumer_args)
+        logger.debug(
+            f"Created async consumer: {pulsar_topic}, "
+            f"subscription: {subscription}"
+        )
+
+        return AsyncPulsarConsumer(pulsar_consumer, schema)
+
+    async def create_producer(
+        self, topic: str, schema: type, **options,
+    ) -> AsyncBackendProducer:
+        pulsar_topic = self._map_topic(topic)
+
+        producer_args = {
+            'topic': pulsar_topic,
+            'schema': pulsar.schema.BytesSchema(),
+        }
+
+        if 'chunking_enabled' in options:
+            producer_args['chunking_enabled'] = options['chunking_enabled']
+
+        pulsar_producer = await self.client.create_producer(**producer_args)
+        logger.debug(f"Created async producer: {pulsar_topic}")
+
+        return AsyncPulsarProducer(pulsar_producer, schema)
+
+    def _admin_api_path(self, pulsar_uri: str) -> str:
+        scheme, rest = pulsar_uri.split('://', 1)
+        tenant, namespace, topic = rest.split('/', 2)
+        encoded_topic = urllib.parse.quote(topic, safe='')
+        return f"/admin/v2/{scheme}/{tenant}/{namespace}/{encoded_topic}"
+
+    def _admin_request(self, method, path):
+        url = f"{self.admin_url}{path}"
+        req = urllib.request.Request(url, method=method)
+        try:
+            with urllib.request.urlopen(req) as resp:
+                if method == 'GET':
+                    return json.loads(resp.read().decode('utf-8'))
+                return None
+        except urllib.error.HTTPError as e:
+            if e.code == 404:
+                return None
+            raise
+
+    def _delete_topic_sync(self, topic: str):
+        pulsar_uri = self._map_topic(topic)
+        if pulsar_uri.startswith('non-persistent://'):
+            return
+        api_path = self._admin_api_path(pulsar_uri)
+        try:
+            subs = self._admin_request('GET', f"{api_path}/subscriptions")
+        except Exception as e:
+            logger.warning(
+                f"Failed to list subscriptions for {topic}: {e}"
+            )
+            return
+        if subs:
+            for sub in subs:
+                encoded_sub = urllib.parse.quote(sub, safe='')
+                try:
+                    self._admin_request(
+                        'DELETE',
+                        f"{api_path}/subscription/{encoded_sub}"
+                        f"?force=true"
+                    )
+                except Exception as e:
+                    logger.warning(
+                        f"Failed to delete subscription {sub} "
+                        f"from {topic}: {e}"
+                    )
+        try:
+            self._admin_request('DELETE', api_path)
+            logger.info(f"Deleted topic: {topic}")
+        except Exception as e:
+            logger.warning(f"Failed to delete topic {topic}: {e}")
+
+    def _topic_exists_sync(self, topic: str) -> bool:
+        pulsar_uri = self._map_topic(topic)
+        if pulsar_uri.startswith('non-persistent://'):
+            return False
+        api_path = self._admin_api_path(pulsar_uri)
+        try:
+            result = self._admin_request('GET', f"{api_path}/stats")
+            return result is not None
+        except Exception:
+            return False
+
+    async def create_topic(self, topic: str) -> None:
+        pass
+
+    async def delete_topic(self, topic: str) -> None:
+        if not self.admin_url:
+            logger.warning(
+                f"Cannot delete topic {topic}: no admin URL configured"
+            )
+            return
+        await asyncio.to_thread(self._delete_topic_sync, topic)
+
+    async def topic_exists(self, topic: str) -> bool:
+        if not self.admin_url:
+            return True
+        return await asyncio.to_thread(self._topic_exists_sync, topic)
+
+    async def ensure_topic(self, topic: str) -> None:
+        pass
+
+    async def close(self) -> None:
+        try:
+            await self.client.close()
+        except BaseException:
+            pass
+        logger.info("Async Pulsar client closed")

--- a/trustgraph-base/trustgraph/base/async_rr_wrapper.py
+++ b/trustgraph-base/trustgraph/base/async_rr_wrapper.py
@@ -1,0 +1,36 @@
+
+from . request_response_client import RequestResponseClient
+
+
+class AsyncRequestResponseWrapper:
+
+    def __init__(self, backend, request_topic, response_topic,
+                 request_schema, response_schema, subscription=None):
+        self._backend = backend
+        self._request_topic = request_topic
+        self._response_topic = response_topic
+        self._request_schema = request_schema
+        self._response_schema = response_schema
+        self._subscription = subscription
+        self._client = None
+
+    async def start(self):
+        self._client = await RequestResponseClient.create(
+            backend=self._backend,
+            request_topic=self._request_topic,
+            response_topic=self._response_topic,
+            request_schema=self._request_schema,
+            response_schema=self._response_schema,
+            subscription=self._subscription,
+        )
+
+    async def request(self, message, timeout=60):
+        return await self._client.request(message, timeout=timeout)
+
+    async def stop(self):
+        if self._client:
+            await self._client.close()
+            self._client = None
+
+    async def close(self):
+        await self.stop()

--- a/trustgraph-base/trustgraph/base/audit_publisher.py
+++ b/trustgraph-base/trustgraph/base/audit_publisher.py
@@ -13,17 +13,33 @@ logger = logging.getLogger(__name__)
 
 class AuditPublisher:
 
-    def __init__(self, backend, component_name, processor_id=None):
+    def __init__(self, component_name, processor_id=None, backend=None):
         self.component_name = component_name
-        self.producer = Producer(
-            backend=backend,
-            topic=audit_events_queue,
-            schema=AuditEvent,
-            metrics=ProducerMetrics(
-                processor=processor_id or component_name,
-                producer="audit-events",
-            ),
-        )
+        self._handle = None
+
+        if backend is not None:
+            self._legacy_producer = Producer(
+                backend=backend,
+                topic=audit_events_queue,
+                schema=AuditEvent,
+                metrics=ProducerMetrics(
+                    processor=processor_id or component_name,
+                    producer="audit-events",
+                ),
+            )
+        else:
+            self._legacy_producer = None
+
+    async def start(self, sender_pool=None):
+        if sender_pool is not None:
+            self._handle = await sender_pool.add_producer(
+                topic=audit_events_queue,
+                schema=AuditEvent,
+            )
+
+    async def stop(self):
+        if self._handle:
+            await self._handle.unregister()
 
     async def emit(self, event_type, payload):
         event = AuditEvent(
@@ -36,6 +52,9 @@ class AuditPublisher:
         )
 
         try:
-            await self.producer.send(event)
+            if self._handle:
+                await self._handle.send(event)
+            elif self._legacy_producer:
+                await self._legacy_producer.send(event)
         except Exception as e:
             logger.warning(f"Failed to emit audit event: {e}")

--- a/trustgraph-base/trustgraph/base/consumer_spec.py
+++ b/trustgraph-base/trustgraph/base/consumer_spec.py
@@ -43,3 +43,26 @@ class ConsumerSpec(Spec):
 
         flow.consumer[self.name] = consumer
 
+    async def register(self, flow: Any, processor: Any, definition: dict[str, Any]) -> Any:
+
+        topic = definition["topics"][self.name]
+        subscription = (
+            processor.id + "--" + flow.workspace + "--" +
+            flow.name + "--" + self.name
+        )
+
+        handler = self.handler
+
+        async def pool_handler(message):
+            await handler(message, None, flow)
+
+        reg = await processor.receiver_pool.add_consumer(
+            topic=topic,
+            subscription=subscription,
+            schema=self.schema,
+            handler=pool_handler,
+        )
+
+        flow.consumer[self.name] = reg
+        return reg
+

--- a/trustgraph-base/trustgraph/base/dynamic_tool_service.py
+++ b/trustgraph-base/trustgraph/base/dynamic_tool_service.py
@@ -23,11 +23,7 @@ from prometheus_client import Counter
 from .. schema import ToolServiceRequest, ToolServiceResponse, Error
 from .. exceptions import TooManyRequests
 from . async_processor import AsyncProcessor
-from . consumer import Consumer
-from . producer import Producer
-from . metrics import ConsumerMetrics, ProducerMetrics
 
-# Module logger
 logger = logging.getLogger(__name__)
 
 default_concurrency = 1
@@ -53,41 +49,10 @@ class DynamicToolService(AsyncProcessor):
         super(DynamicToolService, self).__init__(**params)
 
         self.id = params.get("id")
-        topic = params.get("topic", default_topic)
+        self._topic = params.get("topic", default_topic)
 
-        # Build direct Pulsar topic paths
-        request_topic = f"non-persistent://tg/request/{topic}"
-        response_topic = f"non-persistent://tg/response/{topic}"
-
-        logger.info(f"Tool service topics: request={request_topic}, response={response_topic}")
-
-        # Create consumer for requests
-        consumer_metrics = ConsumerMetrics(
-            processor=self.id, consumer="request",
-        )
-
-        self.consumer = Consumer(
-            taskgroup=self.taskgroup,
-            backend=self.pubsub,
-            subscriber=f"{self.id}-request",
-            flow=None,
-            topic=request_topic,
-            schema=ToolServiceRequest,
-            handler=self.on_request,
-            metrics=consumer_metrics,
-        )
-
-        # Create producer for responses
-        producer_metrics = ProducerMetrics(
-            processor=self.id, producer="response",
-        )
-
-        self.producer = Producer(
-            backend=self.pubsub,
-            topic=response_topic,
-            schema=ToolServiceResponse,
-            metrics=producer_metrics,
-        )
+        self._consumer_reg = None
+        self._producer_handle = None
 
         if not hasattr(__class__, "tool_service_metric"):
             __class__.tool_service_metric = Counter(
@@ -98,8 +63,30 @@ class DynamicToolService(AsyncProcessor):
 
     async def start(self):
         await super(DynamicToolService, self).start()
-        await self.producer.start()
-        await self.consumer.start()
+
+        request_topic = f"non-persistent://tg/request/{self._topic}"
+        response_topic = f"non-persistent://tg/response/{self._topic}"
+
+        logger.info(
+            f"Tool service topics: "
+            f"request={request_topic}, response={response_topic}"
+        )
+
+        self._producer_handle = await self.sender_pool.add_producer(
+            topic=response_topic,
+            schema=ToolServiceResponse,
+        )
+
+        async def handler(message):
+            await self.on_request(message, None, None)
+
+        self._consumer_reg = await self.receiver_pool.add_consumer(
+            topic=request_topic,
+            subscription=f"{self.id}-request",
+            schema=ToolServiceRequest,
+            handler=handler,
+        )
+
         logger.info(f"Tool service {self.id} started")
 
     async def on_request(self, msg, consumer, flow):
@@ -110,23 +97,28 @@ class DynamicToolService(AsyncProcessor):
 
             request = msg.value()
 
-            # Sender-produced ID for correlation
             id = msg.properties().get("id", "unknown")
 
-            # Parse the request
             config = json.loads(request.config) if request.config else {}
-            arguments = json.loads(request.arguments) if request.arguments else {}
+            arguments = (
+                json.loads(request.arguments) if request.arguments
+                else {}
+            )
 
-            logger.debug(f"Tool service request: config={config}, arguments={arguments}")
+            logger.debug(
+                f"Tool service request: "
+                f"config={config}, arguments={arguments}"
+            )
 
-            # Invoke the tool implementation
             response = await self.invoke(config, arguments)
 
-            # Send success response
-            await self.producer.send(
+            await self._producer_handle.send(
                 ToolServiceResponse(
                     error=None,
-                    response=response if isinstance(response, str) else json.dumps(response),
+                    response=(
+                        response if isinstance(response, str)
+                        else json.dumps(response)
+                    ),
                     end_of_stream=True,
                 ),
                 properties={"id": id}
@@ -141,11 +133,14 @@ class DynamicToolService(AsyncProcessor):
 
         except Exception as e:
 
-            logger.error(f"Exception in dynamic tool service: {e}", exc_info=True)
+            logger.error(
+                f"Exception in dynamic tool service: {e}",
+                exc_info=True,
+            )
 
             logger.info("Sending error response...")
 
-            await self.producer.send(
+            await self._producer_handle.send(
                 ToolServiceResponse(
                     error=Error(
                         type="tool-service-error",
@@ -158,18 +153,6 @@ class DynamicToolService(AsyncProcessor):
             )
 
     async def invoke(self, config, arguments):
-        """
-        Invoke the tool service.
-
-        Override this method in subclasses to implement the tool's logic.
-
-        Args:
-            config: Dict of config values from the tool descriptor
-            arguments: Dict of arguments from the LLM
-
-        Returns:
-            A string response (the observation) or a dict/list that will be JSON-encoded
-        """
         raise NotImplementedError("Subclasses must implement invoke()")
 
     @staticmethod
@@ -180,5 +163,6 @@ class DynamicToolService(AsyncProcessor):
         parser.add_argument(
             '-t', '--topic',
             default=default_topic,
-            help=f'Topic name for request/response (default: {default_topic})'
+            help=f'Topic name for request/response '
+                 f'(default: {default_topic})'
         )

--- a/trustgraph-base/trustgraph/base/flow.py
+++ b/trustgraph-base/trustgraph/base/flow.py
@@ -1,41 +1,78 @@
 
+import logging
+
+from .consumer_spec import ConsumerSpec
+
+logger = logging.getLogger(__name__)
+
+
 class Flow:
     """
     Runtime representation of a deployed flow process.
 
-    This class maintains internal processor states and orchestrates
-    lifecycles (start, stop) for inputs (consumers) and parameters
-    that drive data flowing across linked nodes.
+    Maintains internal processor states and orchestrates lifecycles
+    (start, stop) for inputs (consumers), outputs (producers),
+    parameters, and service clients.
+
+    Registration is async and uses the processor's ReceiverPool and
+    SenderPool. Producers are registered before consumers so that
+    handlers can send output immediately.
     """
     def __init__(self, id, flow, workspace, processor, defn):
 
         self.id = id
         self.name = flow
         self.workspace = workspace
+        self.processor = processor
+        self.defn = defn
 
         self.producer = {}
-
-        # Consumers and publishers.  Is this a bit untidy?
         self.consumer = {}
-
         self.parameter = {}
 
         self.librarian = None
 
-        for spec in processor.specifications:
-            spec.add(self, processor, defn)
+        self._registrations = []
 
     async def start(self):
+
+        non_consumers = [
+            s for s in self.processor.specifications
+            if not isinstance(s, ConsumerSpec)
+        ]
+        consumers = [
+            s for s in self.processor.specifications
+            if isinstance(s, ConsumerSpec)
+        ]
+
+        for spec in non_consumers:
+            reg = await spec.register(self, self.processor, self.defn)
+            if reg:
+                self._registrations.append(reg)
+
         if self.librarian:
             await self.librarian.start()
-        for c in self.consumer.values():
-            await c.start()
+
+        for spec in consumers:
+            reg = await spec.register(self, self.processor, self.defn)
+            if reg:
+                self._registrations.append(reg)
 
     async def stop(self):
-        for c in self.consumer.values():
-            await c.stop()
-        for p in self.producer.values():
-            await p.stop()
+
+        for reg in self._registrations:
+            try:
+                if hasattr(reg, 'unregister'):
+                    await reg.unregister()
+                elif hasattr(reg, 'close'):
+                    await reg.close()
+                elif hasattr(reg, 'stop'):
+                    await reg.stop()
+            except BaseException as e:
+                logger.warning(f"Error unregistering: {e}")
+
+        self._registrations.clear()
+
         if self.librarian:
             await self.librarian.stop()
 

--- a/trustgraph-base/trustgraph/base/librarian_spec.py
+++ b/trustgraph-base/trustgraph/base/librarian_spec.py
@@ -30,3 +30,22 @@ class LibrarianSpec(Spec):
         )
 
         flow.librarian = client
+
+    async def register(self, flow: Any, processor: Any, definition: dict[str, Any]) -> Any:
+
+        from .async_librarian_client import AsyncLibrarianClient
+
+        subscription = (
+            processor.id + "--" + flow.workspace + "--" +
+            flow.name + "--librarian--" + str(uuid.uuid4())
+        )
+
+        client = await AsyncLibrarianClient.create(
+            backend=processor.async_backend,
+            request_topic=definition["topics"][self.request_name],
+            response_topic=definition["topics"][self.response_name],
+            subscription=subscription,
+        )
+
+        flow.librarian = client
+        return client

--- a/trustgraph-base/trustgraph/base/processor_group.py
+++ b/trustgraph-base/trustgraph/base/processor_group.py
@@ -73,6 +73,8 @@ async def _supervise(entry):
 
     while True:
 
+        p = None
+
         try:
 
             async with asyncio.TaskGroup() as inner_tg:
@@ -105,11 +107,18 @@ async def _supervise(entry):
                     exc_info=e,
                 )
 
-        except Exception as e:
+        except BaseException as e:
             logger.error(
                 f"Processor {pid} failure: {type(e).__name__}: {e}",
                 exc_info=True,
             )
+
+        finally:
+            if p:
+                try:
+                    await p.stop()
+                except BaseException:
+                    pass
 
         logger.info(
             f"Restarting {pid} in {RESTART_DELAY_SECONDS}s..."
@@ -189,13 +198,13 @@ def run():
             logger.info("Keyboard interrupt.")
             return
 
-        except ExceptionGroup as e:
+        except BaseExceptionGroup as e:
             logger.error("Exception group:")
             for se in e.exceptions:
                 logger.error(f"  Type: {type(se)}")
                 logger.error(f"  Exception: {se}", exc_info=se)
 
-        except Exception as e:
+        except BaseException as e:
             logger.error(f"Type: {type(e)}")
             logger.error(f"Exception: {e}", exc_info=True)
 

--- a/trustgraph-base/trustgraph/base/producer_spec.py
+++ b/trustgraph-base/trustgraph/base/producer_spec.py
@@ -26,3 +26,15 @@ class ProducerSpec(Spec):
         )
 
         flow.producer[self.name] = producer
+
+    async def register(self, flow: Any, processor: Any, definition: dict[str, Any]) -> Any:
+
+        topic = definition["topics"][self.name]
+
+        handle = await processor.sender_pool.add_producer(
+            topic=topic,
+            schema=self.schema,
+        )
+
+        flow.producer[self.name] = handle
+        return handle

--- a/trustgraph-base/trustgraph/base/pubsub.py
+++ b/trustgraph-base/trustgraph/base/pubsub.py
@@ -25,6 +25,30 @@ DEFAULT_KAFKA_SASL_USERNAME = os.getenv("KAFKA_SASL_USERNAME", None)
 DEFAULT_KAFKA_SASL_PASSWORD = os.getenv("KAFKA_SASL_PASSWORD", None)
 
 
+def get_async_pubsub(**config: Any) -> Any:
+    """
+    Factory function to create an async pub/sub backend.
+
+    Currently only Pulsar is supported. RabbitMQ and Kafka async
+    backends are not yet implemented.
+    """
+    backend_type = config.get('pubsub_backend', 'pulsar')
+
+    if backend_type == 'pulsar':
+        from .async_pulsar_backend import AsyncPulsarBackend
+        return AsyncPulsarBackend(
+            host=config.get('pulsar_host', DEFAULT_PULSAR_HOST),
+            api_key=config.get('pulsar_api_key', DEFAULT_PULSAR_API_KEY),
+            listener=config.get('pulsar_listener'),
+            admin_url=config.get('pulsar_admin_url', DEFAULT_PULSAR_ADMIN_URL),
+        )
+    else:
+        raise ValueError(
+            f"Async backend not yet supported for: {backend_type}. "
+            f"Only 'pulsar' is currently supported."
+        )
+
+
 def get_pubsub(**config: Any) -> Any:
     """
     Factory function to create a pub/sub backend based on configuration.

--- a/trustgraph-base/trustgraph/base/receiver_pool.py
+++ b/trustgraph-base/trustgraph/base/receiver_pool.py
@@ -1,0 +1,270 @@
+"""
+ReceiverPool — async consumer runtime for the producer/consumer
+message pattern.
+
+Manages broker subscriptions, receiver coroutines, a shared work
+queue, and a pool of worker coroutines. All pub/sub communication
+stays in the receiver coroutines; workers only process messages and
+signal completion via futures.
+"""
+
+import asyncio
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Callable, Awaitable
+
+from .async_backend import AsyncPubSubBackend, AsyncBackendConsumer, Message
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ConsumerRegistration:
+    """Handle returned by add_consumer, used to remove it later."""
+    topic: str
+    subscription: str
+    backend_consumer: AsyncBackendConsumer
+    receiver_task: asyncio.Task
+    pool: 'ReceiverPool'
+
+    async def unregister(self):
+        await self.pool.remove_consumer(self)
+
+
+@dataclass
+class WorkItem:
+    """Item placed on the work queue for worker dispatch."""
+    message: Message
+    handler: Callable[..., Awaitable[None]]
+    future: asyncio.Future
+
+
+class ReceiverPool:
+    """Manages async consumer receive loops and a worker pool.
+
+    Usage:
+        pool = ReceiverPool(backend=backend, concurrency=4)
+        await pool.start()
+
+        reg = await pool.add_consumer(
+            topic="flow:tg:request:ws1:default",
+            subscription="my-processor",
+            schema=MyRequest,
+            handler=self.on_request,
+        )
+
+        # ... later ...
+        await reg.unregister()
+        await pool.stop()
+    """
+
+    def __init__(self, backend: AsyncPubSubBackend, concurrency: int = 1):
+        self.backend = backend
+        self.concurrency = concurrency
+        self.work_queue = asyncio.Queue(maxsize=concurrency)
+        self.registrations: list[ConsumerRegistration] = []
+        self.worker_tasks: list[asyncio.Task] = []
+        self.running = False
+
+    async def start(self):
+        self.running = True
+        for i in range(self.concurrency):
+            task = asyncio.create_task(
+                self._worker(i), name=f"worker-{i}",
+            )
+            self.worker_tasks.append(task)
+        logger.info(
+            f"ReceiverPool started with {self.concurrency} workers"
+        )
+
+    async def stop(self, drain_timeout: float = 5.0):
+        self.running = False
+
+        for reg in list(self.registrations):
+            try:
+                await reg.backend_consumer.close()
+            except BaseException as e:
+                logger.warning(f"Error closing consumer: {e}")
+
+        for reg in list(self.registrations):
+            reg.receiver_task.cancel()
+        for reg in list(self.registrations):
+            try:
+                await reg.receiver_task
+            except BaseException:
+                pass
+        self.registrations.clear()
+
+        if not self.work_queue.empty():
+            logger.info(
+                f"Draining {self.work_queue.qsize()} pending work items"
+            )
+            try:
+                await asyncio.wait_for(
+                    self._drain_work_queue(), timeout=drain_timeout,
+                )
+            except asyncio.TimeoutError:
+                logger.warning(
+                    f"Drain timeout, {self.work_queue.qsize()} items "
+                    f"remaining"
+                )
+
+        for task in self.worker_tasks:
+            task.cancel()
+        for task in self.worker_tasks:
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+        self.worker_tasks.clear()
+
+        logger.info("ReceiverPool stopped")
+
+    async def _drain_work_queue(self):
+        while not self.work_queue.empty():
+            await asyncio.sleep(0.1)
+
+    async def add_consumer(
+        self, topic: str, subscription: str, schema: type,
+        handler: Callable[..., Awaitable[None]],
+        initial_position: str = 'latest',
+    ) -> ConsumerRegistration:
+        backend_consumer = await self.backend.create_consumer(
+            topic=topic,
+            subscription=subscription,
+            schema=schema,
+            initial_position=initial_position,
+        )
+
+        receiver_task = asyncio.create_task(
+            self._receiver_loop(backend_consumer, handler),
+            name=f"receiver-{topic}",
+        )
+
+        reg = ConsumerRegistration(
+            topic=topic,
+            subscription=subscription,
+            backend_consumer=backend_consumer,
+            receiver_task=receiver_task,
+            pool=self,
+        )
+        self.registrations.append(reg)
+
+        logger.info(f"Added consumer: {topic}")
+        return reg
+
+    async def remove_consumer(self, reg: ConsumerRegistration):
+        try:
+            await reg.backend_consumer.close()
+        except BaseException as e:
+            logger.warning(f"Error closing consumer for {reg.topic}: {e}")
+
+        reg.receiver_task.cancel()
+        try:
+            await reg.receiver_task
+        except (asyncio.CancelledError, Exception):
+            pass
+
+        if reg in self.registrations:
+            self.registrations.remove(reg)
+
+        logger.info(f"Removed consumer: {reg.topic}")
+
+    async def _receiver_loop(
+        self, backend_consumer: AsyncBackendConsumer,
+        handler: Callable[..., Awaitable[None]],
+    ):
+        pending_acks: set[asyncio.Task] = set()
+
+        try:
+            receive_task = asyncio.create_task(backend_consumer.receive())
+
+            while self.running:
+                wait_set = {receive_task} | pending_acks
+                done, _ = await asyncio.wait(
+                    wait_set,
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
+
+                for task in done:
+                    if task is receive_task:
+                        msg = task.result()
+                        future = asyncio.get_event_loop().create_future()
+                        await self.work_queue.put(
+                            WorkItem(
+                                message=msg,
+                                handler=handler,
+                                future=future,
+                            )
+                        )
+
+                        ack_task = asyncio.create_task(
+                            self._await_and_ack(
+                                future, msg, backend_consumer,
+                            )
+                        )
+                        pending_acks.add(ack_task)
+
+                        receive_task = asyncio.create_task(
+                            backend_consumer.receive()
+                        )
+                    else:
+                        pending_acks.discard(task)
+                        try:
+                            task.result()
+                        except BaseException as e:
+                            logger.error(
+                                f"Ack task error: {e}", exc_info=True,
+                            )
+
+        except asyncio.CancelledError:
+            receive_task.cancel()
+            for task in pending_acks:
+                task.cancel()
+            raise
+        except BaseException as e:
+            if not self.running:
+                return
+            logger.error(
+                f"Receiver loop error: {e}", exc_info=True,
+            )
+
+    async def _await_and_ack(
+        self, future: asyncio.Future, msg: Message,
+        consumer: AsyncBackendConsumer,
+    ):
+        try:
+            await future
+            await consumer.acknowledge(msg)
+        except asyncio.CancelledError:
+            raise
+        except BaseException:
+            try:
+                await consumer.negative_acknowledge(msg)
+            except BaseException:
+                pass
+
+    async def _worker(self, worker_id: int):
+        logger.debug(f"Worker {worker_id} started")
+
+        try:
+            while self.running:
+                try:
+                    item = await asyncio.wait_for(
+                        self.work_queue.get(), timeout=1.0,
+                    )
+                except asyncio.TimeoutError:
+                    continue
+
+                try:
+                    await item.handler(item.message)
+                    item.future.set_result(None)
+                except asyncio.CancelledError:
+                    raise
+                except BaseException as e:
+                    item.future.set_exception(e)
+
+        except asyncio.CancelledError:
+            pass
+
+        logger.debug(f"Worker {worker_id} stopped")

--- a/trustgraph-base/trustgraph/base/request_response_client.py
+++ b/trustgraph-base/trustgraph/base/request_response_client.py
@@ -1,0 +1,182 @@
+"""
+RequestResponseClient — async request/response over pub/sub.
+
+Manages a producer for requests, a consumer for responses, and a
+dedicated receiver coroutine that routes responses to waiting callers
+via futures. No worker pool involvement.
+"""
+
+import asyncio
+import logging
+import uuid
+from typing import Any
+
+from .async_backend import AsyncPubSubBackend
+
+logger = logging.getLogger(__name__)
+
+
+class RequestResponseClient:
+    """Async request/response client over pub/sub.
+
+    Usage:
+        client = await RequestResponseClient.create(
+            backend=backend,
+            request_topic="request:tg:triples:ws1:default",
+            response_topic="response:tg:triples:ws1:default",
+            request_schema=TriplesRequest,
+            response_schema=TriplesResponse,
+        )
+
+        response = await client.request(my_request, timeout=60)
+
+        await client.close()
+    """
+
+    def __init__(self):
+        self.producer = None
+        self.consumer = None
+        self.receiver_task = None
+        self.pending: dict[str, asyncio.Future] = {}
+        self.running = False
+
+    @classmethod
+    async def create(
+        cls,
+        backend: AsyncPubSubBackend,
+        request_topic: str,
+        response_topic: str,
+        request_schema: type,
+        response_schema: type,
+        subscription: str | None = None,
+    ) -> 'RequestResponseClient':
+        client = cls()
+
+        client.producer = await backend.create_producer(
+            topic=request_topic,
+            schema=request_schema,
+        )
+
+        if subscription is None:
+            subscription = f"rr-{uuid.uuid4().hex[:12]}"
+
+        client.consumer = await backend.create_consumer(
+            topic=response_topic,
+            subscription=subscription,
+            schema=response_schema,
+            initial_position='latest',
+        )
+
+        client.running = True
+        client.receiver_task = asyncio.create_task(
+            client._response_loop(),
+            name=f"rr-receiver-{response_topic}",
+        )
+
+        logger.info(
+            f"RequestResponseClient created: "
+            f"req={request_topic}, resp={response_topic}"
+        )
+        return client
+
+    async def request(
+        self, message: Any, timeout: float = 60,
+        properties: dict | None = None,
+    ) -> Any:
+        request_id = str(uuid.uuid4())
+        future = asyncio.get_event_loop().create_future()
+        self.pending[request_id] = future
+
+        send_properties = {"id": request_id}
+        if properties:
+            send_properties.update(properties)
+
+        await self.producer.send(message, send_properties)
+
+        try:
+            return await asyncio.wait_for(future, timeout=timeout)
+        except asyncio.TimeoutError:
+            self.pending.pop(request_id, None)
+            raise
+
+    async def request_stream(
+        self, message: Any, timeout: float = 300,
+        properties: dict | None = None,
+    ):
+        request_id = str(uuid.uuid4())
+        queue = asyncio.Queue()
+        self.pending[request_id] = queue
+
+        send_properties = {"id": request_id}
+        if properties:
+            send_properties.update(properties)
+
+        await self.producer.send(message, send_properties)
+
+        try:
+            while True:
+                resp = await asyncio.wait_for(
+                    queue.get(), timeout=timeout,
+                )
+                yield resp
+        except asyncio.TimeoutError:
+            raise
+        finally:
+            self.pending.pop(request_id, None)
+
+    async def _response_loop(self):
+        try:
+            while self.running:
+                msg = await self.consumer.receive()
+                request_id = msg.properties().get("id")
+
+                if request_id is not None:
+                    target = self.pending.get(request_id)
+                    if target is None:
+                        pass
+                    elif isinstance(target, asyncio.Future):
+                        self.pending.pop(request_id, None)
+                        if not target.done():
+                            target.set_result(msg.value())
+                    elif isinstance(target, asyncio.Queue):
+                        await target.put(msg.value())
+
+                await self.consumer.acknowledge(msg)
+
+        except asyncio.CancelledError:
+            raise
+        except BaseException as e:
+            if not self.running:
+                return
+            logger.error(
+                f"Response loop error: {e}", exc_info=True,
+            )
+
+    async def close(self):
+        self.running = False
+
+        if self.consumer:
+            try:
+                await self.consumer.close()
+            except Exception as e:
+                logger.warning(f"Error closing consumer: {e}")
+
+        if self.receiver_task:
+            self.receiver_task.cancel()
+            try:
+                await self.receiver_task
+            except BaseException:
+                pass
+
+        for future in self.pending.values():
+            if not future.done():
+                future.cancel()
+        self.pending.clear()
+
+        if self.producer:
+            try:
+                await self.producer.close()
+            except Exception as e:
+                logger.warning(f"Error closing producer: {e}")
+
+        logger.info("RequestResponseClient closed")

--- a/trustgraph-base/trustgraph/base/request_response_spec.py
+++ b/trustgraph-base/trustgraph/base/request_response_spec.py
@@ -162,3 +162,54 @@ class RequestResponseSpec(Spec):
 
         flow.consumer[self.request_name] = rr
 
+    async def register(self, flow: Any, processor: Any, definition: dict[str, Any]) -> Any:
+
+        from .request_response_client import RequestResponseClient
+
+        topics = definition.get("topics", {})
+        if self.optional and (
+                self.request_name not in topics
+                or self.response_name not in topics):
+            return None
+
+        rr_client = await RequestResponseClient.create(
+            backend=processor.async_backend,
+            request_topic=topics[self.request_name],
+            response_topic=topics[self.response_name],
+            request_schema=self.request_schema,
+            response_schema=self.response_schema,
+        )
+
+        wrapper = _make_impl_wrapper(rr_client, self.impl)
+        flow.consumer[self.request_name] = wrapper
+        return wrapper
+
+
+def _make_impl_wrapper(rr_client, impl_cls):
+    """Create a domain-specific wrapper that delegates request() to the
+    RequestResponseClient while inheriting business methods from impl_cls."""
+
+    class Wrapper(impl_cls):
+        def __init__(self):
+            self._rr_client = rr_client
+
+        async def request(self, req, timeout=300, recipient=None):
+            if recipient is None:
+                return await self._rr_client.request(req, timeout=timeout)
+
+            async for resp in self._rr_client.request_stream(req, timeout=timeout):
+                fin = await recipient(resp)
+                if fin:
+                    return resp
+
+        async def start(self):
+            pass
+
+        async def stop(self):
+            await self._rr_client.close()
+
+        async def close(self):
+            await self._rr_client.close()
+
+    return Wrapper()
+

--- a/trustgraph-base/trustgraph/base/sender_pool.py
+++ b/trustgraph-base/trustgraph/base/sender_pool.py
@@ -1,0 +1,205 @@
+"""
+SenderPool — async producer runtime for the producer/consumer
+message pattern.
+
+Manages broker producers, send queues, and a sender task that
+dispatches messages to backend producers. Decouples application
+send calls from broker I/O.
+"""
+
+import asyncio
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+from .async_backend import AsyncPubSubBackend, AsyncBackendProducer
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class SendItem:
+    """Item placed on the send queue for dispatch."""
+    message: Any
+    properties: dict
+    future: asyncio.Future | None
+
+
+class ProducerHandle:
+    """Handle returned by add_producer, used to send messages."""
+
+    def __init__(
+        self, topic: str, backend_producer: AsyncBackendProducer,
+        send_queue: asyncio.Queue, pool: 'SenderPool',
+    ):
+        self.topic = topic
+        self.backend_producer = backend_producer
+        self.send_queue = send_queue
+        self.pool = pool
+
+    async def send(
+        self, message: Any, properties: dict = {}, wait: bool = False,
+    ):
+        if wait:
+            future = asyncio.get_event_loop().create_future()
+        else:
+            future = None
+
+        await self.send_queue.put(
+            SendItem(message=message, properties=properties, future=future)
+        )
+
+        if future is not None:
+            await future
+
+    async def unregister(self):
+        await self.pool.remove_producer(self)
+
+
+class SenderPool:
+    """Manages async producer send dispatch.
+
+    Usage:
+        pool = SenderPool(backend=backend)
+        await pool.start()
+
+        handle = await pool.add_producer(
+            topic="flow:tg:text-completion-response:ws1:default",
+            schema=TextCompletionResponse,
+        )
+        await handle.send(message, properties={"id": req_id})
+
+        await handle.unregister()
+        await pool.stop()
+    """
+
+    def __init__(
+        self, backend: AsyncPubSubBackend, send_queue_size: int = 64,
+    ):
+        self.backend = backend
+        self.send_queue_size = send_queue_size
+        self.handles: list[ProducerHandle] = []
+        self.sender_task: asyncio.Task | None = None
+        self.running = False
+
+    async def start(self):
+        self.running = True
+        self.sender_task = asyncio.create_task(
+            self._sender_loop(), name="sender-pool",
+        )
+        logger.info("SenderPool started")
+
+    async def stop(self, drain_timeout: float = 5.0):
+        self.running = False
+
+        if self.handles:
+            try:
+                await asyncio.wait_for(
+                    self._drain_all(), timeout=drain_timeout,
+                )
+            except asyncio.TimeoutError:
+                logger.warning("Drain timeout, some messages not sent")
+
+        if self.sender_task:
+            self.sender_task.cancel()
+            try:
+                await self.sender_task
+            except asyncio.CancelledError:
+                pass
+            self.sender_task = None
+
+        for handle in list(self.handles):
+            try:
+                await handle.backend_producer.close()
+            except BaseException as e:
+                logger.warning(f"Error closing producer: {e}")
+        self.handles.clear()
+
+        logger.info("SenderPool stopped")
+
+    async def _drain_all(self):
+        while any(not h.send_queue.empty() for h in self.handles):
+            await asyncio.sleep(0.1)
+
+    async def add_producer(
+        self, topic: str, schema: type, **options,
+    ) -> ProducerHandle:
+        backend_producer = await self.backend.create_producer(
+            topic=topic, schema=schema, **options,
+        )
+
+        send_queue = asyncio.Queue(maxsize=self.send_queue_size)
+
+        handle = ProducerHandle(
+            topic=topic,
+            backend_producer=backend_producer,
+            send_queue=send_queue,
+            pool=self,
+        )
+        self.handles.append(handle)
+
+        logger.info(f"Added producer: {topic}")
+        return handle
+
+    async def remove_producer(self, handle: ProducerHandle):
+        while not handle.send_queue.empty():
+            await asyncio.sleep(0.05)
+
+        try:
+            await handle.backend_producer.close()
+        except BaseException as e:
+            logger.warning(
+                f"Error closing producer for {handle.topic}: {e}"
+            )
+
+        if handle in self.handles:
+            self.handles.remove(handle)
+
+        logger.info(f"Removed producer: {handle.topic}")
+
+    async def _sender_loop(self):
+        try:
+            while self.running:
+                if not self.handles:
+                    await asyncio.sleep(0.1)
+                    continue
+
+                queues = {
+                    asyncio.create_task(h.send_queue.get()): h
+                    for h in self.handles
+                    if not h.send_queue.empty()
+                }
+
+                if not queues:
+                    await asyncio.sleep(0.01)
+                    continue
+
+                done, pending = await asyncio.wait(
+                    queues.keys(),
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
+
+                for task in pending:
+                    task.cancel()
+
+                for task in done:
+                    handle = queues[task]
+                    try:
+                        item: SendItem = task.result()
+                        await handle.backend_producer.send(
+                            item.message, item.properties,
+                        )
+                        if item.future is not None:
+                            item.future.set_result(None)
+                    except asyncio.CancelledError:
+                        raise
+                    except BaseException as e:
+                        logger.error(
+                            f"Send error for {handle.topic}: {e}",
+                            exc_info=True,
+                        )
+                        if item.future is not None:
+                            item.future.set_exception(e)
+
+        except asyncio.CancelledError:
+            pass

--- a/trustgraph-base/trustgraph/base/spec.py
+++ b/trustgraph-base/trustgraph/base/spec.py
@@ -1,4 +1,9 @@
 
 class Spec:
-    pass
 
+    async def register(self, flow, processor, definition):
+        self.add(flow, processor, definition)
+        return None
+
+    def add(self, flow, processor, definition):
+        pass

--- a/trustgraph-base/trustgraph/base/workspace_processor.py
+++ b/trustgraph-base/trustgraph/base/workspace_processor.py
@@ -23,9 +23,8 @@ class WorkspaceProcessor(AsyncProcessor):
         self.register_workspace_handler(self._handle_workspace_changes)
 
     async def _discover_workspaces(self):
-        client = self._create_config_client()
+        client = await self._create_config_client()
         try:
-            await client.start()
             type_data, version = await self._fetch_type_all_workspaces(
                 client, WORKSPACE_TYPE,
             )
@@ -36,7 +35,7 @@ class WorkspaceProcessor(AsyncProcessor):
                             self.active_workspaces.add(workspace_id)
                             await self.on_workspace_created(workspace_id)
         finally:
-            await client.stop()
+            await client.close()
 
     async def _handle_workspace_changes(self, workspace_changes):
         for workspace_id in workspace_changes.created:

--- a/trustgraph-flow/trustgraph/bootstrap/bootstrapper/service.py
+++ b/trustgraph-flow/trustgraph/bootstrap/bootstrapper/service.py
@@ -17,9 +17,8 @@ from argparse import ArgumentParser
 from dataclasses import dataclass
 
 from trustgraph.base import AsyncProcessor
-from trustgraph.base import ProducerMetrics, SubscriberMetrics
-from trustgraph.base.config_client import ConfigClient
-from trustgraph.base.request_response_spec import RequestResponse
+from trustgraph.base.async_config_client import AsyncConfigClient
+from trustgraph.base.async_rr_wrapper import AsyncRequestResponseWrapper
 from trustgraph.schema import (
     ConfigRequest, ConfigResponse,
     config_request_queue, config_response_queue,
@@ -164,68 +163,40 @@ class Processor(AsyncProcessor):
     # Client construction (short-lived per wake cycle).
     # ------------------------------------------------------------------
 
-    def _make_config_client(self):
-        rr_id = str(uuid.uuid4())
-        return ConfigClient(
-            backend=self.pubsub_backend,
-            subscription=f"{self.id}--config--{rr_id}",
-            consumer_name=self.id,
+    async def _make_config_client(self):
+        return await AsyncConfigClient.create(
+            backend=self.async_backend,
             request_topic=config_request_queue,
-            request_schema=ConfigRequest,
-            request_metrics=ProducerMetrics(
-                processor=self.id, producer="config-request",
-            ),
             response_topic=config_response_queue,
-            response_schema=ConfigResponse,
-            response_metrics=SubscriberMetrics(
-                processor=self.id, subscriber="config-response",
-            ),
+            subscription=f"{self.id}--config--{uuid.uuid4()}",
         )
 
     def _make_flow_client(self, workspace):
-        rr_id = str(uuid.uuid4())
-        return RequestResponse(
-            backend=self.pubsub_backend,
-            subscription=f"{self.id}--flow--{rr_id}",
-            consumer_name=self.id,
+        return AsyncRequestResponseWrapper(
+            backend=self.async_backend,
             request_topic=f"{flow_request_queue}:{workspace}",
-            request_schema=FlowRequest,
-            request_metrics=ProducerMetrics(
-                processor=self.id, producer="flow-request",
-            ),
             response_topic=f"{flow_response_queue}:{workspace}",
+            request_schema=FlowRequest,
             response_schema=FlowResponse,
-            response_metrics=SubscriberMetrics(
-                processor=self.id, subscriber="flow-response",
-            ),
+            subscription=f"{self.id}--flow--{uuid.uuid4()}",
         )
 
     def _make_iam_client(self):
-        rr_id = str(uuid.uuid4())
-        return RequestResponse(
-            backend=self.pubsub_backend,
-            subscription=f"{self.id}--iam--{rr_id}",
-            consumer_name=self.id,
+        return AsyncRequestResponseWrapper(
+            backend=self.async_backend,
             request_topic=iam_request_queue,
-            request_schema=IamRequest,
-            request_metrics=ProducerMetrics(
-                processor=self.id, producer="iam-request",
-            ),
             response_topic=iam_response_queue,
+            request_schema=IamRequest,
             response_schema=IamResponse,
-            response_metrics=SubscriberMetrics(
-                processor=self.id, subscriber="iam-response",
-            ),
+            subscription=f"{self.id}--iam--{uuid.uuid4()}",
         )
 
     async def _open_clients(self):
-        config = self._make_config_client()
-        await config.start()
-        return config
+        return await self._make_config_client()
 
     async def _safe_stop(self, client):
         try:
-            await client.stop()
+            await client.close()
         except Exception:
             pass
 

--- a/trustgraph-flow/trustgraph/config/service/service.py
+++ b/trustgraph-flow/trustgraph/config/service/service.py
@@ -21,13 +21,12 @@ from trustgraph.schema import WorkspaceChanges
 from trustgraph.schema import config_request_queue, config_response_queue
 from trustgraph.schema import config_push_queue
 
-from trustgraph.base import AsyncProcessor, Consumer, Producer
+from trustgraph.base import AsyncProcessor
 from trustgraph.base.cassandra_config import add_cassandra_args, resolve_cassandra_config
 
 from . config import Configuration, WORKSPACES_NAMESPACE, WORKSPACE_TYPE
 
 from ... base import ProcessorMetrics, ConsumerMetrics, ProducerMetrics
-from ... base import Consumer, Producer
 
 # Module logger
 logger = logging.getLogger(__name__)
@@ -70,7 +69,7 @@ class Processor(AsyncProcessor):
         self.config_response_queue_base = params.get(
             "config_response_queue", default_config_response_queue
         )
-        config_push_queue = params.get(
+        self.config_push_queue_name = params.get(
             "config_push_queue", default_config_push_queue
         )
 
@@ -105,43 +104,9 @@ class Processor(AsyncProcessor):
             }
         )
 
-        config_request_metrics = ConsumerMetrics(
-            processor=self.id, consumer="config-request",
-        )
-        config_response_metrics = ProducerMetrics(
-            processor=self.id, producer="config-response",
-        )
-        config_push_metrics = ProducerMetrics(
-            processor=self.id, producer="config-push",
-        )
-
+        # Store queue names and schemas for pool registration in start()
         self.config_request_queue_base = config_request_queue
         self.config_request_subscriber = id
-
-        self.system_consumer = Consumer(
-            taskgroup = self.taskgroup,
-            backend = self.pubsub,
-            flow = None,
-            topic = config_request_queue,
-            subscriber = id,
-            schema = ConfigRequest,
-            handler = self.on_system_config_request,
-            metrics = config_request_metrics,
-        )
-
-        self.config_response_producer = Producer(
-            backend = self.pubsub,
-            topic = self.config_response_queue_base,
-            schema = ConfigResponse,
-            metrics = config_response_metrics,
-        )
-
-        self.config_push_producer = Producer(
-            backend = self.pubsub,
-            topic = config_push_queue,
-            schema = ConfigPush,
-            metrics = config_push_metrics,
-        )
 
         self.config = Configuration(
             host = self.cassandra_host,
@@ -217,42 +182,32 @@ class Processor(AsyncProcessor):
             self.config_response_queue_base, workspace_id,
         )
 
-        await self.pubsub.ensure_topic(req_queue)
-        await self.pubsub.ensure_topic(resp_queue)
+        await self.async_backend.ensure_topic(req_queue)
+        await self.async_backend.ensure_topic(resp_queue)
 
-        response_producer = Producer(
-            backend=self.pubsub,
+        response_handle = await self.sender_pool.add_producer(
             topic=resp_queue,
             schema=ConfigResponse,
-            metrics=ProducerMetrics(
-                processor=self.id, producer="config-response",
-                workspace=workspace_id,
-            ),
         )
 
-        consumer = Consumer(
-            taskgroup=self.taskgroup,
-            backend=self.pubsub,
-            flow=None,
+        handler = partial(
+            self.on_workspace_config_request,
+            workspace=workspace_id,
+        )
+
+        async def wrapper(message):
+            await handler(message, None, None)
+
+        consumer_reg = await self.receiver_pool.add_consumer(
             topic=req_queue,
-            subscriber=self.id,
+            subscription=self.id,
             schema=ConfigRequest,
-            handler=partial(
-                self.on_workspace_config_request,
-                workspace=workspace_id,
-            ),
-            metrics=ConsumerMetrics(
-                processor=self.id, consumer="config-request",
-                workspace=workspace_id,
-            ),
+            handler=wrapper,
         )
-
-        await response_producer.start()
-        await consumer.start()
 
         self.workspace_consumers[workspace_id] = {
-            "consumer": consumer,
-            "response": response_producer,
+            "consumer": consumer_reg,
+            "response": response_handle,
         }
 
         logger.info(
@@ -262,22 +217,55 @@ class Processor(AsyncProcessor):
     async def _remove_workspace_consumer(self, workspace_id):
         clients = self.workspace_consumers.pop(workspace_id, None)
         if clients:
-            for client in clients.values():
-                await client.stop()
+            await clients["consumer"].unregister()
+            await clients["response"].unregister()
             logger.info(
                 f"Unsubscribed from workspace config queue: {workspace_id}"
             )
 
     async def start(self):
 
-        await self.pubsub.ensure_topic(self.config_request_queue_base)
-        await self.config_response_producer.start()
+        # Start the pools since we don't call super().start()
+        await self.receiver_pool.start()
+        await self.sender_pool.start()
+
+        await self.async_backend.ensure_topic(self.config_request_queue_base)
+
+        # Create system-level producers via sender_pool
+        self.config_response_handle = await self.sender_pool.add_producer(
+            topic=self.config_response_queue_base,
+            schema=ConfigResponse,
+        )
+
+        self.config_push_handle = await self.sender_pool.add_producer(
+            topic=self.config_push_queue_name,
+            schema=ConfigPush,
+        )
+
         await self.push()  # Startup poke: empty types = everything
-        await self.system_consumer.start()
+
+        # Create system consumer via receiver_pool
+        async def system_handler_wrapper(message):
+            await self.on_system_config_request(message, None, None)
+
+        self._system_consumer_reg = await self.receiver_pool.add_consumer(
+            topic=self.config_request_queue_base,
+            subscription=self.id,
+            schema=ConfigRequest,
+            handler=system_handler_wrapper,
+        )
 
         # Start the config push subscriber so we receive our own
         # workspace change notifications.
-        await self.config_sub_task.start()
+        async def config_notify_wrapper(message):
+            await self.on_config_notify(message, None, None)
+
+        self._config_sub_reg = await self.receiver_pool.add_consumer(
+            topic=self.config_push_queue,
+            subscription=self.id,
+            schema=ConfigPush,
+            handler=config_notify_wrapper,
+        )
 
         await self._discover_workspaces()
 
@@ -306,7 +294,7 @@ class Processor(AsyncProcessor):
             workspace_changes = workspace_changes,
         )
 
-        await self.config_push_producer.send(resp)
+        await self.config_push_handle.send(resp)
 
         logger.info(
             f"Pushed config poke version {version}, "
@@ -330,11 +318,11 @@ class Processor(AsyncProcessor):
                 f"workspace={workspace}..."
             )
 
-            producer = self.workspace_consumers[workspace]["response"]
+            handle = self.workspace_consumers[workspace]["response"]
 
             resp = await self.config.handle_workspace(v, workspace)
 
-            await producer.send(
+            await handle.send(
                 resp, properties={"id": id}
             )
 
@@ -347,7 +335,7 @@ class Processor(AsyncProcessor):
                 ),
             )
 
-            await producer.send(
+            await handle.send(
                 resp, properties={"id": id}
             )
 
@@ -364,7 +352,7 @@ class Processor(AsyncProcessor):
 
             resp = await self.config.handle_system(v)
 
-            await self.config_response_producer.send(
+            await self.config_response_handle.send(
                 resp, properties={"id": id}
             )
 
@@ -377,7 +365,7 @@ class Processor(AsyncProcessor):
                 ),
             )
 
-            await self.config_response_producer.send(
+            await self.config_response_handle.send(
                 resp, properties={"id": id}
             )
 

--- a/trustgraph-flow/trustgraph/cores/service.py
+++ b/trustgraph-flow/trustgraph/cores/service.py
@@ -9,10 +9,9 @@ import base64
 import json
 import logging
 
-from .. base import WorkspaceProcessor, Consumer, Producer, Publisher, Subscriber
+from .. base import WorkspaceProcessor, AsyncLibrarianClient
 from .. base import ConsumerMetrics, ProducerMetrics
 from .. base.cassandra_config import add_cassandra_args, resolve_cassandra_config
-from .. base import LibrarianClient
 
 from .. schema import KnowledgeRequest, KnowledgeResponse, Error
 from .. schema import knowledge_request_queue, knowledge_response_queue
@@ -112,59 +111,42 @@ class Processor(WorkspaceProcessor):
             self.knowledge_response_queue_base, workspace,
         )
 
-        await self.pubsub.ensure_topic(req_queue)
-        await self.pubsub.ensure_topic(resp_queue)
+        await self.async_backend.ensure_topic(req_queue)
+        await self.async_backend.ensure_topic(resp_queue)
 
-        response_producer = Producer(
-            backend=self.pubsub,
+        response_handle = await self.sender_pool.add_producer(
             topic=resp_queue,
             schema=KnowledgeResponse,
-            metrics=ProducerMetrics(
-                processor=self.id, producer="knowledge-response",
-                workspace=workspace,
-            ),
         )
 
-        consumer = Consumer(
-            taskgroup=self.taskgroup,
-            backend=self.pubsub,
-            flow=None,
+        async def handler(message):
+            await self.on_knowledge_request(
+                message, None, None, workspace=workspace,
+            )
+
+        consumer_reg = await self.receiver_pool.add_consumer(
             topic=req_queue,
-            subscriber=self.id,
+            subscription=self.id,
             schema=KnowledgeRequest,
-            handler=partial(
-                self.on_knowledge_request, workspace=workspace,
-            ),
-            metrics=ConsumerMetrics(
-                processor=self.id, consumer="knowledge-request",
-                workspace=workspace,
-            ),
+            handler=handler,
         )
 
-        librarian_client = LibrarianClient(
-            id=self.id,
-            backend=self.pubsub,
-            taskgroup=self.taskgroup,
-            librarian_request_queue=workspace_queue(
+        librarian_client = await AsyncLibrarianClient.create(
+            backend=self.async_backend,
+            request_topic=workspace_queue(
                 librarian_request_queue, workspace,
             ),
-            librarian_response_queue=workspace_queue(
+            response_topic=workspace_queue(
                 librarian_response_queue, workspace,
             ),
-            librarian_subscriber=(
-                f"{self.id}--{workspace}--librarian"
-            ),
+            subscription=f"{self.id}--{workspace}--librarian",
         )
-
-        await response_producer.start()
-        await consumer.start()
-        await librarian_client.start()
 
         self.librarian_clients[workspace] = librarian_client
 
         self.workspace_consumers[workspace] = {
-            "consumer": consumer,
-            "response": response_producer,
+            "consumer": consumer_reg,
+            "response": response_handle,
             "librarian": librarian_client,
         }
 
@@ -176,8 +158,9 @@ class Processor(WorkspaceProcessor):
 
         clients = self.workspace_consumers.pop(workspace, None)
         if clients:
-            for client in clients.values():
-                await client.stop()
+            await clients["consumer"].unregister()
+            await clients["response"].unregister()
+            await clients["librarian"].stop()
             logger.info(f"Unsubscribed from workspace queue: {workspace}")
 
     async def start(self):
@@ -301,4 +284,3 @@ class Processor(WorkspaceProcessor):
 def run():
 
     Processor.launch(default_ident, __doc__)
-

--- a/trustgraph-flow/trustgraph/flow/service/flow.py
+++ b/trustgraph-flow/trustgraph/flow/service/flow.py
@@ -13,10 +13,10 @@ DELETE_RETRY_DELAY = 2  # seconds
 
 
 class FlowConfig:
-    def __init__(self, config, pubsub):
+    def __init__(self, config, async_backend):
 
         self.config = config
-        self.pubsub = pubsub
+        self.async_backend = async_backend
         # Per-workspace cache for parameter type definitions
         # Keyed by (workspace, type-name)
         self.param_type_cache = {}
@@ -241,7 +241,7 @@ class FlowConfig:
         # before processors receive their config and start connecting.
         topics = self._collect_flow_topics(cls, repl_template_with_params)
         for topic in topics:
-            await self.pubsub.create_topic(topic)
+            await self.async_backend.create_topic(topic)
 
         # Build all processor config updates, then write in a single batch.
         updates = []
@@ -364,7 +364,7 @@ class FlowConfig:
 
                     topics = self._collect_flow_topics(cls, repl_template)
                     for topic in topics:
-                        await self.pubsub.ensure_topic(topic)
+                        await self.async_backend.ensure_topic(topic)
 
                     logger.info(
                         f"Ensured topics for existing flow "
@@ -524,7 +524,7 @@ class FlowConfig:
 
             for topic in topics:
                 try:
-                    await self.pubsub.delete_topic(topic)
+                    await self.async_backend.delete_topic(topic)
                 except Exception as e:
                     logger.warning(
                         f"Topic delete failed (attempt {attempt + 1}/"

--- a/trustgraph-flow/trustgraph/flow/service/service.py
+++ b/trustgraph-flow/trustgraph/flow/service/service.py
@@ -12,12 +12,11 @@ from trustgraph.schema import Error
 
 from trustgraph.schema import FlowRequest, FlowResponse
 from trustgraph.schema import flow_request_queue, flow_response_queue
-from trustgraph.schema import ConfigRequest, ConfigResponse
+from trustgraph.schema import ConfigRequest, ConfigResponse, ConfigKey, ConfigValue
 from trustgraph.schema import config_request_queue, config_response_queue
 
-from trustgraph.base import WorkspaceProcessor, Consumer, Producer
-from trustgraph.base import ConsumerMetrics, ProducerMetrics, SubscriberMetrics
-from trustgraph.base import ConfigClient
+from trustgraph.base import WorkspaceProcessor
+from trustgraph.base import RequestResponseClient
 
 from . flow import FlowConfig
 
@@ -29,9 +28,107 @@ default_ident = "flow-svc"
 default_flow_request_queue = flow_request_queue
 default_flow_response_queue = flow_response_queue
 
+CONFIG_TIMEOUT = 10
+
 
 def workspace_queue(base_queue, workspace):
     return f"{base_queue}:{workspace}"
+
+
+class AsyncConfigClient:
+    """Wraps a RequestResponseClient to provide the same convenience
+    methods as the old ConfigClient (get, put, delete, keys, etc.)."""
+
+    def __init__(self, rr_client):
+        self._rr = rr_client
+
+    async def _request(self, timeout=CONFIG_TIMEOUT, **kwargs):
+        resp = await self._rr.request(
+            ConfigRequest(**kwargs),
+            timeout=timeout,
+        )
+        if resp.error:
+            raise RuntimeError(
+                f"{resp.error.type}: {resp.error.message}"
+            )
+        return resp
+
+    async def get(self, workspace, type, key, timeout=CONFIG_TIMEOUT):
+        resp = await self._request(
+            operation="get",
+            workspace=workspace,
+            keys=[ConfigKey(type=type, key=key)],
+            timeout=timeout,
+        )
+        if resp.values and len(resp.values) > 0:
+            return resp.values[0].value
+        return None
+
+    async def put(self, workspace, type, key, value, timeout=CONFIG_TIMEOUT):
+        await self._request(
+            operation="put",
+            workspace=workspace,
+            values=[ConfigValue(type=type, key=key, value=value)],
+            timeout=timeout,
+        )
+
+    async def put_many(self, workspace, values, timeout=CONFIG_TIMEOUT):
+        await self._request(
+            operation="put",
+            workspace=workspace,
+            values=[
+                ConfigValue(type=t, key=k, value=v)
+                for t, k, v in values
+            ],
+            timeout=timeout,
+        )
+
+    async def delete(self, workspace, type, key, timeout=CONFIG_TIMEOUT):
+        await self._request(
+            operation="delete",
+            workspace=workspace,
+            keys=[ConfigKey(type=type, key=key)],
+            timeout=timeout,
+        )
+
+    async def delete_many(self, workspace, keys, timeout=CONFIG_TIMEOUT):
+        await self._request(
+            operation="delete",
+            workspace=workspace,
+            keys=[
+                ConfigKey(type=t, key=k)
+                for t, k in keys
+            ],
+            timeout=timeout,
+        )
+
+    async def keys(self, workspace, type, timeout=CONFIG_TIMEOUT):
+        resp = await self._request(
+            operation="list",
+            workspace=workspace,
+            type=type,
+            timeout=timeout,
+        )
+        return resp.directory
+
+    async def get_all(self, workspace, timeout=CONFIG_TIMEOUT):
+        resp = await self._request(
+            operation="config",
+            workspace=workspace,
+            timeout=timeout,
+        )
+        return resp.config
+
+    async def workspaces_for_type(self, type, timeout=CONFIG_TIMEOUT):
+        resp = await self._request(
+            operation="getvalues-all-ws",
+            type=type,
+            timeout=timeout,
+        )
+        return {v.workspace for v in resp.values if v.workspace}
+
+    async def close(self):
+        await self._rr.close()
 
 
 class Processor(WorkspaceProcessor):
@@ -45,8 +142,6 @@ class Processor(WorkspaceProcessor):
             "flow_response_queue", default_flow_response_queue
         )
 
-        id = params.get("id")
-
         super(Processor, self).__init__(
             **params | {
                 "flow_request_schema": FlowRequest.__name__,
@@ -54,31 +149,38 @@ class Processor(WorkspaceProcessor):
             }
         )
 
-        config_req_metrics = ProducerMetrics(
-            processor=self.id, producer="config-request",
-        )
-        config_resp_metrics = SubscriberMetrics(
-            processor=self.id, subscriber="config-response",
-        )
-
-        config_rr_id = str(uuid.uuid4())
-        self.config_client = ConfigClient(
-            backend=self.pubsub,
-            subscription=f"{self.id}--config--{config_rr_id}",
-            consumer_name=self.id,
-            request_topic=config_request_queue,
-            request_schema=ConfigRequest,
-            request_metrics=config_req_metrics,
-            response_topic=config_response_queue,
-            response_schema=ConfigResponse,
-            response_metrics=config_resp_metrics,
-        )
-
-        self.flow = FlowConfig(self.config_client, self.pubsub)
+        self.config_client = None
+        self.flow = None
 
         self.workspace_consumers = {}
 
         logger.info("Flow service initialized")
+
+    async def start(self):
+
+        rr_client = await RequestResponseClient.create(
+            backend=self.async_backend,
+            request_topic=config_request_queue,
+            response_topic=config_response_queue,
+            request_schema=ConfigRequest,
+            response_schema=ConfigResponse,
+        )
+
+        self.config_client = AsyncConfigClient(rr_client)
+
+        self.flow = FlowConfig(self.config_client, self.async_backend)
+
+        workspaces = await self.config_client.workspaces_for_type("flow")
+        await self.flow.ensure_existing_flow_topics(workspaces)
+
+        await super(Processor, self).start()
+
+    async def stop(self):
+
+        if self.config_client:
+            await self.config_client.close()
+
+        await super(Processor, self).stop()
 
     async def on_workspace_created(self, workspace):
 
@@ -92,41 +194,27 @@ class Processor(WorkspaceProcessor):
             self.flow_response_queue_base, workspace,
         )
 
-        await self.pubsub.ensure_topic(req_queue)
-        await self.pubsub.ensure_topic(resp_queue)
+        await self.async_backend.ensure_topic(req_queue)
+        await self.async_backend.ensure_topic(resp_queue)
 
-        response_producer = Producer(
-            backend=self.pubsub,
+        response_handle = await self.sender_pool.add_producer(
             topic=resp_queue,
             schema=FlowResponse,
-            metrics=ProducerMetrics(
-                processor=self.id, producer="flow-response",
-                workspace=workspace,
-            ),
         )
 
-        consumer = Consumer(
-            taskgroup=self.taskgroup,
-            backend=self.pubsub,
-            flow=None,
+        async def handler_wrapper(message):
+            await self.on_flow_request(message, None, None, workspace=workspace)
+
+        consumer_reg = await self.receiver_pool.add_consumer(
             topic=req_queue,
-            subscriber=self.id,
+            subscription=self.id,
             schema=FlowRequest,
-            handler=partial(
-                self.on_flow_request, workspace=workspace,
-            ),
-            metrics=ConsumerMetrics(
-                processor=self.id, consumer="flow-request",
-                workspace=workspace,
-            ),
+            handler=handler_wrapper,
         )
-
-        await response_producer.start()
-        await consumer.start()
 
         self.workspace_consumers[workspace] = {
-            "consumer": consumer,
-            "response": response_producer,
+            "consumer": consumer_reg,
+            "response": response_handle,
         }
 
         logger.info(f"Subscribed to workspace queue: {workspace}")
@@ -135,17 +223,9 @@ class Processor(WorkspaceProcessor):
 
         clients = self.workspace_consumers.pop(workspace, None)
         if clients:
-            for client in clients.values():
-                await client.stop()
+            await clients["consumer"].unregister()
+            await clients["response"].unregister()
             logger.info(f"Unsubscribed from workspace queue: {workspace}")
-
-    async def start(self):
-
-        await super(Processor, self).start()
-        await self.config_client.start()
-
-        workspaces = await self.config_client.workspaces_for_type("flow")
-        await self.flow.ensure_existing_flow_topics(workspaces)
 
     async def on_flow_request(self, msg, consumer, flow, *, workspace):
 

--- a/trustgraph-flow/trustgraph/iam/noauth/service.py
+++ b/trustgraph-flow/trustgraph/iam/noauth/service.py
@@ -4,18 +4,13 @@ all access unconditionally.  No database, no bootstrap, no signing keys.
 """
 
 import logging
-import uuid
 
 from trustgraph.schema import Error
 from trustgraph.schema import IamRequest, IamResponse
 from trustgraph.schema import iam_request_queue, iam_response_queue
-from trustgraph.schema import ConfigRequest, ConfigResponse, ConfigValue
-from trustgraph.schema import config_request_queue, config_response_queue
+from trustgraph.schema import ConfigRequest, ConfigValue
 
-from trustgraph.base import AsyncProcessor, Consumer, Producer
-from trustgraph.base import ConsumerMetrics, ProducerMetrics
-from trustgraph.base.metrics import SubscriberMetrics
-from trustgraph.base.request_response_spec import RequestResponse
+from trustgraph.base import AsyncProcessor
 
 from . handler import NoAuthHandler
 
@@ -31,10 +26,10 @@ class Processor(AsyncProcessor):
 
     def __init__(self, **params):
 
-        iam_req_q = params.get(
+        self.iam_request_topic = params.get(
             "iam_request_queue", default_iam_request_queue,
         )
-        iam_resp_q = params.get(
+        self.iam_response_topic = params.get(
             "iam_response_queue", default_iam_response_queue,
         )
 
@@ -42,33 +37,6 @@ class Processor(AsyncProcessor):
         default_workspace = params.get("default_workspace", "default")
 
         super().__init__(**params)
-
-        iam_request_metrics = ConsumerMetrics(
-            processor=self.id, consumer="iam-request",
-        )
-        iam_response_metrics = ProducerMetrics(
-            processor=self.id, producer="iam-response",
-        )
-
-        self.iam_request_topic = iam_req_q
-
-        self.iam_request_consumer = Consumer(
-            taskgroup=self.taskgroup,
-            backend=self.pubsub,
-            flow=None,
-            topic=iam_req_q,
-            subscriber=self.id,
-            schema=IamRequest,
-            handler=self.on_iam_request,
-            metrics=iam_request_metrics,
-        )
-
-        self.iam_response_producer = Producer(
-            backend=self.pubsub,
-            topic=iam_resp_q,
-            schema=IamResponse,
-            metrics=iam_response_metrics,
-        )
 
         self.handler = NoAuthHandler(
             default_user_id=default_user_id,
@@ -82,33 +50,30 @@ class Processor(AsyncProcessor):
         )
 
     async def start(self):
-        await self.pubsub.ensure_topic(self.iam_request_topic)
-        await self.iam_request_consumer.start()
+        await super().start()
 
-    def _create_config_client(self):
-        config_rr_id = str(uuid.uuid4())
-        config_req_metrics = ProducerMetrics(
-            processor=self.id, producer="config-request",
-        )
-        config_resp_metrics = SubscriberMetrics(
-            processor=self.id, subscriber="config-response",
-        )
-        return RequestResponse(
-            backend=self.pubsub,
-            subscription=f"{self.id}--config--{config_rr_id}",
-            consumer_name=self.id,
-            request_topic=config_request_queue,
-            request_schema=ConfigRequest,
-            request_metrics=config_req_metrics,
-            response_topic=config_response_queue,
-            response_schema=ConfigResponse,
-            response_metrics=config_resp_metrics,
-        )
+        await self.async_backend.ensure_topic(self.iam_request_topic)
+
+        async def wrapper(message):
+            await self.on_iam_request(message, None, None)
+
+        self.iam_request_consumer = \
+            await self.receiver_pool.add_consumer(
+                topic=self.iam_request_topic,
+                subscription=self.id,
+                schema=IamRequest,
+                handler=wrapper,
+            )
+
+        self.iam_response_producer = \
+            await self.sender_pool.add_producer(
+                topic=self.iam_response_topic,
+                schema=IamResponse,
+            )
 
     async def _ensure_workspace_registered(self, workspace_id):
-        client = self._create_config_client()
+        client = await self._create_config_client()
         try:
-            await client.start()
             await client.request(
                 ConfigRequest(
                     operation="put",
@@ -121,7 +86,7 @@ class Processor(AsyncProcessor):
                 timeout=10,
             )
         finally:
-            await client.stop()
+            await client.close()
         logger.info(
             f"Registered workspace in config: {workspace_id}"
         )

--- a/trustgraph-flow/trustgraph/iam/service/service.py
+++ b/trustgraph-flow/trustgraph/iam/service/service.py
@@ -12,14 +12,10 @@ import os
 from trustgraph.schema import Error
 from trustgraph.schema import IamRequest, IamResponse
 from trustgraph.schema import iam_request_queue, iam_response_queue
-from trustgraph.schema import ConfigRequest, ConfigResponse, ConfigValue
-from trustgraph.schema import config_request_queue, config_response_queue
+from trustgraph.schema import ConfigRequest, ConfigValue
 
-from trustgraph.base import AsyncProcessor, Consumer, Producer
+from trustgraph.base import AsyncProcessor
 from trustgraph.base import AuditPublisher
-from trustgraph.base import ConsumerMetrics, ProducerMetrics
-from trustgraph.base.metrics import SubscriberMetrics
-from trustgraph.base.request_response_spec import RequestResponse
 from trustgraph.base.cassandra_config import (
     add_cassandra_args, resolve_cassandra_config,
 )
@@ -119,35 +115,10 @@ class Processor(AsyncProcessor):
             }
         )
 
-        iam_request_metrics = ConsumerMetrics(
-            processor=self.id, consumer="iam-request",
-        )
-        iam_response_metrics = ProducerMetrics(
-            processor=self.id, producer="iam-response",
-        )
-
         self.iam_request_topic = iam_req_q
-
-        self.iam_request_consumer = Consumer(
-            taskgroup=self.taskgroup,
-            backend=self.pubsub,
-            flow=None,
-            topic=iam_req_q,
-            subscriber=self.id,
-            schema=IamRequest,
-            handler=self.on_iam_request,
-            metrics=iam_request_metrics,
-        )
-
-        self.iam_response_producer = Producer(
-            backend=self.pubsub,
-            topic=iam_resp_q,
-            schema=IamResponse,
-            metrics=iam_response_metrics,
-        )
+        self.iam_response_topic = iam_resp_q
 
         self.audit = AuditPublisher(
-            backend=self.pubsub,
             component_name="iam-service",
             processor_id=self.id,
         )
@@ -169,37 +140,36 @@ class Processor(AsyncProcessor):
         )
 
     async def start(self):
-        await self.pubsub.ensure_topic(self.iam_request_topic)
+        await super().start()
+
+        await self.async_backend.ensure_topic(self.iam_request_topic)
+
+        async def wrapper(message):
+            await self.on_iam_request(message, None, None)
+
+        self.iam_request_consumer = \
+            await self.receiver_pool.add_consumer(
+                topic=self.iam_request_topic,
+                subscription=self.id,
+                schema=IamRequest,
+                handler=wrapper,
+            )
+
+        self.iam_response_producer = \
+            await self.sender_pool.add_producer(
+                topic=self.iam_response_topic,
+                schema=IamResponse,
+            )
+
+        await self.audit.start(self.sender_pool)
+
         # Token-mode auto-bootstrap runs before we accept requests so
         # the first inbound call always sees a populated table.
         await self.iam.auto_bootstrap_if_token_mode()
-        await self.iam_request_consumer.start()
-
-    def _create_config_client(self):
-        import uuid
-        config_rr_id = str(uuid.uuid4())
-        config_req_metrics = ProducerMetrics(
-            processor=self.id, producer="config-request",
-        )
-        config_resp_metrics = SubscriberMetrics(
-            processor=self.id, subscriber="config-response",
-        )
-        return RequestResponse(
-            backend=self.pubsub,
-            subscription=f"{self.id}--config--{config_rr_id}",
-            consumer_name=self.id,
-            request_topic=config_request_queue,
-            request_schema=ConfigRequest,
-            request_metrics=config_req_metrics,
-            response_topic=config_response_queue,
-            response_schema=ConfigResponse,
-            response_metrics=config_resp_metrics,
-        )
 
     async def _config_put(self, workspace, type, key, value):
-        client = self._create_config_client()
+        client = await self._create_config_client()
         try:
-            await client.start()
             await client.request(
                 ConfigRequest(
                     operation="put",
@@ -209,13 +179,12 @@ class Processor(AsyncProcessor):
                 timeout=10,
             )
         finally:
-            await client.stop()
+            await client.close()
 
     async def _config_delete(self, workspace, type, key):
         from trustgraph.schema import ConfigKey
-        client = self._create_config_client()
+        client = await self._create_config_client()
         try:
-            await client.start()
             await client.request(
                 ConfigRequest(
                     operation="delete",
@@ -225,7 +194,7 @@ class Processor(AsyncProcessor):
                 timeout=10,
             )
         finally:
-            await client.stop()
+            await client.close()
 
     async def _ensure_workspace_registered(self, workspace_id):
         await self._config_put(

--- a/trustgraph-flow/trustgraph/librarian/collection_manager.py
+++ b/trustgraph-flow/trustgraph/librarian/collection_manager.py
@@ -32,24 +32,15 @@ class CollectionManager:
 
     def __init__(
         self,
-        config_request_producer,
-        config_response_consumer,
-        taskgroup
+        config_client,
     ):
         """
         Initialize the CollectionManager
 
         Args:
-            config_request_producer: Producer for config service requests
-            config_response_consumer: Consumer for config service responses
-            taskgroup: Task group for async operations
+            config_client: RequestResponseClient for config service
         """
-        self.config_request_producer = config_request_producer
-        self.config_response_consumer = config_response_consumer
-        self.taskgroup = taskgroup
-
-        # Track pending config requests
-        self.pending_config_requests = {}
+        self.config_client = config_client
 
         logger.info("Collection manager initialized with config service backend")
 
@@ -58,39 +49,12 @@ class CollectionManager:
         Send config request and wait for response
 
         Args:
-            request: Config service request (without id field)
+            request: Config service request
 
         Returns:
             ConfigResponse from config service
         """
-        # Generate request ID - passed via message properties, not in schema
-        request_id = str(uuid.uuid4())
-
-        event = asyncio.Event()
-        self.pending_config_requests[request_id] = event
-
-        # Send request with ID in message properties
-        await self.config_request_producer.send(request, properties={"id": request_id})
-        await event.wait()
-
-        response = self.pending_config_requests.pop(request_id + "_response")
-        return response
-
-    async def on_config_response(self, message, consumer, flow):
-        """
-        Handle config response
-
-        Args:
-            message: Pulsar message
-            consumer: Consumer instance
-            flow: Flow context
-        """
-        # Get ID from message properties
-        response_id = message.properties().get("id")
-        if response_id and response_id in self.pending_config_requests:
-            response = message.value()
-            self.pending_config_requests[response_id + "_response"] = response
-            self.pending_config_requests[response_id].set()
+        return await self.config_client.request(request, timeout=60)
 
     async def ensure_collection_exists(self, workspace: str, collection: str):
         """

--- a/trustgraph-flow/trustgraph/librarian/service.py
+++ b/trustgraph-flow/trustgraph/librarian/service.py
@@ -11,7 +11,7 @@ import logging
 import os
 from datetime import datetime
 
-from .. base import WorkspaceProcessor, Consumer, Producer, Publisher, Subscriber
+from .. base import WorkspaceProcessor, RequestResponseClient
 from .. base import ConsumerMetrics, ProducerMetrics
 from .. base.cassandra_config import add_cassandra_args, resolve_cassandra_config
 
@@ -92,11 +92,11 @@ class Processor(WorkspaceProcessor):
             "collection_response_queue", default_collection_response_queue
         )
 
-        config_request_queue = params.get(
+        self.config_request_topic = params.get(
             "config_request_queue", default_config_request_queue
         )
 
-        config_response_queue = params.get(
+        self.config_response_topic = params.get(
             "config_response_queue", default_config_response_queue
         )
 
@@ -169,33 +169,6 @@ class Processor(WorkspaceProcessor):
             }
         )
 
-        # Config service client for collection management
-        config_request_metrics = ProducerMetrics(
-            processor=id, producer="config-request",
-        )
-
-        self.config_request_producer = Producer(
-            backend = self.pubsub,
-            topic = config_request_queue,
-            schema = ConfigRequest,
-            metrics = config_request_metrics,
-        )
-
-        config_response_metrics = ConsumerMetrics(
-            processor=id, consumer="config-response",
-        )
-
-        self.config_response_consumer = Consumer(
-            taskgroup = self.taskgroup,
-            backend = self.pubsub,
-            flow = None,
-            topic = config_response_queue,
-            subscriber = f"{id}-config",
-            schema = ConfigResponse,
-            handler = self.on_config_response,
-            metrics = config_response_metrics,
-        )
-
         self.librarian = Librarian(
             cassandra_host = self.cassandra_host,
             cassandra_username = self.cassandra_username,
@@ -212,11 +185,9 @@ class Processor(WorkspaceProcessor):
             min_chunk_size = min_chunk_size,
         )
 
-        self.collection_manager = CollectionManager(
-            config_request_producer = self.config_request_producer,
-            config_response_consumer = self.config_response_consumer,
-            taskgroup = self.taskgroup,
-        )
+        # CollectionManager and config client are created in start()
+        self.collection_manager = None
+        self.config_client = None
 
         self.register_config_handler(
             self.on_librarian_config,
@@ -248,73 +219,50 @@ class Processor(WorkspaceProcessor):
             self.collection_response_queue_base, workspace,
         )
 
-        await self.pubsub.ensure_topic(lib_req_queue)
-        await self.pubsub.ensure_topic(lib_resp_queue)
-        await self.pubsub.ensure_topic(col_req_queue)
-        await self.pubsub.ensure_topic(col_resp_queue)
+        await self.async_backend.ensure_topic(lib_req_queue)
+        await self.async_backend.ensure_topic(lib_resp_queue)
+        await self.async_backend.ensure_topic(col_req_queue)
+        await self.async_backend.ensure_topic(col_resp_queue)
 
-        lib_response_producer = Producer(
-            backend=self.pubsub,
+        lib_response_handle = await self.sender_pool.add_producer(
             topic=lib_resp_queue,
             schema=LibrarianResponse,
-            metrics=ProducerMetrics(
-                processor=self.id, producer="librarian-response",
-                workspace=workspace,
-            ),
         )
 
-        col_response_producer = Producer(
-            backend=self.pubsub,
+        col_response_handle = await self.sender_pool.add_producer(
             topic=col_resp_queue,
             schema=CollectionManagementResponse,
-            metrics=ProducerMetrics(
-                processor=self.id, producer="collection-response",
-                workspace=workspace,
-            ),
         )
 
-        lib_consumer = Consumer(
-            taskgroup=self.taskgroup,
-            backend=self.pubsub,
-            flow=None,
+        async def lib_handler(message):
+            await self.on_librarian_request(
+                message, None, None, workspace=workspace,
+            )
+
+        lib_consumer_reg = await self.receiver_pool.add_consumer(
             topic=lib_req_queue,
-            subscriber=self.id,
+            subscription=self.id,
             schema=LibrarianRequest,
-            handler=partial(
-                self.on_librarian_request, workspace=workspace,
-            ),
-            metrics=ConsumerMetrics(
-                processor=self.id, consumer="librarian-request",
-                workspace=workspace,
-            ),
+            handler=lib_handler,
         )
 
-        col_consumer = Consumer(
-            taskgroup=self.taskgroup,
-            backend=self.pubsub,
-            flow=None,
+        async def col_handler(message):
+            await self.on_collection_request(
+                message, None, None, workspace=workspace,
+            )
+
+        col_consumer_reg = await self.receiver_pool.add_consumer(
             topic=col_req_queue,
-            subscriber=self.id,
+            subscription=self.id,
             schema=CollectionManagementRequest,
-            handler=partial(
-                self.on_collection_request, workspace=workspace,
-            ),
-            metrics=ConsumerMetrics(
-                processor=self.id, consumer="collection-request",
-                workspace=workspace,
-            ),
+            handler=col_handler,
         )
-
-        await lib_response_producer.start()
-        await col_response_producer.start()
-        await lib_consumer.start()
-        await col_consumer.start()
 
         self.workspace_consumers[workspace] = {
-            "librarian": lib_consumer,
-            "librarian-response": lib_response_producer,
-            "collection": col_consumer,
-            "collection-response": col_response_producer,
+            "librarian": lib_consumer_reg,
+            "librarian-response": lib_response_handle,
+            "collection": col_consumer_reg,
+            "collection-response": col_response_handle,
         }
 
         logger.info(f"Subscribed to workspace queues: {workspace}")
@@ -323,19 +271,36 @@ class Processor(WorkspaceProcessor):
 
         clients = self.workspace_consumers.pop(workspace, None)
         if clients:
-            for client in clients.values():
-                await client.stop()
+            await clients["librarian"].unregister()
+            await clients["collection"].unregister()
+            await clients["librarian-response"].unregister()
+            await clients["collection-response"].unregister()
             logger.info(f"Unsubscribed from workspace queues: {workspace}")
 
     async def start(self):
 
         await super(Processor, self).start()
-        await self.config_request_producer.start()
-        await self.config_response_consumer.start()
 
-    async def on_config_response(self, message, consumer, flow):
-        """Forward config responses to collection manager"""
-        await self.collection_manager.on_config_response(message, consumer, flow)
+        # Create config client for collection management
+        self.config_client = await RequestResponseClient.create(
+            backend=self.async_backend,
+            request_topic=self.config_request_topic,
+            response_topic=self.config_response_topic,
+            request_schema=ConfigRequest,
+            response_schema=ConfigResponse,
+            subscription=f"{self.id}-config",
+        )
+
+        self.collection_manager = CollectionManager(
+            config_client=self.config_client,
+        )
+
+    async def stop(self):
+
+        if self.config_client:
+            await self.config_client.close()
+
+        await super(Processor, self).stop()
 
     async def on_librarian_config(self, workspace, config, version):
 
@@ -397,14 +362,12 @@ class Processor(WorkspaceProcessor):
         # Combine all triples
         all_triples = vocab_triples + prov_triples
 
-        # Create publisher and emit
-        triples_pub = Publisher(
-            self.pubsub, triples_queue, schema=Triples
+        # Create producer handle and emit
+        triples_handle = await self.sender_pool.add_producer(
+            topic=triples_queue, schema=Triples,
         )
 
         try:
-            await triples_pub.start()
-
             triples_msg = Triples(
                 metadata=Metadata(
                     id=doc_uri,
@@ -414,11 +377,11 @@ class Processor(WorkspaceProcessor):
                 triples=all_triples,
             )
 
-            await triples_pub.send(None, triples_msg)
+            await triples_handle.send(triples_msg)
             logger.debug(f"Emitted {len(all_triples)} provenance triples for {document.id}")
 
         finally:
-            await triples_pub.stop()
+            await triples_handle.unregister()
 
     async def load_document(self, document, processing, content, workspace):
 
@@ -473,15 +436,14 @@ class Processor(WorkspaceProcessor):
 
         logger.debug(f"Submitting to queue {q}...")
 
-        pub = Publisher(
-            self.pubsub, q, schema=schema
+        handle = await self.sender_pool.add_producer(
+            topic=q, schema=schema,
         )
 
         try:
-            await pub.start()
-            await pub.send(None, doc)
+            await handle.send(doc)
         finally:
-            await pub.stop()
+            await handle.unregister()
 
         logger.debug("Document submitted")
 
@@ -717,4 +679,3 @@ class Processor(WorkspaceProcessor):
 def run():
 
     Processor.launch(default_ident, __doc__)
-


### PR DESCRIPTION
Eliminate the thread-per-consumer model that causes thread exhaustion at scale (40+ workspaces × 4 flows ≈ 480 OS threads) by migrating to pulsar.asyncio.Client with fully async receive loops.

Core infrastructure:
- Add AsyncPulsarBackend using pulsar.asyncio.Client for native async
- Add ReceiverPool: shared work queue with configurable worker count
- Add SenderPool: async producer dispatch with drain-on-stop
- Add RequestResponseClient with streaming support (request_stream)
- Add AsyncConfigClient and AsyncRequestResponseWrapper for service use

Migration:
- Migrate all core services to AsyncProcessor (config, flow, IAM, librarian, cores, bootstrapper, metering)
- Replace Subscriber/Consumer inheritance with ReceiverPool registrations
- Replace Producer send with SenderPool handles
- Use BaseException throughout for pulsar.asyncio.PulsarException compatibility (inherits BaseException, not Exception)
- Close-before-cancel shutdown pattern for async Pulsar consumers

Includes tech spec: docs/tech-specs/async-receive-threading.md