### PR TITLE
Migrate api-gateway and rev-gateway to async pub/sub

### DIFF
--- a/trustgraph-base/trustgraph/base/audit_publisher.py
+++ b/trustgraph-base/trustgraph/base/audit_publisher.py
@@ -13,9 +13,12 @@ logger = logging.getLogger(__name__)
 
 class AuditPublisher:
 
-    def __init__(self, component_name, processor_id=None, backend=None):
+    def __init__(self, component_name, processor_id=None, backend=None,
+                 async_backend=None):
         self.component_name = component_name
         self._handle = None
+        self._async_producer = None
+        self._async_backend = async_backend
 
         if backend is not None:
             self._legacy_producer = Producer(
@@ -36,8 +39,19 @@ class AuditPublisher:
                 topic=audit_events_queue,
                 schema=AuditEvent,
             )
+        elif self._async_backend is not None:
+            self._async_producer = await self._async_backend.create_producer(
+                topic=audit_events_queue,
+                schema=AuditEvent,
+            )
 
     async def stop(self):
+        if self._async_producer:
+            try:
+                await self._async_producer.close()
+            except BaseException:
+                pass
+            self._async_producer = None
         if self._handle:
             await self._handle.unregister()
 
@@ -54,6 +68,8 @@ class AuditPublisher:
         try:
             if self._handle:
                 await self._handle.send(event)
+            elif self._async_producer:
+                await self._async_producer.send(event)
             elif self._legacy_producer:
                 await self._legacy_producer.send(event)
         except Exception as e:

--- a/trustgraph-flow/trustgraph/gateway/auth.py
+++ b/trustgraph-flow/trustgraph/gateway/auth.py
@@ -28,7 +28,8 @@ from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import ed25519
 
 from ..base.iam_client import IamClient
-from ..base.metrics import ProducerMetrics, SubscriberMetrics
+from ..base.request_response_client import RequestResponseClient
+from ..base.request_response_spec import _make_impl_wrapper
 from ..schema import (
     IamRequest, IamResponse,
     iam_request_queue, iam_response_queue,
@@ -155,33 +156,24 @@ class IamAuth:
     # ghosts from prior calls.
     # ------------------------------------------------------------------
 
-    def _make_client(self):
-        rr_id = str(uuid.uuid4())
-        return IamClient(
+    async def _make_client(self):
+        rr_client = await RequestResponseClient.create(
             backend=self.backend,
-            subscription=f"{self.id}--iam--{rr_id}",
-            consumer_name=self.id,
             request_topic=iam_request_queue,
-            request_schema=IamRequest,
-            request_metrics=ProducerMetrics(
-                processor=self.id, producer="iam-request",
-            ),
             response_topic=iam_response_queue,
+            request_schema=IamRequest,
             response_schema=IamResponse,
-            response_metrics=SubscriberMetrics(
-                processor=self.id, subscriber="iam-response",
-            ),
         )
+        return _make_impl_wrapper(rr_client, IamClient)
 
     async def _with_client(self, op):
         """Open a short-lived IamClient, run ``op(client)``, close."""
-        client = self._make_client()
-        await client.start()
+        client = await self._make_client()
         try:
             return await op(client)
         finally:
             try:
-                await client.stop()
+                await client.close()
             except Exception:
                 pass
 

--- a/trustgraph-flow/trustgraph/gateway/config/receiver.py
+++ b/trustgraph-flow/trustgraph/gateway/config/receiver.py
@@ -13,10 +13,7 @@ import json
 from ... schema import ConfigPush, ConfigRequest, ConfigResponse
 from ... schema import config_push_queue, config_request_queue
 from ... schema import config_response_queue
-from ... base import Consumer, Producer
-from ... base.subscriber import Subscriber
-from ... base.request_response_spec import RequestResponse
-from ... base.metrics import ProducerMetrics, SubscriberMetrics
+from ... base.request_response_client import RequestResponseClient
 
 logger = logging.getLogger("config.receiver")
 logger.setLevel(logging.INFO)
@@ -39,7 +36,7 @@ class ConfigReceiver:
     def add_handler(self, h):
         self.flow_handlers.append(h)
 
-    async def on_config_notify(self, msg, proc, flow):
+    async def on_config_notify(self, msg):
 
         try:
 
@@ -47,7 +44,6 @@ class ConfigReceiver:
             notify_version = v.version
             changes = v.changes
 
-            # Skip if we already have this version or newer
             if notify_version <= self.config_version:
                 logger.debug(
                     f"Ignoring config notify v{notify_version}, "
@@ -55,7 +51,6 @@ class ConfigReceiver:
                 )
                 return
 
-            # Track workspace lifecycle
             if v.workspace_changes and self.auth:
                 for ws in (v.workspace_changes.created or []):
                     self.auth.known_workspaces.add(ws)
@@ -64,8 +59,6 @@ class ConfigReceiver:
                     self.auth.known_workspaces.discard(ws)
                     logger.info(f"Workspace deregistered: {ws}")
 
-            # Gateway cares about flow config — check if any flow
-            # types changed in any workspace
             flow_workspaces = changes.get("flow", [])
             if changes and not flow_workspaces:
                 logger.debug(
@@ -80,7 +73,6 @@ class ConfigReceiver:
                 f"types={list(changes.keys())}, fetching config..."
             )
 
-            # Refresh config for each affected workspace
             for workspace in flow_workspaces:
                 await self.fetch_and_apply_workspace(workspace)
 
@@ -91,32 +83,16 @@ class ConfigReceiver:
                 f"Config notify processing exception: {e}", exc_info=True
             )
 
-    def _create_config_client(self):
-        """Create a short-lived config request/response client."""
-        id = str(uuid.uuid4())
-
-        config_req_metrics = ProducerMetrics(
-            processor="api-gateway", producer="config-request",
-        )
-        config_resp_metrics = SubscriberMetrics(
-            processor="api-gateway", subscriber="config-response",
-        )
-
-        return RequestResponse(
+    async def _create_config_client(self):
+        return await RequestResponseClient.create(
             backend=self.backend,
-            subscription=f"api-gateway--config--{id}",
-            consumer_name="api-gateway",
             request_topic=config_request_queue,
-            request_schema=ConfigRequest,
-            request_metrics=config_req_metrics,
             response_topic=config_response_queue,
+            request_schema=ConfigRequest,
             response_schema=ConfigResponse,
-            response_metrics=config_resp_metrics,
         )
 
     async def fetch_and_apply_workspace(self, workspace, retry=False):
-        """Fetch config for a single workspace and apply flow changes.
-        If retry=True, keeps retrying until successful."""
 
         while True:
 
@@ -125,9 +101,8 @@ class ConfigReceiver:
                     f"Fetching config for workspace {workspace}..."
                 )
 
-                client = self._create_config_client()
+                client = await self._create_config_client()
                 try:
-                    await client.start()
                     resp = await client.request(
                         ConfigRequest(
                             operation="config",
@@ -136,7 +111,7 @@ class ConfigReceiver:
                         timeout=10,
                     )
                 finally:
-                    await client.stop()
+                    await client.close()
 
                 logger.info(f"Config response received")
 
@@ -190,20 +165,15 @@ class ConfigReceiver:
                 return
 
     async def fetch_all_workspaces(self, retry=False):
-        """Fetch config for all workspaces at startup.
-        Discovers workspaces via the config service getvalues-all-ws
-        operation on the flow type."""
 
         while True:
 
             try:
                 logger.info("Discovering workspaces with flows...")
 
-                client = self._create_config_client()
+                client = await self._create_config_client()
                 try:
-                    await client.start()
 
-                    # Discover all known workspaces
                     ws_resp = await client.request(
                         ConfigRequest(
                             operation="getvalues",
@@ -230,7 +200,6 @@ class ConfigReceiver:
                         f"Known workspaces: {discovered}"
                     )
 
-                    # Discover workspaces that have any flow config
                     resp = await client.request(
                         ConfigRequest(
                             operation="getvalues-all-ws",
@@ -248,9 +217,6 @@ class ConfigReceiver:
                         v.workspace for v in resp.values if v.workspace
                     }
 
-                    # Always include the default workspace, even if
-                    # empty, so that newly-created flows in it can be
-                    # picked up by subsequent notifications.
                     workspaces.add("default")
 
                     logger.info(
@@ -258,9 +224,8 @@ class ConfigReceiver:
                     )
 
                 finally:
-                    await client.stop()
+                    await client.close()
 
-                # Fetch and apply config for each workspace
                 for workspace in workspaces:
                     await self.fetch_and_apply_workspace(
                         workspace, retry=retry
@@ -310,43 +275,48 @@ class ConfigReceiver:
 
         while True:
 
+            consumer = None
+
             try:
 
-                async with asyncio.TaskGroup() as tg:
+                consumer = await self.backend.create_consumer(
+                    topic=config_push_queue,
+                    subscription=f"gateway-{uuid.uuid4()}",
+                    schema=ConfigPush,
+                    initial_position='latest',
+                )
 
-                    id = str(uuid.uuid4())
+                logger.info("Config notify consumer started")
 
-                    # Subscribe to notify queue
-                    self.config_cons = Consumer(
-                        taskgroup=tg,
-                        flow=None,
-                        backend=self.backend,
-                        subscriber=f"gateway-{id}",
-                        topic=config_push_queue,
-                        schema=ConfigPush,
-                        handler=self.on_config_notify,
-                        start_of_messages=False,
-                    )
+                await self.fetch_all_workspaces(retry=True)
 
-                    logger.info("Starting config notify consumer...")
-                    await self.config_cons.start()
-                    logger.info("Config notify consumer started")
+                logger.info(
+                    "Config loader initialised, waiting for notifys..."
+                )
 
-                    # Fetch current config (subscribe-then-fetch pattern)
-                    # Retry until config service is available
-                    await self.fetch_all_workspaces(retry=True)
-
-                    logger.info(
-                        "Config loader initialised, waiting for notifys..."
-                    )
-
-                logger.warning("Config consumer exited, restarting...")
+                while True:
+                    msg = await consumer.receive()
+                    try:
+                        await self.on_config_notify(msg)
+                        await consumer.acknowledge(msg)
+                    except Exception as e:
+                        logger.error(
+                            f"Config notify error: {e}", exc_info=True
+                        )
+                        await consumer.negative_acknowledge(msg)
 
             except Exception as e:
                 logger.error(
                     f"Config loader exception: {e}, restarting in 4s...",
                     exc_info=True
                 )
+
+            finally:
+                if consumer:
+                    try:
+                        await consumer.close()
+                    except BaseException:
+                        pass
 
             await asyncio.sleep(4)
 

--- a/trustgraph-flow/trustgraph/gateway/dispatch/document_embeddings_export.py
+++ b/trustgraph-flow/trustgraph/gateway/dispatch/document_embeddings_export.py
@@ -1,91 +1,63 @@
 
 import asyncio
-import queue
-import uuid
 import logging
 
 from ... schema import DocumentEmbeddings
-from ... base import Subscriber
 
 from . serialize import serialize_document_embeddings
 
-# Module logger
 logger = logging.getLogger(__name__)
 
 class DocumentEmbeddingsExport:
 
-    def __init__(
-            self, ws, running, backend, queue, consumer, subscriber
-    ):
-
+    def __init__(self, ws, running, backend, queue, consumer, subscriber):
         self.ws = ws
         self.running = running
         self.backend = backend
         self.queue = queue
-        self.consumer = consumer
-        self.subscriber = subscriber
+        self.subscription = subscriber
+        self._consumer = None
 
     async def destroy(self):
-        # Step 1: Signal stop to prevent new messages
         self.running.stop()
-        
-        # Step 2: Wait briefly for in-flight messages
-        await asyncio.sleep(0.5)
-        
-        # Step 3: Unsubscribe and stop subscriber (triggers queue drain)
-        if hasattr(self, 'subs'):
-            await self.subs.unsubscribe_all(self.id)
-            await self.subs.stop()
-        
-        # Step 4: Close websocket last
+        if self._consumer:
+            try:
+                await self._consumer.close()
+            except BaseException:
+                pass
+            self._consumer = None
         if self.ws and not self.ws.closed:
             await self.ws.close()
 
     async def receive(self, msg):
-        # Ignore incoming info from websocket
         pass
 
     async def run(self):
-        """Enhanced run with better error handling"""
-        self.subs = Subscriber(
-            backend = self.backend,
-            topic = self.queue,
-            consumer_name = self.consumer,
-            subscription = self.subscriber,
-            schema = DocumentEmbeddings,
-            backpressure_strategy = "block"  # Configurable
+        self._consumer = await self.backend.create_consumer(
+            topic=self.queue,
+            subscription=self.subscription,
+            schema=DocumentEmbeddings,
         )
-        
-        await self.subs.start()
-        
-        self.id = str(uuid.uuid4())
-        q = await self.subs.subscribe_all(self.id)
-        
+
         consecutive_errors = 0
         max_consecutive_errors = 5
-        
+
         while self.running.get():
             try:
-                resp = await asyncio.wait_for(q.get(), timeout=0.5)
-                await self.ws.send_json(serialize_document_embeddings(resp))
-                consecutive_errors = 0  # Reset on success
-                
+                msg = await asyncio.wait_for(
+                    self._consumer.receive(), timeout=0.5,
+                )
+                await self.ws.send_json(serialize_document_embeddings(msg.value()))
+                await self._consumer.acknowledge(msg)
+                consecutive_errors = 0
+
             except asyncio.TimeoutError:
                 continue
-                
-            except queue.Empty:
-                continue
-                
+
             except Exception as e:
-                logger.error(f"Exception sending to websocket: {str(e)}")
+                logger.error(f"Exception sending to websocket: {e}")
                 consecutive_errors += 1
-                
                 if consecutive_errors >= max_consecutive_errors:
                     logger.error("Too many consecutive errors, shutting down")
                     break
-                    
-                # Brief pause before retry
                 await asyncio.sleep(0.1)
-        
-        # Graceful cleanup handled in destroy()
-

--- a/trustgraph-flow/trustgraph/gateway/dispatch/document_embeddings_import.py
+++ b/trustgraph-flow/trustgraph/gateway/dispatch/document_embeddings_import.py
@@ -1,59 +1,44 @@
 
 import asyncio
-import uuid
 import logging
-from aiohttp import WSMsgType
 
-from ... schema import Metadata
-from ... schema import DocumentEmbeddings, ChunkEmbeddings
-from ... base import Publisher
+from ... schema import DocumentEmbeddings
 from ... messaging.translators.document_loading import DocumentEmbeddingsTranslator
 
-# Module logger
 logger = logging.getLogger(__name__)
 
 class DocumentEmbeddingsImport:
 
-    def __init__(
-            self, ws, running, backend, queue
-    ):
-
+    def __init__(self, ws, running, backend, queue):
         self.ws = ws
         self.running = running
+        self.backend = backend
+        self.queue = queue
         self.translator = DocumentEmbeddingsTranslator()
-        
-        self.publisher = Publisher(
-            backend, topic = queue, schema = DocumentEmbeddings
-        )
+        self.producer = None
 
     async def start(self):
-        await self.publisher.start()
+        self.producer = await self.backend.create_producer(
+            topic=self.queue, schema=DocumentEmbeddings,
+        )
 
     async def destroy(self):
-        # Step 1: Stop accepting new messages
         self.running.stop()
-
-        # Step 2: Wait for publisher to drain its queue
-        logger.info("Draining publisher queue...")
-        await self.publisher.stop()
-
-        # Step 3: Close websocket only after queue is drained
+        if self.producer:
+            await self.producer.close()
+            self.producer = None
         if self.ws:
             await self.ws.close()
 
     async def receive(self, msg):
-
         data = msg.json()
         elt = self.translator.decode(data)
-        await self.publisher.send(None, elt)
+        await self.producer.send(elt)
 
     async def run(self):
-
         while self.running.get():
             await asyncio.sleep(0.5)
 
         if self.ws:
             await self.ws.close()
-
         self.ws = None
-

--- a/trustgraph-flow/trustgraph/gateway/dispatch/entity_contexts_export.py
+++ b/trustgraph-flow/trustgraph/gateway/dispatch/entity_contexts_export.py
@@ -1,91 +1,63 @@
 
 import asyncio
-import queue
-import uuid
 import logging
 
 from ... schema import EntityContexts
-from ... base import Subscriber
 
 from . serialize import serialize_entity_contexts
 
-# Module logger
 logger = logging.getLogger(__name__)
 
 class EntityContextsExport:
 
-    def __init__(
-            self, ws, running, backend, queue, consumer, subscriber
-    ):
-
+    def __init__(self, ws, running, backend, queue, consumer, subscriber):
         self.ws = ws
         self.running = running
         self.backend = backend
         self.queue = queue
-        self.consumer = consumer
-        self.subscriber = subscriber
+        self.subscription = subscriber
+        self._consumer = None
 
     async def destroy(self):
-        # Step 1: Signal stop to prevent new messages
         self.running.stop()
-        
-        # Step 2: Wait briefly for in-flight messages
-        await asyncio.sleep(0.5)
-        
-        # Step 3: Unsubscribe and stop subscriber (triggers queue drain)
-        if hasattr(self, 'subs'):
-            await self.subs.unsubscribe_all(self.id)
-            await self.subs.stop()
-        
-        # Step 4: Close websocket last
+        if self._consumer:
+            try:
+                await self._consumer.close()
+            except BaseException:
+                pass
+            self._consumer = None
         if self.ws and not self.ws.closed:
             await self.ws.close()
 
     async def receive(self, msg):
-        # Ignore incoming info from websocket
         pass
 
     async def run(self):
-        """Enhanced run with better error handling"""
-        self.subs = Subscriber(
-            backend = self.backend,
-            topic = self.queue,
-            consumer_name = self.consumer,
-            subscription = self.subscriber,
-            schema = EntityContexts,
-            backpressure_strategy = "block"  # Configurable
+        self._consumer = await self.backend.create_consumer(
+            topic=self.queue,
+            subscription=self.subscription,
+            schema=EntityContexts,
         )
-        
-        await self.subs.start()
-        
-        self.id = str(uuid.uuid4())
-        q = await self.subs.subscribe_all(self.id)
-        
+
         consecutive_errors = 0
         max_consecutive_errors = 5
-        
+
         while self.running.get():
             try:
-                resp = await asyncio.wait_for(q.get(), timeout=0.5)
-                await self.ws.send_json(serialize_entity_contexts(resp))
-                consecutive_errors = 0  # Reset on success
-                
+                msg = await asyncio.wait_for(
+                    self._consumer.receive(), timeout=0.5,
+                )
+                await self.ws.send_json(serialize_entity_contexts(msg.value()))
+                await self._consumer.acknowledge(msg)
+                consecutive_errors = 0
+
             except asyncio.TimeoutError:
                 continue
-                
-            except queue.Empty:
-                continue
-                
+
             except Exception as e:
-                logger.error(f"Exception sending to websocket: {str(e)}")
+                logger.error(f"Exception sending to websocket: {e}")
                 consecutive_errors += 1
-                
                 if consecutive_errors >= max_consecutive_errors:
                     logger.error("Too many consecutive errors, shutting down")
                     break
-                    
-                # Brief pause before retry
                 await asyncio.sleep(0.1)
-        
-        # Graceful cleanup handled in destroy()
-

--- a/trustgraph-flow/trustgraph/gateway/dispatch/entity_contexts_import.py
+++ b/trustgraph-flow/trustgraph/gateway/dispatch/entity_contexts_import.py
@@ -1,48 +1,37 @@
 
 import asyncio
-import uuid
 import logging
-from aiohttp import WSMsgType
 
 from ... schema import Metadata
 from ... schema import EntityContexts, EntityContext
-from ... base import Publisher
 
 from . serialize import to_value
 
-# Module logger
 logger = logging.getLogger(__name__)
 
 class EntityContextsImport:
 
-    def __init__(
-            self, ws, running, backend, queue
-    ):
-
+    def __init__(self, ws, running, backend, queue):
         self.ws = ws
         self.running = running
-        
-        self.publisher = Publisher(
-            backend, topic = queue, schema = EntityContexts
-        )
+        self.backend = backend
+        self.queue = queue
+        self.producer = None
 
     async def start(self):
-        await self.publisher.start()
+        self.producer = await self.backend.create_producer(
+            topic=self.queue, schema=EntityContexts,
+        )
 
     async def destroy(self):
-        # Step 1: Stop accepting new messages
         self.running.stop()
-
-        # Step 2: Wait for publisher to drain its queue
-        logger.info("Draining publisher queue...")
-        await self.publisher.stop()
-
-        # Step 3: Close websocket only after queue is drained
+        if self.producer:
+            await self.producer.close()
+            self.producer = None
         if self.ws:
             await self.ws.close()
 
     async def receive(self, msg):
-
         data = msg.json()
 
         elt = EntityContexts(
@@ -59,15 +48,12 @@ class EntityContextsImport:
             ]
         )
 
-        await self.publisher.send(None, elt)
+        await self.producer.send(elt)
 
     async def run(self):
-
         while self.running.get():
             await asyncio.sleep(0.5)
 
         if self.ws:
             await self.ws.close()
-
         self.ws = None
-

--- a/trustgraph-flow/trustgraph/gateway/dispatch/graph_embeddings_export.py
+++ b/trustgraph-flow/trustgraph/gateway/dispatch/graph_embeddings_export.py
@@ -1,91 +1,63 @@
 
 import asyncio
-import queue
-import uuid
 import logging
 
 from ... schema import GraphEmbeddings
-from ... base import Subscriber
 
 from . serialize import serialize_graph_embeddings
 
-# Module logger
 logger = logging.getLogger(__name__)
 
 class GraphEmbeddingsExport:
 
-    def __init__(
-            self, ws, running, backend, queue, consumer, subscriber
-    ):
-
+    def __init__(self, ws, running, backend, queue, consumer, subscriber):
         self.ws = ws
         self.running = running
         self.backend = backend
         self.queue = queue
-        self.consumer = consumer
-        self.subscriber = subscriber
+        self.subscription = subscriber
+        self._consumer = None
 
     async def destroy(self):
-        # Step 1: Signal stop to prevent new messages
         self.running.stop()
-        
-        # Step 2: Wait briefly for in-flight messages
-        await asyncio.sleep(0.5)
-        
-        # Step 3: Unsubscribe and stop subscriber (triggers queue drain)
-        if hasattr(self, 'subs'):
-            await self.subs.unsubscribe_all(self.id)
-            await self.subs.stop()
-        
-        # Step 4: Close websocket last
+        if self._consumer:
+            try:
+                await self._consumer.close()
+            except BaseException:
+                pass
+            self._consumer = None
         if self.ws and not self.ws.closed:
             await self.ws.close()
 
     async def receive(self, msg):
-        # Ignore incoming info from websocket
         pass
 
     async def run(self):
-        """Enhanced run with better error handling"""
-        self.subs = Subscriber(
-            backend = self.backend,
-            topic = self.queue,
-            consumer_name = self.consumer,
-            subscription = self.subscriber,
-            schema = GraphEmbeddings,
-            backpressure_strategy = "block"  # Configurable
+        self._consumer = await self.backend.create_consumer(
+            topic=self.queue,
+            subscription=self.subscription,
+            schema=GraphEmbeddings,
         )
-        
-        await self.subs.start()
-        
-        self.id = str(uuid.uuid4())
-        q = await self.subs.subscribe_all(self.id)
-        
+
         consecutive_errors = 0
         max_consecutive_errors = 5
-        
+
         while self.running.get():
             try:
-                resp = await asyncio.wait_for(q.get(), timeout=0.5)
-                await self.ws.send_json(serialize_graph_embeddings(resp))
-                consecutive_errors = 0  # Reset on success
-                
+                msg = await asyncio.wait_for(
+                    self._consumer.receive(), timeout=0.5,
+                )
+                await self.ws.send_json(serialize_graph_embeddings(msg.value()))
+                await self._consumer.acknowledge(msg)
+                consecutive_errors = 0
+
             except asyncio.TimeoutError:
                 continue
-                
-            except queue.Empty:
-                continue
-                
+
             except Exception as e:
-                logger.error(f"Exception sending to websocket: {str(e)}")
+                logger.error(f"Exception sending to websocket: {e}")
                 consecutive_errors += 1
-                
                 if consecutive_errors >= max_consecutive_errors:
                     logger.error("Too many consecutive errors, shutting down")
                     break
-                    
-                # Brief pause before retry
                 await asyncio.sleep(0.1)
-        
-        # Graceful cleanup handled in destroy()
-

--- a/trustgraph-flow/trustgraph/gateway/dispatch/graph_embeddings_import.py
+++ b/trustgraph-flow/trustgraph/gateway/dispatch/graph_embeddings_import.py
@@ -1,48 +1,37 @@
 
 import asyncio
-import uuid
 import logging
-from aiohttp import WSMsgType
 
 from ... schema import Metadata
 from ... schema import GraphEmbeddings, EntityEmbeddings
-from ... base import Publisher
 
 from . serialize import to_value
 
-# Module logger
 logger = logging.getLogger(__name__)
 
 class GraphEmbeddingsImport:
 
-    def __init__(
-            self, ws, running, backend, queue
-    ):
-
+    def __init__(self, ws, running, backend, queue):
         self.ws = ws
         self.running = running
-        
-        self.publisher = Publisher(
-            backend, topic = queue, schema = GraphEmbeddings
-        )
+        self.backend = backend
+        self.queue = queue
+        self.producer = None
 
     async def start(self):
-        await self.publisher.start()
+        self.producer = await self.backend.create_producer(
+            topic=self.queue, schema=GraphEmbeddings,
+        )
 
     async def destroy(self):
-        # Step 1: Stop accepting new messages
         self.running.stop()
-
-        # Step 2: Wait for publisher to drain its queue
-        logger.info("Draining publisher queue...")
-        await self.publisher.stop()
-
-        # Step 3: Close websocket only after queue is drained
+        if self.producer:
+            await self.producer.close()
+            self.producer = None
         if self.ws:
             await self.ws.close()
 
     async def receive(self, msg):
-
         data = msg.json()
 
         elt = GraphEmbeddings(
@@ -59,15 +48,12 @@ class GraphEmbeddingsImport:
             ]
         )
 
-        await self.publisher.send(None, elt)
+        await self.producer.send(elt)
 
     async def run(self):
-
         while self.running.get():
             await asyncio.sleep(0.5)
 
         if self.ws:
             await self.ws.close()
-
         self.ws = None
-

--- a/trustgraph-flow/trustgraph/gateway/dispatch/requestor.py
+++ b/trustgraph-flow/trustgraph/gateway/dispatch/requestor.py
@@ -1,10 +1,8 @@
 
 import asyncio
-import uuid
 import logging
 
-from ... base import Publisher
-from ... base import Subscriber
+from ... base.request_response_client import RequestResponseClient
 
 logger = logging.getLogger("requestor")
 logger.setLevel(logging.INFO)
@@ -20,30 +18,30 @@ class ServiceRequestor:
             timeout=600,
     ):
 
-        self.pub = Publisher(
-            backend, request_queue,
-            schema=request_schema,
-        )
-
-        self.sub = Subscriber(
-            backend, response_queue,
-            subscription, consumer_name,
-            response_schema
-        )
-
+        self.backend = backend
+        self.request_queue = request_queue
+        self.request_schema = request_schema
+        self.response_queue = response_queue
+        self.response_schema = response_schema
         self.timeout = timeout
-
+        self.client = None
         self.running = True
 
     async def start(self):
         self.running = True
-        await self.sub.start()
-        await self.pub.start()
+        self.client = await RequestResponseClient.create(
+            backend=self.backend,
+            request_topic=self.request_queue,
+            response_topic=self.response_queue,
+            request_schema=self.request_schema,
+            response_schema=self.response_schema,
+        )
 
     async def stop(self):
-        await self.pub.stop()
-        await self.sub.stop()
         self.running = False
+        if self.client:
+            await self.client.close()
+            self.client = None
 
     def to_request(self, request):
         raise RuntimeError("Not defined")
@@ -53,40 +51,41 @@ class ServiceRequestor:
 
     async def process(self, request, responder=None):
 
-        id = str(uuid.uuid4())
-
         try:
 
-            q = await self.sub.subscribe(id)
+            if responder is None:
+                resp = await self.client.request(
+                    self.to_request(request),
+                    timeout=self.timeout,
+                )
 
-            await self.pub.send(id, self.to_request(request))
+                if resp.error:
+                    return { "error": {
+                        "type": resp.error.type,
+                        "message": resp.error.message,
+                    } }
 
-            while self.running:
+                result, fin = self.from_response(resp)
+                return result
 
-                try:
-                    resp = await asyncio.wait_for(
-                        q.get(), timeout=self.timeout
-                    )
-                except Exception as e:
-                    logger.error(f"Request timeout exception: {e}", exc_info=True)
-                    raise RuntimeError("Timeout")
+            async for resp in self.client.request_stream(
+                self.to_request(request),
+                timeout=self.timeout,
+            ):
 
                 if resp.error:
                     err = { "error": {
                         "type": resp.error.type,
                         "message": resp.error.message,
                     } }
-                    if responder:
-                        await responder(err, True)
+                    await responder(err, True)
                     return err
 
-                resp, fin = self.from_response(resp)
-
-                if responder:
-                    await responder(resp, fin)
+                result, fin = self.from_response(resp)
+                await responder(result, fin)
 
                 if fin:
-                    return resp
+                    return result
 
         except Exception as e:
 
@@ -99,7 +98,4 @@ class ServiceRequestor:
             if responder:
                 await responder(err, True)
             return err
-
-        finally:
-            await self.sub.unsubscribe(id)
 

--- a/trustgraph-flow/trustgraph/gateway/dispatch/rows_import.py
+++ b/trustgraph-flow/trustgraph/gateway/dispatch/rows_import.py
@@ -1,53 +1,38 @@
 import asyncio
-import uuid
 import logging
-from aiohttp import WSMsgType
 
 from ... schema import Metadata
 from ... schema import ExtractedObject
-from ... base import Publisher
 
-from . serialize import to_subgraph
-
-# Module logger
 logger = logging.getLogger(__name__)
 
 class RowsImport:
 
-    def __init__(
-            self, ws, running, backend, queue
-    ):
-
+    def __init__(self, ws, running, backend, queue):
         self.ws = ws
         self.running = running
-
-        self.publisher = Publisher(
-            backend, topic = queue, schema = ExtractedObject
-        )
+        self.backend = backend
+        self.queue = queue
+        self.producer = None
 
     async def start(self):
-        await self.publisher.start()
+        self.producer = await self.backend.create_producer(
+            topic=self.queue, schema=ExtractedObject,
+        )
 
     async def destroy(self):
-        # Step 1: Stop accepting new messages
         self.running.stop()
-
-        # Step 2: Wait for publisher to drain its queue
-        logger.info("Draining publisher queue...")
-        await self.publisher.stop()
-
-        # Step 3: Close websocket only after queue is drained
+        if self.producer:
+            await self.producer.close()
+            self.producer = None
         if self.ws:
             await self.ws.close()
 
     async def receive(self, msg):
-
         data = msg.json()
 
-        # Handle both single object and array of objects for backward compatibility
         values_data = data["values"]
         if not isinstance(values_data, list):
-            # Single object - wrap in array
             values_data = [values_data]
 
         elt = ExtractedObject(
@@ -61,14 +46,12 @@ class RowsImport:
             source_span=data.get("source_span", ""),
         )
 
-        await self.publisher.send(None, elt)
+        await self.producer.send(elt)
 
     async def run(self):
-
         while self.running.get():
             await asyncio.sleep(0.5)
 
         if self.ws:
             await self.ws.close()
-
         self.ws = None

--- a/trustgraph-flow/trustgraph/gateway/dispatch/sender.py
+++ b/trustgraph-flow/trustgraph/gateway/dispatch/sender.py
@@ -1,11 +1,5 @@
 
-# Like ServiceRequestor, but just fire-and-forget instead of request/response
-
-import asyncio
-import uuid
 import logging
-
-from ... base import Publisher
 
 logger = logging.getLogger("sender")
 logger.setLevel(logging.INFO)
@@ -18,16 +12,21 @@ class ServiceSender:
             queue, schema,
     ):
 
-        self.pub = Publisher(
-            backend, queue,
-            schema=schema,
-        )
+        self.backend = backend
+        self.queue = queue
+        self.schema = schema
+        self.producer = None
 
     async def start(self):
-        await self.pub.start()
+        self.producer = await self.backend.create_producer(
+            topic=self.queue,
+            schema=self.schema,
+        )
 
     async def stop(self):
-        await self.pub.stop()
+        if self.producer:
+            await self.producer.close()
+            self.producer = None
 
     def to_request(self, request):
         raise RuntimeError("Not defined")
@@ -36,7 +35,7 @@ class ServiceSender:
 
         try:
 
-            await self.pub.send(None, self.to_request(request))
+            await self.producer.send(self.to_request(request))
 
             if responder:
                 await responder({}, True)
@@ -53,4 +52,3 @@ class ServiceSender:
                 await responder(err, True)
 
             return err
-

--- a/trustgraph-flow/trustgraph/gateway/dispatch/triples_export.py
+++ b/trustgraph-flow/trustgraph/gateway/dispatch/triples_export.py
@@ -1,91 +1,63 @@
 
 import asyncio
-import queue
-import uuid
 import logging
 
 from ... schema import Triples
-from ... base import Subscriber
 
 from . serialize import serialize_triples
 
-# Module logger
 logger = logging.getLogger(__name__)
 
 class TriplesExport:
 
-    def __init__(
-            self, ws, running, backend, queue, consumer, subscriber
-    ):
-
+    def __init__(self, ws, running, backend, queue, consumer, subscriber):
         self.ws = ws
         self.running = running
         self.backend = backend
         self.queue = queue
-        self.consumer = consumer
-        self.subscriber = subscriber
+        self.subscription = subscriber
+        self._consumer = None
 
     async def destroy(self):
-        # Step 1: Signal stop to prevent new messages
         self.running.stop()
-        
-        # Step 2: Wait briefly for in-flight messages
-        await asyncio.sleep(0.5)
-        
-        # Step 3: Unsubscribe and stop subscriber (triggers queue drain)
-        if hasattr(self, 'subs'):
-            await self.subs.unsubscribe_all(self.id)
-            await self.subs.stop()
-        
-        # Step 4: Close websocket last
+        if self._consumer:
+            try:
+                await self._consumer.close()
+            except BaseException:
+                pass
+            self._consumer = None
         if self.ws and not self.ws.closed:
             await self.ws.close()
 
     async def receive(self, msg):
-        # Ignore incoming info from websocket
         pass
 
     async def run(self):
-        """Enhanced run with better error handling"""
-        self.subs = Subscriber(
-            backend = self.backend,
-            topic = self.queue,
-            consumer_name = self.consumer,
-            subscription = self.subscriber,
-            schema = Triples,
-            backpressure_strategy = "block"  # Configurable
+        self._consumer = await self.backend.create_consumer(
+            topic=self.queue,
+            subscription=self.subscription,
+            schema=Triples,
         )
-        
-        await self.subs.start()
-        
-        self.id = str(uuid.uuid4())
-        q = await self.subs.subscribe_all(self.id)
-        
+
         consecutive_errors = 0
         max_consecutive_errors = 5
-        
+
         while self.running.get():
             try:
-                resp = await asyncio.wait_for(q.get(), timeout=0.5)
-                await self.ws.send_json(serialize_triples(resp))
-                consecutive_errors = 0  # Reset on success
-                
+                msg = await asyncio.wait_for(
+                    self._consumer.receive(), timeout=0.5,
+                )
+                await self.ws.send_json(serialize_triples(msg.value()))
+                await self._consumer.acknowledge(msg)
+                consecutive_errors = 0
+
             except asyncio.TimeoutError:
                 continue
-                
-            except queue.Empty:
-                continue
-                
+
             except Exception as e:
-                logger.error(f"Exception sending to websocket: {str(e)}")
+                logger.error(f"Exception sending to websocket: {e}")
                 consecutive_errors += 1
-                
                 if consecutive_errors >= max_consecutive_errors:
                     logger.error("Too many consecutive errors, shutting down")
                     break
-                    
-                # Brief pause before retry
                 await asyncio.sleep(0.1)
-        
-        # Graceful cleanup handled in destroy()
-

--- a/trustgraph-flow/trustgraph/gateway/dispatch/triples_import.py
+++ b/trustgraph-flow/trustgraph/gateway/dispatch/triples_import.py
@@ -1,48 +1,37 @@
 
 import asyncio
-import uuid
 import logging
-from aiohttp import WSMsgType
 
 from ... schema import Metadata
 from ... schema import Triples
-from ... base import Publisher
 
 from . serialize import to_subgraph
 
-# Module logger
 logger = logging.getLogger(__name__)
 
 class TriplesImport:
 
-    def __init__(
-            self, ws, running, backend, queue
-    ):
-
+    def __init__(self, ws, running, backend, queue):
         self.ws = ws
         self.running = running
-        
-        self.publisher = Publisher(
-            backend, topic = queue, schema = Triples
-        )
+        self.backend = backend
+        self.queue = queue
+        self.producer = None
 
     async def start(self):
-        await self.publisher.start()
+        self.producer = await self.backend.create_producer(
+            topic=self.queue, schema=Triples,
+        )
 
     async def destroy(self):
-        # Step 1: Stop accepting new messages
         self.running.stop()
-
-        # Step 2: Wait for publisher to drain its queue
-        logger.info("Draining publisher queue...")
-        await self.publisher.stop()
-
-        # Step 3: Close websocket only after queue is drained
+        if self.producer:
+            await self.producer.close()
+            self.producer = None
         if self.ws:
             await self.ws.close()
 
     async def receive(self, msg):
-
         data = msg.json()
 
         elt = Triples(
@@ -54,15 +43,12 @@ class TriplesImport:
             triples=to_subgraph(data["triples"]),
         )
 
-        await self.publisher.send(None, elt)
+        await self.producer.send(elt)
 
     async def run(self):
-
         while self.running.get():
             await asyncio.sleep(0.5)
 
         if self.ws:
             await self.ws.close()
-
         self.ws = None
-

--- a/trustgraph-flow/trustgraph/gateway/service.py
+++ b/trustgraph-flow/trustgraph/gateway/service.py
@@ -10,7 +10,7 @@ import logging
 import os
 
 from trustgraph.base.logging import setup_logging, add_logging_args
-from trustgraph.base.pubsub import get_pubsub, add_pubsub_args
+from trustgraph.base.pubsub import get_async_pubsub, add_pubsub_args
 from trustgraph.base import AuditPublisher
 
 from . auth import IamAuth
@@ -51,8 +51,8 @@ class Api:
 
         self.pulsar_listener = config.get("pulsar_listener", None)
 
-        # Create backend using factory
-        self.pubsub_backend = get_pubsub(**config)
+        # Create async backend using factory
+        self.pubsub_backend = get_async_pubsub(**config)
 
         self.prometheus_url = config.get(
             "prometheus_url", default_prometheus_url,
@@ -125,7 +125,7 @@ class Api:
         )
 
         self.audit_publisher = AuditPublisher(
-            backend=self.pubsub_backend,
+            async_backend=self.pubsub_backend,
             component_name="api-gateway",
             processor_id=config.get("id", "api-gateway"),
         )
@@ -152,6 +152,8 @@ class Api:
         # Blocks for a bounded retry window; the gateway starts even
         # if IAM is still unreachable (JWT validation will 401 until
         # the key is available).
+        await self.audit_publisher.start()
+
         await self.auth.start()
 
         await self.config_receiver.start()

--- a/trustgraph-flow/trustgraph/rev_gateway/service.py
+++ b/trustgraph-flow/trustgraph/rev_gateway/service.py
@@ -17,7 +17,7 @@ from urllib.parse import urlparse, urlunparse
 from .dispatcher import MessageDispatcher
 from ..gateway.auth import IamAuth
 from ..gateway.config.receiver import ConfigReceiver
-from ..base.pubsub import get_pubsub, add_pubsub_args
+from ..base.pubsub import get_async_pubsub, add_pubsub_args
 from ..base.logging import setup_logging, add_logging_args
 
 logger = logging.getLogger("rev_gateway")
@@ -62,7 +62,7 @@ class ReverseGateway:
         self.running = False
         self.reconnect_delay = 3.0
 
-        self.backend = get_pubsub(**config)
+        self.backend = get_async_pubsub(**config)
 
         self.auth = IamAuth(
             backend=self.backend,
@@ -178,7 +178,7 @@ class ReverseGateway:
         await self.disconnect()
 
         if hasattr(self, 'backend'):
-            self.backend.close()
+            await self.backend.close()
 
     def stop(self):
         self.running = False


### PR DESCRIPTION
## Summary
- Replace all sync `Publisher`/`Subscriber`/`Consumer`/`Producer` usage with async backend (`RequestResponseClient`, `create_producer`, `create_consumer`)
- Zero OS threads for broker I/O — removes all `ThreadPoolExecutor` usage from gateway
- Update `AuditPublisher` to support async backend directly
- 16 files changed, net -212 lines

## Test plan
- [ ] Gateway starts and serves requests via Pulsar
- [ ] WebSocket mux (agent, text-completion) works end-to-end
- [ ] Config notify picks up flow changes
- [ ] Import/export streaming works
- [ ] IAM auth (JWT + API key) works
- [ ] Rev-gateway connects and dispatches