### PR TITLE
Comprehensive metrics refactor across all three layers

### DIFF
--- a/docs/metrics-guide.md
+++ b/docs/metrics-guide.md
@@ -1,0 +1,225 @@
+# TrustGraph Metrics Guide
+
+TrustGraph exposes Prometheus metrics on a per-process `/metrics` HTTP
+endpoint.  All metric names use the `tg_` prefix to avoid collisions
+with library or infrastructure metrics.
+
+Metrics are organised in three layers:
+
+- **Layer 1 — Infrastructure** (automatic): message consumption,
+  production, rate limiting, processor identity.  Emitted by
+  `ReceiverPool` / `SenderPool` with no application code required.
+- **Layer 2 — Service base classes** (semi-automatic): downstream call
+  duration, embeddings / reranker / query / store service metrics.
+  Instrumented in the base class; implementations inherit them.
+- **Layer 3 — Application** (manual): agent orchestration, gateway,
+  knowledge extraction, IAM, metering.  Added per-processor where
+  domain-specific signals matter.
+
+
+## Histogram bucket presets
+
+Three centrally defined presets are available in
+`trustgraph.base.metrics` for consistent histogram boundaries:
+
+| Preset | Values | Use case |
+|---|---|---|
+| `BUCKETS_STANDARD` | 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0 | Internal RPCs, store operations, short-lived calls |
+| `BUCKETS_LLM` | 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0, 60.0, 120.0 | LLM completions, embeddings, extraction |
+| `BUCKETS_SESSION` | 1.0, 5.0, 10.0, 30.0, 60.0, 120.0, 300.0, 600.0 | End-to-end user-facing requests, agent sessions |
+
+
+## Metric reference
+
+### Infrastructure (Layer 1)
+
+These are emitted automatically for every consumer and producer
+registered through the pool APIs.  Config-internal consumers
+(registered with `instrument=False`) are excluded.
+
+| Metric | Type | Labels | Description |
+|---|---|---|---|
+| `tg_consumer_state` | Enum | processor, consumer | Consumer lifecycle state (starting, running, stopped, error) |
+| `tg_consumer_processing_total` | Counter | processor, consumer, status | Messages processed (status: ok, error) |
+| `tg_consumer_rate_limit_total` | Counter | processor, consumer | TooManyRequests rate-limit events (not counted as errors) |
+| `tg_consumer_request_duration_seconds` | Histogram | processor, consumer | Per-message processing latency |
+| `tg_producer_messages_total` | Counter | processor, producer | Messages sent to output topics |
+| `tg_config_version` | Gauge | processor | Current config version known to this processor |
+| `tg_processor_info` | Info | processor | Static processor metadata (version, backend, etc.) |
+
+### Downstream calls (Layer 2)
+
+Instrumented automatically when `RequestResponseClient` is created
+with `processor_id` and `target_service` parameters (wired by
+`RequestResponseSpec` for flow processors, and by
+`ServiceRequestor.start()` for the gateway).
+
+| Metric | Type | Labels | Description |
+|---|---|---|---|
+| `tg_downstream_call_duration_seconds` | Histogram | processor, target_service | Round-trip latency for request/response calls |
+| `tg_downstream_timeout_total` | Counter | processor, target_service | Calls that hit the timeout deadline |
+| `tg_downstream_error_total` | Counter | processor, target_service, error_type | Downstream call errors by type |
+
+### Embeddings service (Layer 2)
+
+| Metric | Type | Labels | Description |
+|---|---|---|---|
+| `tg_embeddings_request_total` | Counter | processor, model | Embedding requests processed |
+| `tg_embeddings_duration_seconds` | Histogram | processor, model | Embedding call latency |
+| `tg_embeddings_batch_size` | Histogram | processor, model | Number of texts per request |
+
+### Reranker service (Layer 2)
+
+| Metric | Type | Labels | Description |
+|---|---|---|---|
+| `tg_reranker_request_total` | Counter | processor, model | Rerank requests processed |
+| `tg_reranker_duration_seconds` | Histogram | processor, model | Rerank call latency |
+| `tg_reranker_result_count` | Histogram | processor, model | Results returned per call |
+
+### Query services (Layer 2)
+
+| Metric | Type | Labels | Description |
+|---|---|---|---|
+| `tg_triples_query_duration_seconds` | Histogram | processor | Triples query backend latency |
+| `tg_triples_query_result_count` | Histogram | processor | Triples returned per query |
+| `tg_graph_embeddings_query_duration_seconds` | Histogram | processor | Graph embeddings query latency |
+| `tg_graph_embeddings_query_result_count` | Histogram | processor | Entities returned per query |
+| `tg_document_embeddings_query_duration_seconds` | Histogram | processor | Document embeddings query latency |
+| `tg_document_embeddings_query_result_count` | Histogram | processor | Chunks returned per query |
+
+### Store services (Layer 2)
+
+Write metrics are defined in the base classes and inherited by all
+backend implementations (Neo4j, Cassandra, Memgraph, FalkorDB, Qdrant,
+Milvus, Pinecone).
+
+| Metric | Type | Labels | Description |
+|---|---|---|---|
+| `tg_triples_store_write_duration_seconds` | Histogram | processor | Write latency per batch |
+| `tg_triples_store_write_batch_size` | Histogram | processor | Triples per write batch |
+| `tg_triples_store_write_error_total` | Counter | processor | Write errors |
+| `tg_graph_embeddings_store_write_duration_seconds` | Histogram | processor | Write latency per batch |
+| `tg_graph_embeddings_store_write_batch_size` | Histogram | processor | Embeddings per write batch |
+| `tg_graph_embeddings_store_write_error_total` | Counter | processor | Write errors |
+| `tg_document_embeddings_store_write_duration_seconds` | Histogram | processor | Write latency per batch |
+| `tg_document_embeddings_store_write_batch_size` | Histogram | processor | Embeddings per write batch |
+| `tg_document_embeddings_store_write_error_total` | Counter | processor | Write errors |
+
+### LLM and vision services (Layer 2)
+
+| Metric | Type | Labels | Description |
+|---|---|---|---|
+| `tg_text_completion_duration_seconds` | Histogram | processor | Text completion latency |
+| `tg_text_completion_model` | Info | processor | Active LLM model metadata |
+| `tg_image_to_text_duration_seconds` | Histogram | processor | Image-to-text latency |
+| `tg_image_to_text_model` | Info | processor | Active vision model metadata |
+
+### Tool services (Layer 2)
+
+| Metric | Type | Labels | Description |
+|---|---|---|---|
+| `tg_tool_invocation_total` | Counter | processor, tool | Tool invocations |
+| `tg_dynamic_tool_service_invocation_total` | Counter | processor | Dynamic tool service invocations |
+
+### Agent orchestration (Layer 3)
+
+Emitted by the ReAct agent processor.
+
+| Metric | Type | Labels | Description |
+|---|---|---|---|
+| `tg_agent_session_total` | Counter | processor, outcome | Agent sessions (outcome: completed, max-iterations, error) |
+| `tg_agent_iteration_count` | Histogram | processor | ReAct iterations per session |
+| `tg_agent_tool_invocation_total` | Counter | processor, tool | Tool calls by tool name |
+| `tg_agent_tool_duration_seconds` | Histogram | processor, tool | Per-tool invocation latency |
+| `tg_agent_tool_error_total` | Counter | processor, tool | Tool invocation failures |
+| `tg_agent_llm_duration_seconds` | Histogram | processor | LLM reasoning step latency |
+
+### Gateway (Layer 3)
+
+#### Request dispatch
+
+| Metric | Type | Labels | Description |
+|---|---|---|---|
+| `tg_gateway_request_total` | Counter | service, status | Dispatched operations (status: ok, error) |
+| `tg_gateway_request_duration_seconds` | Histogram | service | End-to-end request latency |
+
+#### Authentication and authorisation
+
+| Metric | Type | Labels | Description |
+|---|---|---|---|
+| `tg_gateway_signing_key_state` | Enum | — | IAM signing key fetch state (absent, present) |
+| `tg_gateway_auth_failure_total` | Counter | reason | Authentication failures (reason: no-signing-key, invalid-jwt, jwt-missing-claims, anonymous-rejected, invalid-api-key) |
+| `tg_gateway_authz_decision_total` | Counter | outcome | Authorisation decisions (outcome: allow, deny, error) |
+
+#### Inventory
+
+| Metric | Type | Labels | Description |
+|---|---|---|---|
+| `tg_gateway_known_workspaces` | Gauge | — | Workspaces known to the gateway |
+| `tg_gateway_active_flow_count` | Gauge | — | Active flows tracked by the gateway |
+
+### Knowledge extraction (Layer 3)
+
+Shared metric names across all three extractors, distinguished by the
+`extractor` label (`definitions`, `relationships`, `ontology`).
+
+| Metric | Type | Labels | Description |
+|---|---|---|---|
+| `tg_extraction_duration_seconds` | Histogram | processor, extractor | Wall-clock time per chunk extraction |
+| `tg_extraction_triple_total` | Counter | processor, extractor | Content triples produced |
+| `tg_extraction_entity_total` | Counter | processor, extractor | Entities extracted (definitions extractor only) |
+| `tg_extraction_empty_total` | Counter | processor, extractor | Chunks that yielded zero extractions |
+
+#### Ontology-specific
+
+| Metric | Type | Labels | Description |
+|---|---|---|---|
+| `tg_ontology_loaded_count` | Gauge | processor, workspace | Ontology definitions loaded from config |
+| `tg_ontology_element_count` | Gauge | processor | Embedded ontology elements |
+| `tg_ontology_selection_count` | Histogram | processor | Elements selected per chunk |
+| `tg_ontology_selection_duration_seconds` | Histogram | processor | Similarity selection time per chunk |
+| `tg_ontology_no_match_total` | Counter | processor | Chunks with no ontology match |
+
+### IAM service (Layer 3)
+
+| Metric | Type | Labels | Description |
+|---|---|---|---|
+| `tg_iam_request_total` | Counter | operation, outcome | Per-operation request count (outcome: ok, error, exception) |
+| `tg_iam_request_duration_seconds` | Histogram | operation | Per-operation latency |
+| `tg_iam_user_count` | Gauge | — | Total IAM users |
+| `tg_iam_workspace_count` | Gauge | — | Total IAM workspaces |
+| `tg_iam_api_key_created_total` | Counter | — | Lifetime API keys created |
+| `tg_iam_api_key_revoked_total` | Counter | — | Lifetime API keys revoked |
+
+### Chunking (Layer 3)
+
+| Metric | Type | Labels | Description |
+|---|---|---|---|
+| `tg_chunk_size` | Histogram | processor | Size of produced text chunks |
+
+### Metering (Layer 3)
+
+| Metric | Type | Labels | Description |
+|---|---|---|---|
+| `tg_metering_tokens_total` | Counter | model, direction | Token count by model and direction (input/output) |
+| `tg_metering_cost_usd_total` | Counter | model, direction | Estimated cost in USD |
+
+
+## Adding new metrics
+
+Follow these conventions when adding metrics:
+
+1. **Prefix**: always use `tg_`.
+2. **Naming**: `tg_{domain}_{noun}_{unit}` for histograms/gauges,
+   `tg_{domain}_{noun}_total` for counters.
+3. **Singleton pattern**: use `if not hasattr(__class__, "metric_name"):`
+   to create metrics once per class, not per instance.
+4. **Labels**: include `processor` where applicable. Use human-readable
+   names for discriminating labels (e.g. `extractor="definitions"`),
+   not topic names or internal IDs.
+5. **Buckets**: use one of the three preset tuples from
+   `trustgraph.base.metrics` rather than defining custom boundaries.
+6. **TooManyRequests**: never count rate-limit retries as errors.
+   They are tracked separately via `tg_consumer_rate_limit_total`.
+7. **Config consumers**: register with `instrument=False` so internal
+   config subscriptions don't pollute work metrics.

--- a/docs/tech-specs/metrics-refactor.md
+++ b/docs/tech-specs/metrics-refactor.md
@@ -1,0 +1,882 @@
+---
+layout: default
+title: "Metrics Refactor Technical Specification"
+parent: "Tech Specs"
+---
+
+# Metrics Refactor Technical Specification
+
+## Overview
+
+This specification describes a refactor of TrustGraph's Prometheus metrics
+to address issues inherited from the sync-to-async pub/sub migration,
+reduce cardinality, improve naming consistency, and ensure all
+observable behaviour is properly instrumented.
+
+## Current State
+
+### Metric Inventory
+
+TrustGraph defines 19 Prometheus metrics across 8 files.  The tables
+below document every metric as of v2.8.
+
+#### Infrastructure metrics (metrics.py, wired via ReceiverPool / SenderPool)
+
+| Metric | Type | Labels | Status | Notes |
+|--------|------|--------|--------|-------|
+| `consumer_state` | Enum | processor, consumer | Live | Running/stopped lifecycle, set on add/remove consumer |
+| `request_latency` | Histogram | processor, consumer | Live | Handler wall-clock time (default buckets, max 10 s) |
+| `processing_count` | Counter | processor, consumer, status | Live | Incremented per handler call with status ok/error |
+| `rate_limit_count` | Counter | processor, consumer | Registered | Never incremented in the async path |
+| `producer_count` | Counter | processor, producer | Live | Incremented on every ProducerHandle.send() |
+| `processor` (processor_info) | Info | processor | Live | Emitted once at processor startup with config dict |
+| `subscriber_state` | Enum | processor, subscriber | Dead | SubscriberMetrics class exists but nothing instantiates it |
+| `received_count` | Counter | processor, subscriber | Dead | Same -- no async wiring |
+| `dropped_count` | Counter | processor, subscriber | Dead | Same -- no async wiring |
+
+#### Service-specific metrics
+
+| Metric | Type | Labels | Defined in | Notes |
+|--------|------|--------|------------|-------|
+| `tool_invocation_count` | Counter | processor, tool | `base/tool_service.py` | Per-tool counter inside ToolService.on_request |
+| `dynamic_tool_service_invocation_count` | Counter | processor | `base/dynamic_tool_service.py` | Single counter, no tool-name breakdown |
+| `text_completion_duration` | Histogram | processor | `base/llm_service.py` | Custom buckets 0.25 s -- 120 s |
+| `text_completion_model` | Info | processor | `base/llm_service.py` | Records model name and temperature |
+| `image_to_text_duration` | Histogram | processor | `base/image_to_text_service.py` | Custom buckets 0.25 s -- 120 s |
+| `image_to_text_model` | Info | processor | `base/image_to_text_service.py` | Records model name |
+| `chunk_size` | Histogram | processor | `chunking/token/chunker.py` | Custom buckets 100 -- 16 000 |
+| `chunk_size` | Histogram | processor | `chunking/recursive/chunker.py` | Same metric name, same buckets -- will collide if both chunkers run in one process |
+
+#### Metering metrics
+
+| Metric | Type | Labels | Defined in | Notes |
+|--------|------|--------|------------|-------|
+| `tokens` | Counter | model, direction | `metering/counter.py` | Cumulative token count, direction = input/output |
+| `cost` | Counter | model, direction | `metering/counter.py` | Cumulative cost in USD |
+
+### Known Issues
+
+1. **Dead subscriber metrics.**  `SubscriberMetrics` (`subscriber_state`,
+   `received_count`, `dropped_count`) is defined in metrics.py and
+   exported from `trustgraph.base`, but nothing in the async path
+   instantiates it.  The old sync `Subscriber` class created these; the
+   async `ReceiverPool` replaced it but only creates `ConsumerMetrics`.
+
+2. **`rate_limit_count` never incremented.**  The counter is registered
+   when a `ConsumerMetrics` is constructed, but nothing in the async
+   handler instrumentation calls `metrics.rate_limit()`.  Rate limiting
+   is handled at a higher level (inside individual service classes) via
+   the `TooManyRequests` exception (`trustgraph.exceptions`).  This
+   exception is caught and re-raised in 11 service base classes
+   (`llm_service`, `embeddings_service`, `tool_service`,
+   `agent_service`, `reranker_service`, `image_to_text_service`,
+   `dynamic_tool_service`, `triples_store_service`,
+   `graph_embeddings_store_service`, `document_embeddings_store_service`,
+   `keyword_index_service`).  The re-raise propagates up to the
+   `ReceiverPool` worker, which negative-acknowledges the message, but
+   no metric is recorded.  The instrumented handler currently counts
+   `TooManyRequests` as `status="error"` in `processing_count` --
+   there is no way to distinguish a rate-limit from a real failure.
+
+3. **`request_latency` default buckets are too small.**  The Prometheus
+   default Histogram buckets cap at 10 s.  LLM-backed processors
+   routinely take 30--120 s per request.  Those observations land in the
+   `+Inf` bucket, making p50/p90/p99 calculations meaningless for LLM
+   processors.  (`text_completion_duration` has correct custom buckets
+   but measures a different scope -- just the LLM call, not the full
+   handler.)
+
+4. **`chunk_size` name collision.**  Both `token/chunker.py` and
+   `recursive/chunker.py` register a Histogram called `chunk_size` with
+   the same label set.  If both chunkers are ever loaded in the same
+   process the second registration will raise `ValueError: Duplicated
+   timeseries`.  Today this doesn't happen because only one chunker type
+   is deployed per container, but it is fragile.
+
+5. **Naming inconsistency.**  Metric names follow no convention --
+   `processing_count` vs `producer_count` vs `tool_invocation_count` vs
+   `text_completion_duration` vs bare `tokens`.  The Prometheus naming
+   best-practice is `<namespace>_<subsystem>_<name>_<unit>`.
+
+6. **`consumer` label contains full topic names.**  The `consumer` label
+   value is the raw topic string (e.g.
+   `flow:tg:chunk-load:default:default`).  This is functionally correct
+   but verbose in dashboards and couples metric queries to the topic
+   naming scheme.
+
+7. **No metrics for the gateway / API layer.**  The HTTP gateway
+   (FastAPI) has no request-level metrics -- no request count, latency
+   histogram, or error rate by endpoint.  Grafana dashboards must rely
+   on external load-balancer metrics or have a blind spot.
+
+8. **Singleton registration pattern is brittle.**  Every metric class
+   uses `if not hasattr(__class__, "xxx_metric")` to guard
+   `Counter(...)` / `Histogram(...)` calls.  This works but is easy to
+   get wrong when subclassing or in tests (the `reset_metric_singletons`
+   fixture exists solely to work around it).
+
+9. **Config consumers pollute throughput/latency metrics.**  Every
+   processor subscribes to `notify:tg:config` for config pushes.
+   These are infrastructure housekeeping, not actual work, but they
+   share the same `processing_count` and `request_latency` metrics as
+   flow consumers.  An operator looking at throughput or p99 latency
+   sees config updates mixed in with real request processing.  The
+   `consumer` label can be used to filter, but aggregates across
+   consumers are misleading by default.
+
+10. **No config version metric.**  Every processor tracks
+    `self.config_version` (an incrementing integer), but this is only
+    visible in debug logs.  A gauge would let operators confirm that
+    all processors are on the same config version, and alert when a
+    processor is stuck on a stale version.
+
+11. **No model identity metrics for embeddings or reranker.**
+    `LlmService` records `text_completion_model` (Info) with model
+    name and temperature.  `ImageToTextService` records
+    `image_to_text_model`.  `EmbeddingsService` and `RerankerService`
+    have no equivalent -- the active model is invisible to monitoring.
+
+12. **No query-side latency metrics.**  `TriplesQueryService`,
+    `GraphEmbeddingsQueryService`, and
+    `DocumentEmbeddingsQueryService` have no duration histograms.
+    The only latency signal is `request_latency` from the consumer
+    instrumentation, which includes message deserialization and
+    response serialisation overhead.  There is no metric for the
+    actual backend query time (e.g. FalkorDB, Neo4j, Qdrant, Milvus).
+
+### Desired Metrics
+
+The following metrics are missing from the codebase and represent
+observable behaviours that operators need for production support.
+Organised by subsystem.
+
+#### Pipeline / message bus
+
+| Metric | Type | Labels | What it tracks |
+|--------|------|--------|----------------|
+| `work_queue_depth` | Gauge | processor | ReceiverPool work queue size -- backpressure indicator |
+| `send_queue_depth` | Gauge | processor, producer | SenderPool per-producer queue size |
+| `pending_acks` | Gauge | processor, consumer | Outstanding unacknowledged messages in receiver loop |
+| `negative_ack_count` | Counter | processor, consumer | Messages nacked (requeued after handler failure) |
+| `drain_timeout_count` | Counter | processor | Graceful-shutdown drain exceeded timeout |
+
+#### Rate limiting
+
+Rate-limit events (`TooManyRequests`) are retryable -- the message
+gets nacked and redelivered.  They should NOT increment
+`processing_count` at all because the work hasn't been done yet.
+Instead, rate limits should be tracked as a separate signal that
+indicates a resource needs scaling up.
+
+| Metric | Type | Labels | What it tracks |
+|--------|------|--------|----------------|
+| `rate_limit_count` | Counter | processor, consumer | Already registered but never incremented; should fire when `TooManyRequests` is caught by the instrumented handler |
+
+The instrumented handler in `ReceiverPool._instrumented_handler`
+should catch `TooManyRequests` before the generic `Exception` handler
+so that it increments `rate_limit_count` instead of
+`processing_count{status="error"}`, and re-raises for the nack path.
+
+#### Gateway / API layer
+
+The gateway serves requests over two transports -- HTTP REST and
+WebSocket -- but both converge at the `DispatcherManager` for
+dispatch.  Auth and authorisation are transport-agnostic (same
+`IamAuth` and operation registry).  The audit middleware already
+captures per-request timing and metadata for HTTP, but there is no
+Prometheus equivalent, and WebSocket has no request-level counting.
+
+Gateway metrics should be transport-agnostic where possible.  A
+"request" is a dispatched operation regardless of whether it arrived
+as an HTTP POST or a WebSocket frame.
+
+| Metric | Type | Labels | What it tracks |
+|--------|------|--------|----------------|
+| `gateway_request_count` | Counter | service, operation, status | Dispatched operations (HTTP + WebSocket), status = ok / error / auth-denied |
+| `gateway_request_duration` | Histogram | service, operation | End-to-end latency from dispatch to final response (both transports) |
+| `gateway_active_connections` | Gauge | transport | Active HTTP requests in flight + active WebSocket connections |
+| `gateway_auth_failure_count` | Counter | reason | Malformed Bearer, missing token, expired JWT, invalid signature, unknown API key |
+
+#### Gateway readiness / status
+
+The gateway has startup dependencies that affect its ability to
+serve requests.  These should be exposed as metrics so that
+alerting can fire when the gateway is running but degraded.
+
+| Metric | Type | Labels | What it tracks |
+|--------|------|--------|----------------|
+| `gateway_signing_key_state` | Enum | -- | Whether the IAM signing public key has been fetched (states: `absent`, `present`).  Without it, JWT validation fails and the gateway falls back to retry-on-request.  Currently `IamAuth._signing_public_pem` is `None` until fetched, with up to 30 retries at startup. |
+| `gateway_known_workspaces` | Gauge | -- | Number of workspaces in `IamAuth.known_workspaces`.  Zero means the gateway will reject all workspace-scoped requests.  Populated by `ConfigReceiver` on config push. |
+
+#### Config state
+
+| Metric | Type | Labels | What it tracks |
+|--------|------|--------|----------------|
+| `config_version` | Gauge | processor | Current config version known to each processor.  Allows operators to confirm all processors converged to the same version after a config push. |
+
+The config push consumer (`notify:tg:config`) should ideally be
+excluded from `processing_count` and `request_latency`, or use a
+distinct set of metrics, so that throughput and latency dashboards
+reflect actual work rather than infrastructure housekeeping.
+
+#### LLM / model services
+
+| Metric | Type | Labels | What it tracks |
+|--------|------|--------|----------------|
+| `llm_retry_count` | Counter | processor, model | Retries before a successful LLM response |
+| `llm_token_count` | Counter | processor, model, direction | Input/output tokens per call (distinct from metering -- this is per-processor, metering is per-model) |
+| `llm_streaming_chunk_count` | Counter | processor | Chunks received in streaming mode |
+
+#### Embeddings
+
+The active model is resolved dynamically per request from the flow
+parameter `flow("model")`, so model must be a label rather than an
+Info metric.
+
+| Metric | Type | Labels | What it tracks |
+|--------|------|--------|----------------|
+| `embeddings_request_count` | Counter | processor, model | Requests per model -- capacity signal, shows model mix |
+| `embeddings_duration` | Histogram | processor, model | Embedding call latency per model (custom buckets) |
+| `embeddings_batch_size` | Histogram | processor, model | Number of texts per embedding request |
+| `embeddings_dimension` | Gauge | processor, model | Vector dimension size -- changes with model |
+
+#### Reranker
+
+Same dynamic model resolution as embeddings.
+
+| Metric | Type | Labels | What it tracks |
+|--------|------|--------|----------------|
+| `reranker_request_count` | Counter | processor, model | Requests per model -- capacity signal |
+| `reranker_duration` | Histogram | processor, model | Rerank call latency per model (custom buckets) |
+| `reranker_result_count` | Histogram | processor, model | Number of results returned per rerank call |
+
+#### Knowledge transformation pipeline
+
+The extraction pipeline runs: Document → Decoder → Chunker →
+Extractors (definitions, relationships, ontology, rows) → Store
+writers.  Each stage has observable throughput and yield ratios
+that are invisible today.
+
+| Metric | Type | Labels | What it tracks |
+|--------|------|--------|----------------|
+| `decode_document_count` | Counter | processor, decoder_type | Documents decoded (PDF, OCR, etc.) |
+| `decode_page_count` | Counter | processor, decoder_type | Pages produced per document decode |
+| `chunk_count` | Counter | processor | Chunks produced (complements existing `chunk_size` histogram) |
+| `chunks_per_document` | Histogram | processor | Yield ratio -- how many chunks per input document |
+| `extraction_entity_count` | Counter | processor, extractor | Entities / relationships / rows extracted |
+| `extraction_triple_count` | Counter | processor, extractor | Triples produced per extractor (definitions, relationships, ontology) |
+| `extraction_duration` | Histogram | processor, extractor | Wall-clock time per chunk extraction (includes LLM call + parsing) |
+| `extraction_empty_count` | Counter | processor, extractor | Chunks that yielded zero extractions -- signal of low-quality input or prompt issues |
+
+The `extractor` label values would be: `definitions`,
+`relationships`, `ontology`, `rows`, `topics`.
+
+#### Ontology-specific extraction
+
+The ontology extractor (`kg-extract-ontology`) selects a subset of
+loaded ontology elements per chunk based on similarity.  This
+selection process and its yield are invisible to monitoring today.
+
+| Metric | Type | Labels | What it tracks |
+|--------|------|--------|----------------|
+| `ontology_loaded_count` | Gauge | processor | Number of ontology definitions loaded (from config) |
+| `ontology_element_count` | Gauge | processor | Total embedded ontology elements (classes + properties) available for selection |
+| `ontology_selection_count` | Histogram | processor | Number of ontology elements selected per chunk (classes + object properties + datatype properties) |
+| `ontology_selection_duration` | Histogram | processor | Time for the similarity-based ontology subset selection step |
+| `ontology_no_match_count` | Counter | processor | Chunks where no relevant ontology elements were found (early return, zero extraction) |
+
+Per-chunk processing should also emit counts broken down by
+workspace and ontology.  Both are operator-controlled bounded sets,
+so the cardinality is safe.
+
+| Metric | Type | Labels | What it tracks |
+|--------|------|--------|----------------|
+| `ontology_extraction_triple_count` | Counter | processor, workspace, ontology | Triples produced per workspace × ontology combination |
+| `ontology_extraction_entity_count` | Counter | processor, workspace, ontology | Entities / entity-contexts produced per workspace × ontology |
+| `ontology_chunk_count` | Counter | processor, workspace, ontology | Chunks processed per workspace × ontology |
+
+These answer: which ontology is producing results?  Is one workspace
+getting all the extractions while another yields nothing?  Which
+ontology should be tuned or retired?
+
+The broader metrics above (`ontology_selection_count`, etc.) answer
+whether the ontology is well-fitted.  These per-workspace counters
+answer whether the deployment is balanced.
+
+#### Knowledge transformation summary
+
+These metrics collectively answer operational questions like:
+- What is the extraction yield per document?
+- Which extractor is the bottleneck?
+- What fraction of chunks produce nothing?
+- How does extraction throughput scale with document volume?
+
+#### Storage backends (write path)
+
+| Metric | Type | Labels | What it tracks |
+|--------|------|--------|----------------|
+| `store_write_duration` | Histogram | processor, store_type | Write latency for triples / graph-embeddings / doc-embeddings stores |
+| `store_write_count` | Counter | processor, store_type | Successful writes |
+| `store_error_count` | Counter | processor, store_type, error_type | Write failures by category |
+| `cassandra_query_duration` | Histogram | keyspace, operation | CQL query latency (select / insert / delete) |
+
+#### Storage backends (query path)
+
+| Metric | Type | Labels | What it tracks |
+|--------|------|--------|----------------|
+| `query_duration` | Histogram | processor, store_type | Backend query time for triples / graph-embeddings / doc-embeddings queries (the actual DB/vector-store call, not the full handler) |
+| `query_result_count` | Histogram | processor, store_type | Number of results returned per query -- useful for tuning limits and detecting empty-result patterns |
+
+#### IAM / auth
+
+| Metric | Type | Labels | What it tracks |
+|--------|------|--------|----------------|
+| `iam_login_count` | Counter | outcome | Successful / failed login attempts |
+| `iam_auth_decision_count` | Counter | outcome | Allow / deny authorisation decisions |
+| `iam_api_key_resolution_count` | Counter | outcome | API key lookups (valid / invalid / expired) |
+| `auth_cache_hit_count` | Counter | cache_type | JWT validation / authorisation cache hits vs misses |
+| `signing_key_fetch_count` | Counter | outcome | Signing key retrieval successes / failures / retries |
+
+#### Knowledge cores
+
+| Metric | Type | Labels | What it tracks |
+|--------|------|--------|----------------|
+| `core_operation_duration` | Histogram | processor, operation | Load / save / delete / list latency |
+| `core_loader_queue_depth` | Gauge | processor | Background loader queue saturation (maxsize=20) |
+
+#### Librarian / document management
+
+| Metric | Type | Labels | What it tracks |
+|--------|------|--------|----------------|
+| `librarian_operation_duration` | Histogram | operation | add-document / remove-document / update latency |
+| `blob_store_bytes` | Counter | operation | Bytes uploaded / downloaded to blob store |
+
+#### System inventory
+
+High-level gauges that give operators and dashboards a snapshot of
+the deployment's scale.  These are slow-moving values, suitable for
+scrape intervals of 30--60 s.
+
+| Metric | Type | Labels | What it tracks | Source |
+|--------|------|--------|----------------|--------|
+| `iam_user_count` | Gauge | -- | Total registered users | IAM service (Cassandra users table) |
+| `iam_workspace_count` | Gauge | -- | Total workspaces | IAM service or config service (`__workspaces__` registry) |
+| `active_flow_count` | Gauge | processor | Number of running flow instances per processor | `FlowProcessor.flows` dict size |
+| `librarian_document_count` | Gauge | -- | Total documents in the librarian | Librarian service |
+
+These answer at-a-glance questions: how big is the deployment, is
+it growing, did a workspace or flow disappear unexpectedly?
+
+#### Agent orchestration
+
+The ReAct agent loop (`agent/react/agent_manager.py`) is the
+highest-value user-facing path and currently has zero metrics.
+Each agent session runs up to `max_iterations` (default 10) cycles
+of think → act → observe.  Tools are invoked via
+request/response messaging; MCP tools make HTTP calls to external
+servers.
+
+| Metric | Type | Labels | What it tracks |
+|--------|------|--------|----------------|
+| `agent_session_count` | Counter | processor, outcome | Agent sessions started; outcome = completed / max-iterations / error / timeout |
+| `agent_session_duration` | Histogram | processor | Total wall-clock time per agent session |
+| `agent_iteration_count` | Histogram | processor | Number of ReAct iterations per session (distribution tells you if agents are solving in 2 steps or grinding to 10) |
+| `agent_tool_invocation_count` | Counter | processor, tool | Tool calls per tool name -- shows which tools the agent uses most |
+| `agent_tool_duration` | Histogram | processor, tool | Per-tool invocation latency (helps identify slow tools) |
+| `agent_tool_error_count` | Counter | processor, tool, error_type | Tool invocation failures by type (timeout, service-error, parse-error) |
+| `agent_llm_duration` | Histogram | processor | LLM reasoning step latency per iteration (separate from tool time) |
+| `agent_mcp_invocation_count` | Counter | processor, mcp_tool | MCP tool calls specifically -- external service dependency |
+| `agent_mcp_duration` | Histogram | processor, mcp_tool | MCP tool latency (includes HTTP round-trip to external server) |
+| `agent_mcp_error_count` | Counter | processor, mcp_tool, error_type | MCP failures: connection refused, timeout, protocol error, auth failure |
+
+These answer: how often do agents solve on first try vs grind?
+Which tools are hot?  Are MCP tools reliable?  Where is the agent
+spending its time -- thinking or acting?
+
+#### Timeouts and downstream failures
+
+Timeouts are a critical operational signal across Graph RAG,
+Document RAG, and agent orchestration.  Each service makes
+cascading downstream calls with different timeout budgets:
+
+| Service | Downstream call | Default timeout |
+|---------|----------------|-----------------|
+| Agent (ReAct) | Prompt/LLM | 600 s |
+| Agent (ReAct) | Tool service | 600 s |
+| Agent (ReAct) | MCP tool (HTTP) | no explicit timeout |
+| Graph RAG | Prompt (concept extraction) | 600 s |
+| Graph RAG | Embeddings | 300 s |
+| Graph RAG | Graph embeddings query | 30 s (× N entities) |
+| Graph RAG | Triples query | 300 s |
+| Graph RAG | Reranker | 300 s |
+| Document RAG | Document embeddings query | 30 s |
+| Document RAG | Chunk fetch | 120 s |
+| All services | Config fetch | 60 s |
+| All services | Librarian | 120 s |
+
+Cascading timeouts are a problem: Graph RAG can accumulate
+600 s + 300 s + (30 s × N entities) + 300 s = 1000 s+ without
+any single call exceeding its budget.  No deadline propagation
+exists.
+
+Today, all timeouts surface as `asyncio.TimeoutError` and are
+indistinguishable from other exceptions in metrics.  The proposed
+metrics:
+
+| Metric | Type | Labels | What it tracks |
+|--------|------|--------|----------------|
+| `timeout_count` | Counter | processor, target_service | Timeout events by which downstream service timed out (prompt, embeddings, triples-query, graph-embeddings-query, reranker, librarian, mcp-tool) |
+| `downstream_call_duration` | Histogram | processor, target_service | Latency of downstream request/response calls -- shows how close calls are to their timeout budget |
+| `downstream_error_count` | Counter | processor, target_service, error_type | Non-timeout errors by downstream service and type (service-error, connection-refused, parse-error) |
+
+The `error_type` label should distinguish at minimum:
+- `timeout` -- asyncio.TimeoutError
+- `rate-limited` -- TooManyRequests
+- `service-error` -- error response from downstream
+- `connection-error` -- broker / network failure
+
+This replaces the current undifferentiated `processing_count{status="error"}`
+with structured error attribution.
+
+#### Config service
+
+| Metric | Type | Labels | What it tracks |
+|--------|------|--------|----------------|
+| `config_push_count` | Counter | -- | Config version push events (global, not per-workspace to avoid cardinality) |
+| `config_provision_duration` | Histogram | -- | Time to provision a workspace from template |
+
+## Goals
+
+1. Every operationally significant behaviour emits a metric without
+   requiring service-specific code where possible.
+2. Metrics are correctly categorised: infrastructure housekeeping
+   (config pushes) does not pollute work throughput/latency.
+3. Histogram buckets match the expected latency range of each
+   operation.
+4. Cardinality is bounded by operator-controlled dimensions only.
+5. Existing dead metrics are removed rather than carried forward.
+6. New dashboards can be designed from a clean, consistent metric
+   schema.
+
+## Technical Design
+
+### Metric Layers
+
+Metrics are organised into three layers.  Each layer has a clear
+owner and instrumentation strategy.
+
+**Layer 1 — Infrastructure (automatic).**
+Instrumented by `ReceiverPool` and `SenderPool`.  Every consumer
+and producer gets throughput, latency, state, and error metrics
+without any service code.  This is the current `ConsumerMetrics` /
+`ProducerMetrics` mechanism.
+
+**Layer 2 — Service base class (semi-automatic).**
+Instrumented by service base classes (`LlmService`,
+`EmbeddingsService`, `RerankerService`, `TriplesQueryService`,
+etc.).  Each base class defines metrics appropriate to its domain
+(LLM duration, embedding batch size, query result count, etc.).
+Service implementations inherit these without additional code.
+
+**Layer 3 — Application (manual).**
+Instrumented by individual processors where domain-specific
+metrics are needed (ontology selection counts, chunk size
+distribution, agent iteration counts, etc.).  These are opt-in
+and defined in the processor code.
+
+### Consumer vs Subscriber: Unify and Simplify
+
+**Decision: remove `SubscriberMetrics` entirely.**
+
+The consumer/subscriber distinction was a sync-era artefact.  The
+old sync codebase had separate `Consumer` (request/response pattern)
+and `Subscriber` (pub/sub, fire-and-forget) classes, each with their
+own metrics.  In the async architecture, `ReceiverPool` handles both
+patterns identically — receive message, dispatch to handler, ack or
+nack.  There is no behavioural difference that warrants separate
+metric classes.
+
+`ConsumerMetrics` already captures everything needed:
+- `consumer_state` — lifecycle (running/stopped)
+- `processing_count` — throughput with ok/error status
+- `request_latency` — handler duration
+- `rate_limit_count` — backpressure signal
+
+The subscriber-specific metrics (`received_count`, `dropped_count`)
+mapped to concepts that no longer exist in the async model:
+- `received_count` was incremented before processing — in the pool
+  model, receiving and processing are decoupled (receiver loop vs
+  worker pool), so a pre-processing count is just a noisier version
+  of `processing_count`.
+- `dropped_count` tracked messages that couldn't be processed — in
+  the pool model, these surface as nacks and
+  `processing_count{status="error"}`.
+
+**Action:** delete `SubscriberMetrics` from `metrics.py`, remove
+the export from `__init__.py`, and remove the two remaining call
+sites in `trustgraph-flow` (`agent/react/tools.py`).
+
+### Config Consumer: Exclude from Work Metrics
+
+**Decision: config consumers should not be instrumented.**
+
+The `notify:tg:config` consumer is infrastructure housekeeping.
+It processes config push notifications (a few per deployment
+lifetime), not user-driven work.  Including it in
+`processing_count` and `request_latency` pollutes aggregates and
+makes dashboards misleading.
+
+`ReceiverPool.add_consumer()` gains an `instrument` parameter
+(default `True`).  When `False`, no `ConsumerMetrics` is created
+and the handler is not wrapped.
+
+```python
+# AsyncProcessor.start() — config consumer, no metrics
+self._config_consumer_reg = \
+    await self.receiver_pool.add_consumer(
+        topic=self.config_push_queue,
+        subscription=config_subscriber_id,
+        schema=ConfigPush,
+        handler=config_notify_handler,
+        initial_position='latest',
+        instrument=False,
+    )
+```
+
+Config version tracking is handled separately via a
+`config_version` gauge (see desired metrics above), set in
+`on_config_notify` when the version advances.
+
+**The principle:** Layer 1 consumer metrics (`processing_count`,
+`request_latency`, `consumer_state`, `rate_limit_count`) exist to
+measure the main processing queues — the actual work a processor
+was deployed to do.  The prompt processor's metrics should reflect
+prompt requests.  The chunker's metrics should reflect documents
+chunked.  Infrastructure housekeeping like config pushes, which
+every processor subscribes to, must not appear in these metrics.
+Otherwise aggregates are inflated and latency percentiles are
+skewed by fast, low-value config operations mixed in with real
+work.
+
+Before (current state, prompt processor):
+```
+processing_count_total{processor="prompt", consumer="notify:tg:config", status="ok"} 10
+processing_count_total{processor="prompt", consumer="request:tg:prompt:default:default", status="ok"} 30
+# sum = 40, but only 30 are real prompt requests
+```
+
+After (config consumer uninstrumented):
+```
+processing_count_total{processor="prompt", consumer="request:tg:prompt:default:default", status="ok"} 30
+# sum = 30, reflects actual work done
+```
+
+### Rate Limiting: Separate from Errors
+
+**Decision: `TooManyRequests` gets its own path in the
+instrumented handler.**
+
+The instrumented handler in `ReceiverPool._instrumented_handler`
+currently catches `Exception` and records `status="error"`.
+`TooManyRequests` is a retryable signal, not a failure.  It should:
+
+1. Increment `rate_limit_count` (already registered, never used).
+2. NOT increment `processing_count` (work was not done).
+3. NOT record in `request_latency` (no meaningful duration).
+4. Re-raise for the nack/redelivery path.
+
+```python
+async def wrapper(message):
+    with metrics.record_time():
+        try:
+            await handler(message)
+            metrics.process("ok")
+        except TooManyRequests:
+            metrics.rate_limit()
+            raise
+        except Exception:
+            metrics.process("error")
+            raise
+```
+
+Note: `record_time()` is a context manager that always records
+on exit.  For rate-limited requests, we should skip the timing
+entirely since the duration is meaningless.  This requires
+restructuring to separate the timing from the try/except:
+
+```python
+async def wrapper(message):
+    try:
+        t0 = time.monotonic()
+        await handler(message)
+        metrics.observe_latency(time.monotonic() - t0)
+        metrics.process("ok")
+    except TooManyRequests:
+        metrics.rate_limit()
+        raise
+    except Exception:
+        metrics.observe_latency(time.monotonic() - t0)
+        metrics.process("error")
+        raise
+```
+
+### request_latency: Custom Buckets
+
+**Decision: `request_latency` gets medium-ops buckets globally.**
+
+The current default buckets (max 10 s) are wrong for most
+processors.  Replacing with medium-ops buckets
+(0.05 -- 30 s) covers the majority of handler durations.
+
+Processors with genuinely different profiles (LLM services,
+agent orchestration) already define their own histograms
+(`text_completion_duration`, `agent_session_duration`) with
+appropriate buckets.  `request_latency` captures the full
+handler duration including message deserialisation and response
+send — it is a coarse-grained signal, not the primary latency
+metric for specialised services.
+
+### Namespace Prefix
+
+**Decision: adopt `tg_` prefix for all new metrics.**
+
+Prometheus best practice is `<namespace>_<subsystem>_<name>`.
+A short `tg_` prefix avoids collisions with other exporters
+(Python runtime, process metrics) without excessive verbosity.
+
+Existing metrics will be renamed in the refactor (no deprecation
+period — dashboards are being redesigned).
+
+Examples:
+- `processing_count` → `tg_consumer_processing_total`
+- `producer_count` → `tg_producer_messages_total`
+- `request_latency` → `tg_consumer_request_duration_seconds`
+- `text_completion_duration` → `tg_llm_request_duration_seconds`
+- `tokens` → `tg_metering_tokens_total`
+
+### Downstream Call Instrumentation
+
+**Decision: instrument at the `RequestResponseClient` level.**
+
+Most downstream calls (embeddings, triples query, graph embeddings
+query, reranker, prompt, librarian) flow through
+`RequestResponseClient.request()`.  This is the natural
+instrumentation point for `downstream_call_duration` and
+`timeout_count` — a single code change covers all downstream
+services.
+
+The `target_service` label can be derived from the request topic
+name, which the client already knows.
+
+```python
+# In RequestResponseClient.request():
+t0 = time.monotonic()
+try:
+    result = await asyncio.wait_for(future, timeout=timeout)
+    DownstreamMetrics.observe(self.request_topic, time.monotonic() - t0)
+    return result
+except asyncio.TimeoutError:
+    DownstreamMetrics.timeout(self.request_topic)
+    raise
+```
+
+### Singleton Pattern: Keep but Standardise
+
+The `hasattr(__class__, ...)` singleton pattern works correctly in
+the multi-processor container model.  Each metric name is registered
+once per process, with label values providing per-processor
+discrimination.  The pattern is well-understood and the
+`reset_metric_singletons` test fixture handles the test-isolation
+concern.
+
+Replacing it with a registry abstraction would add complexity
+without solving a real problem.  Standardise the pattern (consistent
+naming, always use `__class__`, always guard with `hasattr`) but
+do not replace it.
+
+### Architectural Constraints
+
+1. **Multi-processor containers.**  Containers like `ingest`,
+   `control`, `rag` each bundle multiple processors sharing a single
+   metrics port (8000) and a single Prometheus registry.  The
+   `hasattr(__class__, ...)` singleton pattern ensures each metric
+   name is registered once per process, with the `processor` label
+   distinguishing instances.  This means per-processor isolation is
+   not possible without splitting containers or running separate
+   registries.  All proposed metrics must work within this shared-
+   registry model.
+
+2. **Stale time series.**  When a flow is stopped or a consumer
+   removed, Prometheus retains the last-scraped value until
+   retention expires.  A deleted workspace's
+   `consumer_state{..., consumer_state="running"}=1` will linger as
+   a phantom.  There is no application-side mechanism to remove stale
+   series.  Dashboards must account for this (e.g. filtering on
+   recent `up` or using `absent()` / recording rules).
+
+### Histogram Bucket Strategy
+
+Each histogram should define buckets appropriate to its expected
+latency range.  Using Prometheus defaults (max 10 s) for all
+histograms is the root cause of issue 3 (`request_latency` overflow).
+
+| Latency class | Bucket range | Applies to |
+|---------------|-------------|------------|
+| Fast ops | 0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5 s | `query_duration`, `store_write_duration`, `ontology_selection_duration`, `config_provision_duration` |
+| Medium ops | 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0 s | `request_latency` (refactored), `embeddings_duration`, `reranker_duration`, `downstream_call_duration`, `gateway_request_duration` |
+| LLM-scale ops | 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0, 60.0, 120.0 s | `text_completion_duration` (existing), `extraction_duration`, `agent_llm_duration`, `agent_tool_duration`, `agent_mcp_duration` |
+| Session-scale ops | 1.0, 5.0, 10.0, 30.0, 60.0, 120.0, 300.0, 600.0 s | `agent_session_duration`, `core_operation_duration`, `librarian_operation_duration` |
+
+Count-based histograms (not time):
+
+| Distribution | Bucket range | Applies to |
+|-------------|-------------|------------|
+| Small counts | 1, 2, 5, 10, 20, 50, 100 | `agent_iteration_count`, `chunks_per_document`, `reranker_result_count`, `ontology_selection_count` |
+| Medium counts | 1, 5, 10, 25, 50, 100, 250, 500, 1000 | `embeddings_batch_size`, `extraction_entity_count`, `extraction_triple_count`, `query_result_count` |
+
+### Cardinality Policy
+
+Cardinality is allowed where it adds operational value, subject to
+these constraints:
+
+- **Operator-controlled dimensions only.**  Labels like `workspace`,
+  `ontology`, `model`, `tool` are bounded by operator configuration,
+  not by user activity or data volume.  These are acceptable.
+- **No user-derived or data-derived labels.**  User IDs, document
+  IDs, request IDs, topic content must never appear as label values.
+- **Review histograms × labels carefully.**  Each histogram bucket
+  is a separate time series.  A histogram with 15 buckets and a
+  label with 10 values = 150 series per processor.  Histograms with
+  high-cardinality labels are the most expensive combination and
+  must be justified.
+- **Prefer counters for high-cardinality breakdowns.**  If you need
+  per-model, per-tool, or per-workspace breakdowns, counters are
+  cheap (1 series per combination).  Histograms should only carry
+  those labels if the latency distribution genuinely varies by that
+  dimension.
+
+### Dashboard Strategy
+
+Existing Grafana dashboards are of limited use and will not
+constrain the metric refactor.  New dashboards will be designed
+alongside the new metric schema.  This avoids a migration /
+backwards-compatibility tax -- metric names can be renamed freely
+without a deprecation period.
+
+### Decisions
+
+- **Gateway instrumentation**: custom instrumentation at the
+  dispatcher level, not transport-layer middleware.  Both HTTP and
+  WebSocket dispatch to the same `DispatcherManager` and represent
+  the same logical operations.  HTTP-centric libraries like
+  `prometheus_fastapi_instrumentator` would miss WebSocket requests
+  entirely.
+
+## Open Questions
+
+_None remaining — all resolved.  See Decisions below._
+
+## Future Design Goal: Document Pipeline Progress
+
+A key gap today is the inability to answer "how much work is
+left?" for a document flowing through the ingest pipeline.  A
+document enters as a single blob, fans out through decode →
+chunk → N extractors → store writes, and there is no way to
+tell from metrics whether processing is complete, stalled, or
+partially done.
+
+### The problem
+
+The pipeline is a DAG with fan-out:
+
+```
+Document (1)
+  → Decoder (1 → N pages)
+    → Chunker (N pages → M chunks)
+      → Definitions extractor (M chunks → ? triples)
+      → Relationships extractor (M chunks → ? triples)
+      → Ontology extractor (M chunks → ? triples)
+      → Row extractor (M chunks → ? rows)
+        → Triples store writer
+        → Graph embeddings store writer
+        → Document embeddings store writer
+```
+
+No single processor sees the full picture.  The chunker knows how
+many chunks it emitted but not how many have been fully extracted.
+The store writers know what they received but not what's still in
+flight upstream.
+
+### Approach: emit/complete counters per document
+
+Each stage emits a count of items it produced and a count of items
+it completed.  By comparing these across stages, the outstanding
+work for a document can be derived.
+
+| Metric | Type | Labels | What it tracks |
+|--------|------|--------|----------------|
+| `tg_pipeline_emitted_total` | Counter | processor, stage | Items emitted to the next stage (chunks produced, triples sent, etc.) |
+| `tg_pipeline_completed_total` | Counter | processor, stage | Items whose processing completed at this stage |
+
+Outstanding work at any stage =
+`sum(tg_pipeline_emitted_total{stage="chunker"})` −
+`sum(tg_pipeline_completed_total{stage="triples-store"})`.
+
+This requires a correlation mechanism — each item must carry a
+document ID through all stages so that per-document progress can
+be calculated.  The `metadata.id` field on chunks and triples
+already serves this purpose, but it is not currently exposed as a
+metric dimension (and should not be — document IDs are unbounded
+cardinality).
+
+### Practical options
+
+1. **Aggregate counters only (no per-document breakdown).**
+   Track total emitted vs total completed across the pipeline.
+   Gives a global "work outstanding" gauge but cannot distinguish
+   a stuck document from normal processing lag.  Cheapest to
+   implement.
+
+2. **Per-document state in an external store.**
+   Write document lifecycle events (entered-pipeline,
+   chunking-complete, extraction-complete, store-complete) to
+   Cassandra or a dedicated state table.  Query the table for
+   per-document progress.  More expensive but gives per-document
+   visibility.  Could power a UI progress bar.
+
+3. **Pipeline depth gauge.**
+   Each stage increments a gauge on entry and decrements on exit.
+   `tg_pipeline_in_flight{stage="definitions-extractor"}` gives a
+   real-time count of items being processed at each stage.
+   Combined with throughput rates, this gives estimated time to
+   completion.  Does not give per-document breakdown but is cheap
+   and immediately useful.
+
+Option 3 is the likely starting point — it answers "is the
+pipeline draining or backing up?" without per-document cardinality.
+Options 1 and 2 can be layered on top in subsequent phases.
+
+This is a phase 2 goal and is out of scope for the initial metrics
+refactor.
+
+## Resolved Questions
+
+- **Histogram bucket parameterisation.**  Define centrally named
+  bucket presets that services can invoke.  Three standard profiles:
+  - `BUCKETS_STANDARD` — fast/medium ops (default for most
+    consumers and downstream calls)
+  - `BUCKETS_LLM` — LLM-scale latencies (0.25 -- 120 s)
+  - `BUCKETS_SESSION` — agent/session-scale (1 -- 600 s)
+
+  Service base classes select the appropriate preset.  Individual
+  processors should not need to define custom buckets.
+
+- **`tg_` prefix scope.**  Applies to everything, including metering
+  metrics (`tokens` → `tg_metering_tokens_total`, `cost` →
+  `tg_metering_cost_total`).  One namespace, no exceptions.
+
+- **`target_service` label derivation.**  Callers pass an explicit
+  human-readable service name (e.g. `embeddings`, `triples-query`,
+  `prompt`, `reranker`, `librarian`).  Topic names are communication
+  wiring details and should not leak into metric labels — they are
+  opaque, verbose, and couple dashboards to the pub/sub topology.

--- a/tests/unit/test_base/test_metrics.py
+++ b/tests/unit/test_base/test_metrics.py
@@ -23,11 +23,14 @@ def reset_metric_singletons():
             "rate_limit_metric",
         ],
         metrics.ProducerMetrics: ["producer_metric"],
-        metrics.ProcessorMetrics: ["processor_metric"],
-        metrics.SubscriberMetrics: [
-            "state_metric",
-            "received_metric",
-            "dropped_metric",
+        metrics.ProcessorMetrics: [
+            "processor_metric",
+            "config_version_metric",
+        ],
+        metrics.DownstreamMetrics: [
+            "duration_metric",
+            "timeout_metric",
+            "error_metric",
         ],
     }
 
@@ -59,11 +62,9 @@ def test_consumer_metrics_reuses_singletons_and_records_events(monkeypatch):
     request_labels = MagicMock()
     processing_labels = MagicMock()
     rate_limit_labels = MagicMock()
-    timer = MagicMock()
 
     enum_factory.return_value.labels.return_value = state_labels
     histogram_factory.return_value.labels.return_value = request_labels
-    request_labels.time.return_value = timer
     counter_factory.side_effect = [
         MagicMock(labels=MagicMock(return_value=processing_labels)),
         MagicMock(labels=MagicMock(return_value=rate_limit_labels)),
@@ -73,7 +74,7 @@ def test_consumer_metrics_reuses_singletons_and_records_events(monkeypatch):
     monkeypatch.setattr(metrics, "Histogram", histogram_factory)
     monkeypatch.setattr(metrics, "Counter", counter_factory)
 
-    first = metrics.ConsumerMetrics("proc", "cons", workspace="ws", flow="fl")
+    first = metrics.ConsumerMetrics("proc", "cons")
     second = metrics.ConsumerMetrics("proc-2", "cons-2")
 
     assert enum_factory.call_count == 1
@@ -83,11 +84,12 @@ def test_consumer_metrics_reuses_singletons_and_records_events(monkeypatch):
     first.process("ok")
     first.rate_limit()
     first.state("running")
-    assert first.record_time() is timer
+    first.observe_latency(1.5)
 
     processing_labels.inc.assert_called_once_with()
     rate_limit_labels.inc.assert_called_once_with()
     state_labels.state.assert_called_once_with("running")
+    request_labels.observe.assert_called_once_with(1.5)
 
 
 def test_producer_metrics_increments_counter_once(monkeypatch):
@@ -105,39 +107,59 @@ def test_producer_metrics_increments_counter_once(monkeypatch):
 
 def test_processor_metrics_reports_info(monkeypatch):
     info_factory = MagicMock()
-    labels = MagicMock()
-    info_factory.return_value.labels.return_value = labels
+    gauge_factory = MagicMock()
+    info_labels = MagicMock()
+    gauge_labels = MagicMock()
+    info_factory.return_value.labels.return_value = info_labels
+    gauge_factory.return_value.labels.return_value = gauge_labels
     monkeypatch.setattr(metrics, "Info", info_factory)
+    monkeypatch.setattr(metrics, "Gauge", gauge_factory)
 
     processor_metrics = metrics.ProcessorMetrics("proc")
     processor_metrics.info({"kind": "test"})
 
     info_factory.assert_called_once()
-    labels.info.assert_called_once_with({"kind": "test"})
+    info_labels.info.assert_called_once_with({"kind": "test"})
 
 
-def test_subscriber_metrics_tracks_received_state_and_dropped(monkeypatch):
-    enum_factory = MagicMock()
+def test_processor_metrics_sets_config_version(monkeypatch):
+    info_factory = MagicMock()
+    gauge_factory = MagicMock()
+    gauge_labels = MagicMock()
+    info_factory.return_value.labels.return_value = MagicMock()
+    gauge_factory.return_value.labels.return_value = gauge_labels
+    monkeypatch.setattr(metrics, "Info", info_factory)
+    monkeypatch.setattr(metrics, "Gauge", gauge_factory)
+
+    processor_metrics = metrics.ProcessorMetrics("proc")
+    processor_metrics.set_config_version(42)
+
+    gauge_labels.set.assert_called_once_with(42)
+
+
+def test_downstream_metrics_tracks_duration_timeout_error(monkeypatch):
+    histogram_factory = MagicMock()
     counter_factory = MagicMock()
 
-    state_labels = MagicMock()
-    received_labels = MagicMock()
-    dropped_labels = MagicMock()
+    duration_labels = MagicMock()
+    timeout_labels = MagicMock()
+    error_labels = MagicMock()
 
-    enum_factory.return_value.labels.return_value = state_labels
+    histogram_factory.return_value.labels.return_value = duration_labels
     counter_factory.side_effect = [
-        MagicMock(labels=MagicMock(return_value=received_labels)),
-        MagicMock(labels=MagicMock(return_value=dropped_labels)),
+        MagicMock(labels=MagicMock(return_value=timeout_labels)),
+        MagicMock(labels=MagicMock(return_value=error_labels)),
     ]
 
-    monkeypatch.setattr(metrics, "Enum", enum_factory)
+    monkeypatch.setattr(metrics, "Histogram", histogram_factory)
     monkeypatch.setattr(metrics, "Counter", counter_factory)
 
-    subscriber_metrics = metrics.SubscriberMetrics("proc", "input")
-    subscriber_metrics.received()
-    subscriber_metrics.state("running")
-    subscriber_metrics.dropped("ignored")
+    dm = metrics.DownstreamMetrics("proc", "embeddings")
 
-    received_labels.inc.assert_called_once_with()
-    dropped_labels.inc.assert_called_once_with()
-    state_labels.state.assert_called_once_with("running")
+    dm.observe_duration(2.5)
+    dm.timeout()
+    dm.error("connection-error")
+
+    duration_labels.observe.assert_called_once_with(2.5)
+    timeout_labels.inc.assert_called_once_with()
+    error_labels.inc.assert_called_once_with()

--- a/tests/unit/test_embeddings/test_embeddings_service_request.py
+++ b/tests/unit/test_embeddings/test_embeddings_service_request.py
@@ -11,13 +11,39 @@ from trustgraph.schema import EmbeddingsRequest, EmbeddingsResponse, Error
 from trustgraph.exceptions import TooManyRequests
 
 
+def _ensure_embeddings_metrics():
+    """Initialize EmbeddingsService class-level metrics if not already set."""
+    if not hasattr(EmbeddingsService, "embeddings_request_metric"):
+        from prometheus_client import Counter, Histogram
+        from trustgraph.base.metrics import BUCKETS_STANDARD
+        EmbeddingsService.embeddings_request_metric = Counter(
+            'tg_embeddings_request_total',
+            'Embeddings requests per model',
+            ["processor", "model"],
+        )
+        EmbeddingsService.embeddings_duration_metric = Histogram(
+            'tg_embeddings_duration_seconds',
+            'Embeddings call latency (seconds)',
+            ["processor", "model"],
+            buckets=BUCKETS_STANDARD,
+        )
+        EmbeddingsService.embeddings_batch_size_metric = Histogram(
+            'tg_embeddings_batch_size',
+            'Number of texts per embedding request',
+            ["processor", "model"],
+            buckets=[1, 5, 10, 25, 50, 100, 250, 500, 1000],
+        )
+
+
 class StubEmbeddingsService(EmbeddingsService):
     """Minimal concrete implementation for testing on_request."""
 
     def __init__(self, embed_result=None, embed_error=None):
         # Skip super().__init__ to avoid taskgroup/registration
+        self.id = "test-embeddings"
         self.embed_result = embed_result or [[0.1, 0.2]]
         self.embed_error = embed_error
+        _ensure_embeddings_metrics()
 
     async def on_embeddings(self, texts, model=None):
         if self.embed_error:
@@ -76,7 +102,8 @@ class TestEmbeddingsServiceOnRequest:
 
         class TrackingService(EmbeddingsService):
             def __init__(self):
-                pass
+                self.id = "test-embeddings"
+                _ensure_embeddings_metrics()
 
             async def on_embeddings(self, texts, model=None):
                 calls.append({"texts": texts, "model": model})

--- a/tests/unit/test_gateway/test_dispatch_requestor.py
+++ b/tests/unit/test_gateway/test_dispatch_requestor.py
@@ -84,6 +84,8 @@ class TestServiceRequestor:
             response_topic="response-queue",
             request_schema=mock_request_schema,
             response_schema=mock_response_schema,
+            processor_id="api-gateway",
+            target_service=None,
         )
         assert requestor.client is mock_client_instance
         assert requestor.running is True

--- a/tests/unit/test_iam/test_iam_audit_events.py
+++ b/tests/unit/test_iam/test_iam_audit_events.py
@@ -31,7 +31,49 @@ def _make_processor():
     proc.id = "test-iam-svc"
     proc.iam_response_producer = AsyncMock()
     proc.audit = AsyncMock()
+
+    # Ensure class-level metrics are initialized (normally done in __init__)
+    if not hasattr(Processor, "_metrics_initialized"):
+        from trustgraph.base.metrics import BUCKETS_STANDARD
+        from prometheus_client import Counter, Gauge, Histogram
+        Processor._metrics_initialized = True
+        Processor.iam_request_metric = Counter(
+            'tg_iam_request_total',
+            'IAM service requests by operation and outcome',
+            ["operation", "outcome"],
+        )
+        Processor.iam_request_duration_metric = Histogram(
+            'tg_iam_request_duration_seconds',
+            'IAM service per-operation latency',
+            ["operation"],
+            buckets=BUCKETS_STANDARD,
+        )
+        Processor.iam_user_count_metric = Gauge(
+            'tg_iam_user_count',
+            'Total number of IAM users',
+        )
+        Processor.iam_workspace_count_metric = Gauge(
+            'tg_iam_workspace_count',
+            'Total number of IAM workspaces',
+        )
+        Processor.iam_api_key_created_metric = Counter(
+            'tg_iam_api_key_created_total',
+            'Total API keys created (lifetime)',
+        )
+        Processor.iam_api_key_revoked_metric = Counter(
+            'tg_iam_api_key_revoked_total',
+            'Total API keys revoked (lifetime)',
+        )
+
     return proc
+
+
+def _make_table_store_mock():
+    """Create a mock table store with async list methods."""
+    ts = MagicMock()
+    ts.list_users = AsyncMock(return_value=[])
+    ts.list_workspaces = AsyncMock(return_value=[])
+    return ts
 
 
 # ---------------------------------------------------------------------------

--- a/trustgraph-base/trustgraph/base/__init__.py
+++ b/trustgraph-base/trustgraph/base/__init__.py
@@ -1,7 +1,8 @@
 
 from . pubsub import get_async_pubsub, add_pubsub_args
 from . async_processor import AsyncProcessor
-from . metrics import ProcessorMetrics, ConsumerMetrics, ProducerMetrics, SubscriberMetrics
+from . metrics import ProcessorMetrics, ConsumerMetrics, ProducerMetrics, DownstreamMetrics
+from . metrics import BUCKETS_STANDARD, BUCKETS_LLM, BUCKETS_SESSION
 from . logging import add_logging_args, setup_logging
 from . workspace_processor import WorkspaceProcessor
 from . flow_processor import FlowProcessor

--- a/trustgraph-base/trustgraph/base/async_processor.py
+++ b/trustgraph-base/trustgraph/base/async_processor.py
@@ -157,6 +157,7 @@ class AsyncProcessor:
                 schema=ConfigPush,
                 handler=config_notify_handler,
                 initial_position='latest',
+                instrument=False,
             )
 
         await self.fetch_and_apply_config()
@@ -196,6 +197,11 @@ class AsyncProcessor:
                         f"Applied startup config version {version}"
                     )
                     self.config_version = version
+
+                    from . metrics import ProcessorMetrics
+                    ProcessorMetrics(
+                        processor=self.id
+                    ).set_config_version(version)
 
                 finally:
                     await client.close()
@@ -287,6 +293,10 @@ class AsyncProcessor:
                 f"no handlers for types {notify_types}"
             )
             self.config_version = notify_version
+            from . metrics import ProcessorMetrics
+            ProcessorMetrics(
+                processor=self.id
+            ).set_config_version(notify_version)
             return
 
         logger.info(
@@ -322,6 +332,10 @@ class AsyncProcessor:
                 await client.close()
 
             self.config_version = notify_version
+            from . metrics import ProcessorMetrics
+            ProcessorMetrics(
+                processor=self.id
+            ).set_config_version(notify_version)
 
         except BaseException as e:
             if isinstance(e, asyncio.CancelledError):

--- a/trustgraph-base/trustgraph/base/async_rr_wrapper.py
+++ b/trustgraph-base/trustgraph/base/async_rr_wrapper.py
@@ -5,13 +5,16 @@ from . request_response_client import RequestResponseClient
 class AsyncRequestResponseWrapper:
 
     def __init__(self, backend, request_topic, response_topic,
-                 request_schema, response_schema, subscription=None):
+                 request_schema, response_schema, subscription=None,
+                 processor_id=None, target_service=None):
         self._backend = backend
         self._request_topic = request_topic
         self._response_topic = response_topic
         self._request_schema = request_schema
         self._response_schema = response_schema
         self._subscription = subscription
+        self._processor_id = processor_id
+        self._target_service = target_service
         self._client = None
 
     async def start(self):
@@ -22,6 +25,8 @@ class AsyncRequestResponseWrapper:
             request_schema=self._request_schema,
             response_schema=self._response_schema,
             subscription=self._subscription,
+            processor_id=self._processor_id,
+            target_service=self._target_service,
         )
 
     async def request(self, message, timeout=60):

--- a/trustgraph-base/trustgraph/base/document_embeddings_query_service.py
+++ b/trustgraph-base/trustgraph/base/document_embeddings_query_service.py
@@ -7,7 +7,9 @@ from __future__ import annotations
 
 from argparse import ArgumentParser
 
+import time
 import logging
+from prometheus_client import Histogram
 
 from .. schema import DocumentEmbeddingsRequest, DocumentEmbeddingsResponse
 from .. schema import Error, Term
@@ -49,6 +51,21 @@ class DocumentEmbeddingsQueryService(FlowProcessor):
             )
         )
 
+        if not hasattr(__class__, "query_duration_metric"):
+            from . metrics import BUCKETS_STANDARD
+            __class__.query_duration_metric = Histogram(
+                'tg_document_embeddings_query_duration_seconds',
+                'Document embeddings query backend latency (seconds)',
+                ["processor"],
+                buckets=BUCKETS_STANDARD,
+            )
+            __class__.query_result_count_metric = Histogram(
+                'tg_document_embeddings_query_result_count',
+                'Number of chunks returned per query',
+                ["processor"],
+                buckets=[1, 5, 10, 25, 50, 100, 250, 500, 1000],
+            )
+
     async def on_message(self, msg, consumer, flow):
 
         try:
@@ -60,9 +77,16 @@ class DocumentEmbeddingsQueryService(FlowProcessor):
 
             logger.debug(f"Handling document embeddings query request {id}...")
 
+            t0 = time.monotonic()
             docs = await self.query_document_embeddings(
                 flow.workspace, request,
             )
+            __class__.query_duration_metric.labels(
+                processor=self.id,
+            ).observe(time.monotonic() - t0)
+            __class__.query_result_count_metric.labels(
+                processor=self.id,
+            ).observe(len(docs))
 
             logger.debug("Sending document embeddings query response...")
             r = DocumentEmbeddingsResponse(chunks=docs, error=None)

--- a/trustgraph-base/trustgraph/base/document_embeddings_store_service.py
+++ b/trustgraph-base/trustgraph/base/document_embeddings_store_service.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 from argparse import ArgumentParser
 
 import logging
+import time
+from prometheus_client import Counter, Histogram
 
 from .. schema import DocumentEmbeddings
 from .. base import FlowProcessor, ConsumerSpec
@@ -27,6 +29,27 @@ class DocumentEmbeddingsStoreService(FlowProcessor):
             **params | { "id": id }
         )
 
+        if not hasattr(__class__, "_metrics_initialized"):
+            from . metrics import BUCKETS_STANDARD
+            __class__._metrics_initialized = True
+            __class__.store_write_duration_metric = Histogram(
+                'tg_document_embeddings_store_write_duration_seconds',
+                'Document embeddings store write latency per batch',
+                ["processor"],
+                buckets=BUCKETS_STANDARD,
+            )
+            __class__.store_write_batch_metric = Histogram(
+                'tg_document_embeddings_store_write_batch_size',
+                'Number of embeddings per write batch',
+                ["processor"],
+                buckets=[1, 5, 10, 20, 50, 100, 200, 500],
+            )
+            __class__.store_write_error_metric = Counter(
+                'tg_document_embeddings_store_write_error_total',
+                'Document embeddings store write errors',
+                ["processor"],
+            )
+
         self.register_specification(
             ConsumerSpec(
                 name = "input",
@@ -41,14 +64,25 @@ class DocumentEmbeddingsStoreService(FlowProcessor):
 
             request = msg.value()
 
+            t0 = time.monotonic()
+
             # Workspace comes from the flow the message arrived on.
             await self.store_document_embeddings(flow.workspace, request)
+
+            __class__.store_write_duration_metric.labels(
+                processor=self.id,
+            ).observe(time.monotonic() - t0)
+            __class__.store_write_batch_metric.labels(
+                processor=self.id,
+            ).observe(len(request.vectors) if request.vectors else 0)
 
         except TooManyRequests as e:
             raise e
 
         except Exception as e:
-            
+            __class__.store_write_error_metric.labels(
+                processor=self.id,
+            ).inc()
             logger.error(f"Exception in document embeddings store service: {e}", exc_info=True)
             raise e
 

--- a/trustgraph-base/trustgraph/base/dynamic_tool_service.py
+++ b/trustgraph-base/trustgraph/base/dynamic_tool_service.py
@@ -56,7 +56,7 @@ class DynamicToolService(AsyncProcessor):
 
         if not hasattr(__class__, "tool_service_metric"):
             __class__.tool_service_metric = Counter(
-                'dynamic_tool_service_invocation_count',
+                'tg_dynamic_tool_service_invocation_total',
                 'Dynamic tool service invocation count',
                 ["processor"],
             )

--- a/trustgraph-base/trustgraph/base/embeddings_service.py
+++ b/trustgraph-base/trustgraph/base/embeddings_service.py
@@ -8,6 +8,7 @@ from argparse import ArgumentParser
 
 import time
 import logging
+from prometheus_client import Counter, Histogram
 
 from .. schema import EmbeddingsRequest, EmbeddingsResponse, Error
 from .. exceptions import TooManyRequests
@@ -53,6 +54,26 @@ class EmbeddingsService(FlowProcessor):
             )
         )
 
+        if not hasattr(__class__, "embeddings_request_metric"):
+            from . metrics import BUCKETS_STANDARD
+            __class__.embeddings_request_metric = Counter(
+                'tg_embeddings_request_total',
+                'Embeddings requests per model',
+                ["processor", "model"],
+            )
+            __class__.embeddings_duration_metric = Histogram(
+                'tg_embeddings_duration_seconds',
+                'Embeddings call latency (seconds)',
+                ["processor", "model"],
+                buckets=BUCKETS_STANDARD,
+            )
+            __class__.embeddings_batch_size_metric = Histogram(
+                'tg_embeddings_batch_size',
+                'Number of texts per embedding request',
+                ["processor", "model"],
+                buckets=[1, 5, 10, 25, 50, 100, 250, 500, 1000],
+            )
+
     async def on_request(self, msg, consumer, flow):
 
         try:
@@ -65,9 +86,21 @@ class EmbeddingsService(FlowProcessor):
 
             logger.debug(f"Handling embeddings request {id}...")
 
-            # Pass model from request if specified (non-empty), otherwise use default
             model = flow("model")
+            model_label = str(model) if model else ""
+
+            t0 = time.monotonic()
             vectors = await self.on_embeddings(request.texts, model=model)
+            duration = time.monotonic() - t0
+
+            labels = dict(processor=self.id, model=model_label)
+            __class__.embeddings_request_metric.labels(**labels).inc()
+            __class__.embeddings_duration_metric.labels(**labels).observe(
+                duration,
+            )
+            __class__.embeddings_batch_size_metric.labels(**labels).observe(
+                len(request.texts),
+            )
 
             await flow("response").send(
                 EmbeddingsResponse(

--- a/trustgraph-base/trustgraph/base/graph_embeddings_query_service.py
+++ b/trustgraph-base/trustgraph/base/graph_embeddings_query_service.py
@@ -7,7 +7,9 @@ from __future__ import annotations
 
 from argparse import ArgumentParser
 
+import time
 import logging
+from prometheus_client import Histogram
 
 from .. schema import GraphEmbeddingsRequest, GraphEmbeddingsResponse
 from .. schema import Error, Term
@@ -49,6 +51,21 @@ class GraphEmbeddingsQueryService(FlowProcessor):
             )
         )
 
+        if not hasattr(__class__, "query_duration_metric"):
+            from . metrics import BUCKETS_STANDARD
+            __class__.query_duration_metric = Histogram(
+                'tg_graph_embeddings_query_duration_seconds',
+                'Graph embeddings query backend latency (seconds)',
+                ["processor"],
+                buckets=BUCKETS_STANDARD,
+            )
+            __class__.query_result_count_metric = Histogram(
+                'tg_graph_embeddings_query_result_count',
+                'Number of entities returned per query',
+                ["processor"],
+                buckets=[1, 5, 10, 25, 50, 100, 250, 500, 1000],
+            )
+
     async def on_message(self, msg, consumer, flow):
 
         try:
@@ -60,9 +77,16 @@ class GraphEmbeddingsQueryService(FlowProcessor):
 
             logger.debug(f"Handling graph embeddings query request {id}...")
 
+            t0 = time.monotonic()
             entities = await self.query_graph_embeddings(
                 flow.workspace, request,
             )
+            __class__.query_duration_metric.labels(
+                processor=self.id,
+            ).observe(time.monotonic() - t0)
+            __class__.query_result_count_metric.labels(
+                processor=self.id,
+            ).observe(len(entities))
 
             logger.debug("Sending graph embeddings query response...")
             r = GraphEmbeddingsResponse(entities=entities, error=None)

--- a/trustgraph-base/trustgraph/base/graph_embeddings_store_service.py
+++ b/trustgraph-base/trustgraph/base/graph_embeddings_store_service.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 from argparse import ArgumentParser
 
 import logging
+import time
+from prometheus_client import Counter, Histogram
 
 from .. schema import GraphEmbeddings
 from .. base import FlowProcessor, ConsumerSpec
@@ -27,6 +29,27 @@ class GraphEmbeddingsStoreService(FlowProcessor):
             **params | { "id": id }
         )
 
+        if not hasattr(__class__, "_metrics_initialized"):
+            from . metrics import BUCKETS_STANDARD
+            __class__._metrics_initialized = True
+            __class__.store_write_duration_metric = Histogram(
+                'tg_graph_embeddings_store_write_duration_seconds',
+                'Graph embeddings store write latency per batch',
+                ["processor"],
+                buckets=BUCKETS_STANDARD,
+            )
+            __class__.store_write_batch_metric = Histogram(
+                'tg_graph_embeddings_store_write_batch_size',
+                'Number of embeddings per write batch',
+                ["processor"],
+                buckets=[1, 5, 10, 20, 50, 100, 200, 500],
+            )
+            __class__.store_write_error_metric = Counter(
+                'tg_graph_embeddings_store_write_error_total',
+                'Graph embeddings store write errors',
+                ["processor"],
+            )
+
         self.register_specification(
             ConsumerSpec(
                 name = "input",
@@ -41,14 +64,25 @@ class GraphEmbeddingsStoreService(FlowProcessor):
 
             request = msg.value()
 
+            t0 = time.monotonic()
+
             # Workspace comes from the flow the message arrived on.
             await self.store_graph_embeddings(flow.workspace, request)
+
+            __class__.store_write_duration_metric.labels(
+                processor=self.id,
+            ).observe(time.monotonic() - t0)
+            __class__.store_write_batch_metric.labels(
+                processor=self.id,
+            ).observe(len(request.vectors) if request.vectors else 0)
 
         except TooManyRequests as e:
             raise e
 
         except Exception as e:
-            
+            __class__.store_write_error_metric.labels(
+                processor=self.id,
+            ).inc()
             logger.error(f"Exception in graph embeddings store service: {e}", exc_info=True)
             raise e
 

--- a/trustgraph-base/trustgraph/base/image_to_text_service.py
+++ b/trustgraph-base/trustgraph/base/image_to_text_service.py
@@ -72,22 +72,17 @@ class ImageToTextService(FlowProcessor):
         )
 
         if not hasattr(__class__, "image_to_text_metric"):
+            from . metrics import BUCKETS_LLM
             __class__.image_to_text_metric = Histogram(
-                'image_to_text_duration',
+                'tg_image_to_text_duration_seconds',
                 'Image-to-text duration (seconds)',
                 ["processor"],
-                buckets=[
-                    0.25, 0.5, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0,
-                    8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
-                    17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0, 25.0,
-                    30.0, 35.0, 40.0, 45.0, 50.0, 60.0, 80.0, 100.0,
-                    120.0
-                ]
+                buckets=BUCKETS_LLM,
             )
 
         if not hasattr(__class__, "image_to_text_model_metric"):
             __class__.image_to_text_model_metric = Info(
-                'image_to_text_model',
+                'tg_image_to_text_model',
                 'Image-to-text model',
                 ["processor"]
             )

--- a/trustgraph-base/trustgraph/base/llm_service.py
+++ b/trustgraph-base/trustgraph/base/llm_service.py
@@ -91,22 +91,17 @@ class LlmService(FlowProcessor):
         )
 
         if not hasattr(__class__, "text_completion_metric"):
+            from . metrics import BUCKETS_LLM
             __class__.text_completion_metric = Histogram(
-                'text_completion_duration',
+                'tg_text_completion_duration_seconds',
                 'Text completion duration (seconds)',
                 ["processor"],
-                buckets=[
-                    0.25, 0.5, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0,
-                    8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
-                    17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0, 25.0,
-                    30.0, 35.0, 40.0, 45.0, 50.0, 60.0, 80.0, 100.0,
-                    120.0
-                ]
+                buckets=BUCKETS_LLM,
             )
 
         if not hasattr(__class__, "text_completion_model_metric"):
             __class__.text_completion_model_metric = Info(
-                'text_completion_model',
+                'tg_text_completion_model',
                 'Text completion model',
                 ["processor"]
             )

--- a/trustgraph-base/trustgraph/base/metrics.py
+++ b/trustgraph-base/trustgraph/base/metrics.py
@@ -1,41 +1,56 @@
 from __future__ import annotations
 
+import time
 from typing import Any
 
 from prometheus_client import start_http_server, Info, Enum, Histogram
-from prometheus_client import Counter
+from prometheus_client import Counter, Gauge
+
+BUCKETS_STANDARD = (
+    0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0,
+)
+
+BUCKETS_LLM = (
+    0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0, 60.0, 120.0,
+)
+
+BUCKETS_SESSION = (
+    1.0, 5.0, 10.0, 30.0, 60.0, 120.0, 300.0, 600.0,
+)
+
 
 class ConsumerMetrics:
 
-    def __init__(self, processor: str, consumer: str,
-                 workspace: str | None = None,
-                 flow: str | None = None) -> None:
+    def __init__(self, processor: str, consumer: str) -> None:
 
         self.processor = processor
         self.consumer = consumer
 
         if not hasattr(__class__, "state_metric"):
             __class__.state_metric = Enum(
-                'consumer_state', 'Consumer state',
+                'tg_consumer_state', 'Consumer state',
                 ["processor", "consumer"],
                 states=['stopped', 'running']
             )
 
         if not hasattr(__class__, "request_metric"):
             __class__.request_metric = Histogram(
-                'request_latency', 'Request latency (seconds)',
+                'tg_consumer_request_duration_seconds',
+                'Request latency (seconds)',
                 ["processor", "consumer"],
+                buckets=BUCKETS_STANDARD,
             )
 
         if not hasattr(__class__, "processing_metric"):
             __class__.processing_metric = Counter(
-                'processing_count', 'Processing count',
+                'tg_consumer_processing_total', 'Processing count',
                 ["processor", "consumer", "status"],
             )
 
         if not hasattr(__class__, "rate_limit_metric"):
             __class__.rate_limit_metric = Counter(
-                'rate_limit_count', 'Rate limit event count',
+                'tg_consumer_rate_limit_total',
+                'Rate limit event count',
                 ["processor", "consumer"],
             )
 
@@ -72,23 +87,23 @@ class ConsumerMetrics:
             consumer=self.consumer,
         ).state(state)
 
-    def record_time(self) -> Any:
-        return __class__.request_metric.labels(
+    def observe_latency(self, duration: float) -> None:
+        __class__.request_metric.labels(
             processor=self.processor, consumer=self.consumer,
-        ).time()
+        ).observe(duration)
+
 
 class ProducerMetrics:
 
-    def __init__(self, processor: str, producer: str,
-                 workspace: str | None = None,
-                 flow: str | None = None) -> None:
+    def __init__(self, processor: str, producer: str) -> None:
 
         self.processor = processor
         self.producer = producer
 
         if not hasattr(__class__, "producer_metric"):
             __class__.producer_metric = Counter(
-                'producer_count', 'Output items produced',
+                'tg_producer_messages_total',
+                'Output items produced',
                 ["processor", "producer"],
             )
 
@@ -102,6 +117,63 @@ class ProducerMetrics:
             producer=self.producer,
         ).inc()
 
+
+class DownstreamMetrics:
+
+    def __init__(self, processor: str, target_service: str) -> None:
+
+        self.processor = processor
+        self.target_service = target_service
+
+        if not hasattr(__class__, "duration_metric"):
+            __class__.duration_metric = Histogram(
+                'tg_downstream_call_duration_seconds',
+                'Downstream request/response call latency (seconds)',
+                ["processor", "target_service"],
+                buckets=BUCKETS_STANDARD,
+            )
+
+        if not hasattr(__class__, "timeout_metric"):
+            __class__.timeout_metric = Counter(
+                'tg_downstream_timeout_total',
+                'Downstream call timeout count',
+                ["processor", "target_service"],
+            )
+
+        if not hasattr(__class__, "error_metric"):
+            __class__.error_metric = Counter(
+                'tg_downstream_error_total',
+                'Downstream call error count',
+                ["processor", "target_service", "error_type"],
+            )
+
+        __class__.duration_metric.labels(
+            processor=self.processor, target_service=self.target_service,
+        )
+        __class__.timeout_metric.labels(
+            processor=self.processor, target_service=self.target_service,
+        )
+
+    def observe_duration(self, duration: float) -> None:
+        __class__.duration_metric.labels(
+            processor=self.processor,
+            target_service=self.target_service,
+        ).observe(duration)
+
+    def timeout(self) -> None:
+        __class__.timeout_metric.labels(
+            processor=self.processor,
+            target_service=self.target_service,
+        ).inc()
+
+    def error(self, error_type: str) -> None:
+        __class__.error_metric.labels(
+            processor=self.processor,
+            target_service=self.target_service,
+            error_type=error_type,
+        ).inc()
+
+
 class ProcessorMetrics:
     def __init__(self, processor: str) -> None:
 
@@ -109,57 +181,23 @@ class ProcessorMetrics:
 
         if not hasattr(__class__, "processor_metric"):
             __class__.processor_metric = Info(
-                'processor', 'Processor configuration',
+                'tg_processor', 'Processor configuration',
                 ["processor"]
+            )
+
+        if not hasattr(__class__, "config_version_metric"):
+            __class__.config_version_metric = Gauge(
+                'tg_config_version',
+                'Current config version known to this processor',
+                ["processor"],
             )
 
     def info(self, info: dict[str, str]) -> None:
         __class__.processor_metric.labels(
-            processor = self.processor
+            processor=self.processor
         ).info(info)
 
-class SubscriberMetrics:
-
-    def __init__(self, processor: str, subscriber: str,
-                 workspace: str | None = None,
-                 flow: str | None = None) -> None:
-
-        self.processor = processor
-        self.subscriber = subscriber
-
-        if not hasattr(__class__, "state_metric"):
-            __class__.state_metric = Enum(
-                'subscriber_state', 'Subscriber state',
-                ["processor", "subscriber"],
-                states=['stopped', 'running']
-            )
-
-        if not hasattr(__class__, "received_metric"):
-            __class__.received_metric = Counter(
-                'received_count', 'Received count',
-                ["processor", "subscriber"],
-            )
-
-        if not hasattr(__class__, "dropped_metric"):
-            __class__.dropped_metric = Counter(
-                'dropped_count', 'Dropped messages count',
-                ["processor", "subscriber"],
-            )
-
-    def received(self) -> None:
-        __class__.received_metric.labels(
-            processor=self.processor,
-            subscriber=self.subscriber,
-        ).inc()
-
-    def state(self, state: str) -> None:
-        __class__.state_metric.labels(
-            processor=self.processor,
-            subscriber=self.subscriber,
-        ).state(state)
-
-    def dropped(self, state: str) -> None:
-        __class__.dropped_metric.labels(
-            processor=self.processor,
-            subscriber=self.subscriber,
-        ).inc()
+    def set_config_version(self, version: int) -> None:
+        __class__.config_version_metric.labels(
+            processor=self.processor
+        ).set(version)

--- a/trustgraph-base/trustgraph/base/receiver_pool.py
+++ b/trustgraph-base/trustgraph/base/receiver_pool.py
@@ -10,10 +10,12 @@ signal completion via futures.
 
 import asyncio
 import logging
+import time
 from dataclasses import dataclass, field
 from typing import Any, Callable, Awaitable
 
 from .async_backend import AsyncPubSubBackend, AsyncBackendConsumer, Message
+from ..exceptions import TooManyRequests
 
 logger = logging.getLogger(__name__)
 
@@ -138,6 +140,7 @@ class ReceiverPool:
         self, topic: str, subscription: str, schema: type,
         handler: Callable[..., Awaitable[None]],
         initial_position: str = 'latest',
+        instrument: bool = True,
     ) -> ConsumerRegistration:
         backend_consumer = await self.backend.create_consumer(
             topic=topic,
@@ -147,7 +150,7 @@ class ReceiverPool:
         )
 
         metrics = None
-        if self.processor_id:
+        if instrument and self.processor_id:
             from .metrics import ConsumerMetrics
             metrics = ConsumerMetrics(
                 processor=self.processor_id, consumer=topic,
@@ -183,13 +186,18 @@ class ReceiverPool:
             return handler
 
         async def wrapper(message):
-            with metrics.record_time():
-                try:
-                    await handler(message)
-                    metrics.process("ok")
-                except Exception:
-                    metrics.process("error")
-                    raise
+            t0 = time.monotonic()
+            try:
+                await handler(message)
+                metrics.observe_latency(time.monotonic() - t0)
+                metrics.process("ok")
+            except TooManyRequests:
+                metrics.rate_limit()
+                raise
+            except Exception:
+                metrics.observe_latency(time.monotonic() - t0)
+                metrics.process("error")
+                raise
 
         return wrapper
 

--- a/trustgraph-base/trustgraph/base/request_response_client.py
+++ b/trustgraph-base/trustgraph/base/request_response_client.py
@@ -8,6 +8,7 @@ via futures. No worker pool involvement.
 
 import asyncio
 import logging
+import time
 import uuid
 from typing import Any
 
@@ -33,13 +34,14 @@ class RequestResponseClient:
         await client.close()
     """
 
-    def __init__(self, default_timeout=60):
+    def __init__(self, default_timeout=60, metrics=None):
         self.producer = None
         self.consumer = None
         self.receiver_task = None
         self.pending: dict[str, asyncio.Future] = {}
         self.running = False
         self.default_timeout = default_timeout
+        self.metrics = metrics
 
     @classmethod
     async def create(
@@ -51,8 +53,18 @@ class RequestResponseClient:
         response_schema: type,
         subscription: str | None = None,
         default_timeout: float = 60,
+        processor_id: str | None = None,
+        target_service: str | None = None,
     ) -> 'RequestResponseClient':
-        client = cls(default_timeout=default_timeout)
+        metrics = None
+        if processor_id and target_service:
+            from .metrics import DownstreamMetrics
+            metrics = DownstreamMetrics(
+                processor=processor_id,
+                target_service=target_service,
+            )
+
+        client = cls(default_timeout=default_timeout, metrics=metrics)
 
         client.producer = await backend.create_producer(
             topic=request_topic,
@@ -98,10 +110,17 @@ class RequestResponseClient:
 
         await self.producer.send(message, send_properties)
 
+        t0 = time.monotonic()
         try:
-            return await asyncio.wait_for(future, timeout=timeout)
+            result = await asyncio.wait_for(future, timeout=timeout)
+            if self.metrics:
+                self.metrics.observe_duration(time.monotonic() - t0)
+            return result
         except asyncio.TimeoutError:
             self.pending.pop(request_id, None)
+            if self.metrics:
+                self.metrics.observe_duration(time.monotonic() - t0)
+                self.metrics.timeout()
             raise
 
     async def request_stream(
@@ -121,6 +140,8 @@ class RequestResponseClient:
 
         await self.producer.send(message, send_properties)
 
+        t0 = time.monotonic()
+        timed_out = False
         try:
             while True:
                 resp = await asyncio.wait_for(
@@ -128,8 +149,14 @@ class RequestResponseClient:
                 )
                 yield resp
         except asyncio.TimeoutError:
+            timed_out = True
+            if self.metrics:
+                self.metrics.observe_duration(time.monotonic() - t0)
+                self.metrics.timeout()
             raise
         finally:
+            if not timed_out and self.metrics:
+                self.metrics.observe_duration(time.monotonic() - t0)
             self.pending.pop(request_id, None)
 
     async def _response_loop(self):

--- a/trustgraph-base/trustgraph/base/request_response_spec.py
+++ b/trustgraph-base/trustgraph/base/request_response_spec.py
@@ -40,6 +40,8 @@ class RequestResponseSpec(Spec):
             response_topic=topics[self.response_name],
             request_schema=self.request_schema,
             response_schema=self.response_schema,
+            processor_id=getattr(processor, 'id', None),
+            target_service=self.request_name,
         )
 
         wrapper = _make_impl_wrapper(rr_client, self.impl)

--- a/trustgraph-base/trustgraph/base/reranker_service.py
+++ b/trustgraph-base/trustgraph/base/reranker_service.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 
 from argparse import ArgumentParser
 
+import time
 import logging
+from prometheus_client import Counter, Histogram
 
 from .. schema import (
     RerankerRequest, RerankerResponse, RerankerResult, Error,
@@ -50,6 +52,26 @@ class RerankerService(FlowProcessor):
             )
         )
 
+        if not hasattr(__class__, "reranker_request_metric"):
+            from . metrics import BUCKETS_STANDARD
+            __class__.reranker_request_metric = Counter(
+                'tg_reranker_request_total',
+                'Reranker requests per model',
+                ["processor", "model"],
+            )
+            __class__.reranker_duration_metric = Histogram(
+                'tg_reranker_duration_seconds',
+                'Rerank call latency (seconds)',
+                ["processor", "model"],
+                buckets=BUCKETS_STANDARD,
+            )
+            __class__.reranker_result_count_metric = Histogram(
+                'tg_reranker_result_count',
+                'Number of results per rerank call',
+                ["processor", "model"],
+                buckets=[1, 2, 5, 10, 20, 50, 100],
+            )
+
     async def on_request(self, msg, consumer, flow):
 
         try:
@@ -61,9 +83,22 @@ class RerankerService(FlowProcessor):
             logger.debug(f"Handling reranker request {id}...")
 
             model = flow("model")
+            model_label = str(model) if model else ""
+
+            t0 = time.monotonic()
             results = await self.on_rerank(
                 request.queries, request.documents,
                 request.limit, model=model,
+            )
+            duration = time.monotonic() - t0
+
+            labels = dict(processor=self.id, model=model_label)
+            __class__.reranker_request_metric.labels(**labels).inc()
+            __class__.reranker_duration_metric.labels(**labels).observe(
+                duration,
+            )
+            __class__.reranker_result_count_metric.labels(**labels).observe(
+                len(results),
             )
 
             await flow("response").send(

--- a/trustgraph-base/trustgraph/base/tool_service.py
+++ b/trustgraph-base/trustgraph/base/tool_service.py
@@ -49,7 +49,7 @@ class ToolService(FlowProcessor):
 
         if not hasattr(__class__, "tool_invocation_metric"):
             __class__.tool_invocation_metric = Counter(
-                'tool_invocation_count', 'Tool invocation count',
+                'tg_tool_invocation_total', 'Tool invocation count',
                 ["processor", "tool"],
             )
 

--- a/trustgraph-base/trustgraph/base/triples_query_service.py
+++ b/trustgraph-base/trustgraph/base/triples_query_service.py
@@ -7,7 +7,9 @@ from __future__ import annotations
 
 from argparse import ArgumentParser
 
+import time
 import logging
+from prometheus_client import Histogram
 
 from .. schema import TriplesQueryRequest, TriplesQueryResponse, Error
 from .. schema import Term, Triple
@@ -47,6 +49,21 @@ class TriplesQueryService(FlowProcessor):
             )
         )
 
+        if not hasattr(__class__, "query_duration_metric"):
+            from . metrics import BUCKETS_STANDARD
+            __class__.query_duration_metric = Histogram(
+                'tg_triples_query_duration_seconds',
+                'Triples query backend latency (seconds)',
+                ["processor"],
+                buckets=BUCKETS_STANDARD,
+            )
+            __class__.query_result_count_metric = Histogram(
+                'tg_triples_query_result_count',
+                'Number of triples returned per query',
+                ["processor"],
+                buckets=[1, 5, 10, 25, 50, 100, 250, 500, 1000],
+            )
+
     async def on_message(self, msg, consumer, flow):
 
         try:
@@ -61,20 +78,34 @@ class TriplesQueryService(FlowProcessor):
             workspace = flow.workspace
 
             if request.streaming:
-                # Streaming mode: send batches
+                t0 = time.monotonic()
+                total_results = 0
                 async for batch, is_final in self.query_triples_stream(
                     workspace, request,
                 ):
+                    total_results += len(batch)
                     r = TriplesQueryResponse(
                         triples=batch,
                         error=None,
                         is_final=is_final,
                     )
                     await flow("response").send(r, properties={"id": id})
+                __class__.query_duration_metric.labels(
+                    processor=self.id,
+                ).observe(time.monotonic() - t0)
+                __class__.query_result_count_metric.labels(
+                    processor=self.id,
+                ).observe(total_results)
                 logger.debug("Triples query streaming completed")
             else:
-                # Non-streaming mode: single response
+                t0 = time.monotonic()
                 triples = await self.query_triples(workspace, request)
+                __class__.query_duration_metric.labels(
+                    processor=self.id,
+                ).observe(time.monotonic() - t0)
+                __class__.query_result_count_metric.labels(
+                    processor=self.id,
+                ).observe(len(triples))
                 logger.debug("Sending triples query response...")
                 r = TriplesQueryResponse(triples=triples, error=None)
                 await flow("response").send(r, properties={"id": id})

--- a/trustgraph-base/trustgraph/base/triples_store_service.py
+++ b/trustgraph-base/trustgraph/base/triples_store_service.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 from argparse import ArgumentParser
 
 import logging
+import time
+from prometheus_client import Counter, Histogram
 
 from .. schema import Triples
 from .. base import FlowProcessor, ConsumerSpec
@@ -20,8 +22,8 @@ default_ident = "triples-write"
 class TriplesStoreService(FlowProcessor):
     """
     Component for maintaining the triples store.
-    
-    This service acts as a processor in the flow that receives knowledge triples 
+
+    This service acts as a processor in the flow that receives knowledge triples
     and writes them persistently into an overarching graph database or equivalent backend.
     """
 
@@ -30,6 +32,27 @@ class TriplesStoreService(FlowProcessor):
         id = params.get("id")
 
         super(TriplesStoreService, self).__init__(**params | { "id": id })
+
+        if not hasattr(__class__, "_metrics_initialized"):
+            from . metrics import BUCKETS_STANDARD
+            __class__._metrics_initialized = True
+            __class__.store_write_duration_metric = Histogram(
+                'tg_triples_store_write_duration_seconds',
+                'Triples store write latency per batch',
+                ["processor"],
+                buckets=BUCKETS_STANDARD,
+            )
+            __class__.store_write_batch_metric = Histogram(
+                'tg_triples_store_write_batch_size',
+                'Number of triples per write batch',
+                ["processor"],
+                buckets=[1, 5, 10, 20, 50, 100, 200, 500],
+            )
+            __class__.store_write_error_metric = Counter(
+                'tg_triples_store_write_error_total',
+                'Triples store write errors',
+                ["processor"],
+            )
 
         self.register_specification(
             ConsumerSpec(
@@ -45,16 +68,27 @@ class TriplesStoreService(FlowProcessor):
 
             request = msg.value()
 
+            t0 = time.monotonic()
+
             # Workspace is derived from the flow the message arrived on,
             # not from fields in the message payload. Topic routing is
             # the isolation boundary.
             await self.store_triples(flow.workspace, request)
 
+            __class__.store_write_duration_metric.labels(
+                processor=self.id,
+            ).observe(time.monotonic() - t0)
+            __class__.store_write_batch_metric.labels(
+                processor=self.id,
+            ).observe(len(request.triples) if request.triples else 0)
+
         except TooManyRequests as e:
             raise e
 
         except Exception as e:
-            
+            __class__.store_write_error_metric.labels(
+                processor=self.id,
+            ).inc()
             logger.error(f"Exception in triples store service: {e}", exc_info=True)
             raise e
 

--- a/trustgraph-flow/trustgraph/agent/react/service.py
+++ b/trustgraph-flow/trustgraph/agent/react/service.py
@@ -8,9 +8,11 @@ import re
 import sys
 import functools
 import logging
+import time
 import uuid
 from typing import Dict
 from datetime import datetime, timezone
+from prometheus_client import Counter, Histogram
 
 # Module logger
 logger = logging.getLogger(__name__)
@@ -72,6 +74,42 @@ class Processor(AgentService):
 
         # Track active tool service clients for cleanup
         self.tool_service_clients = {}
+
+        if not hasattr(__class__, "agent_session_metric"):
+            from trustgraph.base.metrics import BUCKETS_LLM, BUCKETS_SESSION
+            __class__.agent_session_metric = Counter(
+                'tg_agent_session_total',
+                'Agent sessions by outcome',
+                ["processor", "outcome"],
+            )
+            __class__.agent_iteration_metric = Histogram(
+                'tg_agent_iteration_count',
+                'Number of ReAct iterations per session',
+                ["processor"],
+                buckets=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 15, 20],
+            )
+            __class__.agent_tool_invocation_metric = Counter(
+                'tg_agent_tool_invocation_total',
+                'Agent tool calls per tool name',
+                ["processor", "tool"],
+            )
+            __class__.agent_tool_duration_metric = Histogram(
+                'tg_agent_tool_duration_seconds',
+                'Per-tool invocation latency (seconds)',
+                ["processor", "tool"],
+                buckets=BUCKETS_LLM,
+            )
+            __class__.agent_tool_error_metric = Counter(
+                'tg_agent_tool_error_total',
+                'Tool invocation failures',
+                ["processor", "tool"],
+            )
+            __class__.agent_llm_duration_metric = Histogram(
+                'tg_agent_llm_duration_seconds',
+                'LLM reasoning step latency per iteration (seconds)',
+                ["processor"],
+                buckets=BUCKETS_LLM,
+            )
 
         self.register_config_handler(
             self.on_tools_config, types=["tool", "tool-service"]
@@ -372,6 +410,12 @@ class Processor(AgentService):
             logger.info(f"Question: {request.question}")
 
             if len(history) >= self.max_iterations:
+                __class__.agent_session_metric.labels(
+                    processor=self.id, outcome="max-iterations",
+                ).inc()
+                __class__.agent_iteration_metric.labels(
+                    processor=self.id,
+                ).observe(self.max_iterations)
                 raise RuntimeError("Too many agent iterations")
 
             logger.debug(f"History: {history}")
@@ -557,6 +601,24 @@ class Processor(AgentService):
 
             logger.debug(f"Action: {act}")
 
+            if hasattr(act, 'llm_duration_ms') and act.llm_duration_ms:
+                __class__.agent_llm_duration_metric.labels(
+                    processor=self.id,
+                ).observe(act.llm_duration_ms / 1000.0)
+
+            if isinstance(act, Action) and act.name != "__parse_error__":
+                __class__.agent_tool_invocation_metric.labels(
+                    processor=self.id, tool=act.name,
+                ).inc()
+                if hasattr(act, 'tool_duration_ms') and act.tool_duration_ms:
+                    __class__.agent_tool_duration_metric.labels(
+                        processor=self.id, tool=act.name,
+                    ).observe(act.tool_duration_ms / 1000.0)
+                if hasattr(act, 'tool_error') and act.tool_error:
+                    __class__.agent_tool_error_metric.labels(
+                        processor=self.id, tool=act.name,
+                    ).inc()
+
             if isinstance(act, Final):
 
                 logger.debug("Send final response...")
@@ -638,6 +700,13 @@ class Processor(AgentService):
                     )
 
                 await respond(r)
+
+                __class__.agent_session_metric.labels(
+                    processor=self.id, outcome="completed",
+                ).inc()
+                __class__.agent_iteration_metric.labels(
+                    processor=self.id,
+                ).observe(iteration_num)
 
                 logger.debug("Done.")
 
@@ -729,6 +798,11 @@ class Processor(AgentService):
         except Exception as e:
 
             logger.error(f"agent_request Exception: {e}", exc_info=True)
+
+            if "Too many agent iterations" not in str(e):
+                __class__.agent_session_metric.labels(
+                    processor=self.id, outcome="error",
+                ).inc()
 
             logger.debug("Send error response...")
 

--- a/trustgraph-flow/trustgraph/agent/react/tools.py
+++ b/trustgraph-flow/trustgraph/agent/react/tools.py
@@ -271,17 +271,13 @@ class ToolServiceImpl:
 
         # Import here to avoid circular imports
         from trustgraph.base.tool_service_client import ToolServiceClient
-        from trustgraph.base.metrics import ProducerMetrics, SubscriberMetrics
+        from trustgraph.base.metrics import ProducerMetrics
         from trustgraph.schema import ToolServiceRequest, ToolServiceResponse
         import uuid
 
         request_metrics = ProducerMetrics(
             processor=self.processor.id,
             producer=self.request_queue,
-        )
-        response_metrics = SubscriberMetrics(
-            processor=self.processor.id,
-            subscriber=self.response_queue,
         )
 
         # Create unique subscription for responses
@@ -296,7 +292,6 @@ class ToolServiceImpl:
             request_metrics=request_metrics,
             response_topic=self.response_queue,
             response_schema=ToolServiceResponse,
-            response_metrics=response_metrics,
         )
 
         # Start the client

--- a/trustgraph-flow/trustgraph/chunking/recursive/chunker.py
+++ b/trustgraph-flow/trustgraph/chunking/recursive/chunker.py
@@ -52,7 +52,7 @@ class Processor(ChunkingService):
 
         if not hasattr(__class__, "chunk_metric"):
             __class__.chunk_metric = Histogram(
-                'chunk_size', 'Chunk size',
+                'tg_chunk_size', 'Chunk size',
                 ["processor"],
                 buckets=[100, 160, 250, 400, 650, 1000, 1600,
                          2500, 4000, 6400, 10000, 16000]

--- a/trustgraph-flow/trustgraph/chunking/token/chunker.py
+++ b/trustgraph-flow/trustgraph/chunking/token/chunker.py
@@ -50,7 +50,7 @@ class Processor(ChunkingService):
 
         if not hasattr(__class__, "chunk_metric"):
             __class__.chunk_metric = Histogram(
-                'chunk_size', 'Chunk size',
+                'tg_chunk_size', 'Chunk size',
                 ["processor"],
                 buckets=[100, 160, 250, 400, 650, 1000, 1600,
                          2500, 4000, 6400, 10000, 16000]

--- a/trustgraph-flow/trustgraph/extract/kg/definitions/extract.py
+++ b/trustgraph-flow/trustgraph/extract/kg/definitions/extract.py
@@ -6,8 +6,10 @@ entity/context definitions for embedding.
 """
 
 import json
+import time
 import urllib.parse
 import logging
+from prometheus_client import Counter, Histogram
 
 from .... schema import Chunk, Triple, Triples, Metadata, Term, IRI, LITERAL
 
@@ -45,6 +47,30 @@ class Processor(FlowProcessor):
                 "concurrency": concurrency,
             }
         )
+
+        if not hasattr(__class__, "extraction_duration_metric"):
+            from trustgraph.base.metrics import BUCKETS_LLM
+            __class__.extraction_duration_metric = Histogram(
+                'tg_extraction_duration_seconds',
+                'Wall-clock time per chunk extraction',
+                ["processor", "extractor"],
+                buckets=BUCKETS_LLM,
+            )
+            __class__.extraction_entity_metric = Counter(
+                'tg_extraction_entity_total',
+                'Entities extracted',
+                ["processor", "extractor"],
+            )
+            __class__.extraction_triple_metric = Counter(
+                'tg_extraction_triple_total',
+                'Triples produced per extractor',
+                ["processor", "extractor"],
+            )
+            __class__.extraction_empty_metric = Counter(
+                'tg_extraction_empty_total',
+                'Chunks that yielded zero extractions',
+                ["processor", "extractor"],
+            )
 
         self.register_specification(
             ConsumerSpec(
@@ -112,6 +138,9 @@ class Processor(FlowProcessor):
         chunk = v.chunk.decode("utf-8")
 
         logger.debug(f"Processing chunk: {chunk[:200]}...")  # Log first 200 chars
+
+        t0 = time.monotonic()
+        extractor_label = "definitions"
 
         try:
 
@@ -230,6 +259,19 @@ class Processor(FlowProcessor):
                     ),
                     batch
                 )
+
+            labels = dict(processor=self.id, extractor=extractor_label)
+            __class__.extraction_duration_metric.labels(
+                **labels,
+            ).observe(time.monotonic() - t0)
+            __class__.extraction_triple_metric.labels(
+                **labels,
+            ).inc(len(extracted_triples))
+            __class__.extraction_entity_metric.labels(
+                **labels,
+            ).inc(len(entities))
+            if not extracted_triples:
+                __class__.extraction_empty_metric.labels(**labels).inc()
 
         except Exception as e:
             logger.error(f"Definitions extraction exception: {e}", exc_info=True)

--- a/trustgraph-flow/trustgraph/extract/kg/ontology/extract.py
+++ b/trustgraph-flow/trustgraph/extract/kg/ontology/extract.py
@@ -6,7 +6,9 @@ Extracts ontology-conformant triples from text chunks.
 import json
 import logging
 import asyncio
+import time
 from typing import List, Dict, Any, Optional
+from prometheus_client import Counter, Histogram, Gauge
 
 from .... schema import Chunk, Triple, Triples, Metadata, Term, IRI, LITERAL
 from .... schema import EntityContext, EntityContexts
@@ -67,6 +69,52 @@ class Processor(FlowProcessor):
                 "concurrency": concurrency,
             }
         )
+
+        if not hasattr(__class__, "extraction_duration_metric"):
+            from trustgraph.base.metrics import BUCKETS_LLM, BUCKETS_STANDARD
+            __class__.extraction_duration_metric = Histogram(
+                'tg_extraction_duration_seconds',
+                'Wall-clock time per chunk extraction',
+                ["processor", "extractor"],
+                buckets=BUCKETS_LLM,
+            )
+            __class__.extraction_triple_metric = Counter(
+                'tg_extraction_triple_total',
+                'Triples produced per extractor',
+                ["processor", "extractor"],
+            )
+            __class__.extraction_empty_metric = Counter(
+                'tg_extraction_empty_total',
+                'Chunks that yielded zero extractions',
+                ["processor", "extractor"],
+            )
+            __class__.ontology_loaded_metric = Gauge(
+                'tg_ontology_loaded_count',
+                'Number of ontology definitions loaded from config',
+                ["processor", "workspace"],
+            )
+            __class__.ontology_element_metric = Gauge(
+                'tg_ontology_element_count',
+                'Number of embedded ontology elements',
+                ["processor"],
+            )
+            __class__.ontology_selection_count_metric = Histogram(
+                'tg_ontology_selection_count',
+                'Ontology elements selected per chunk',
+                ["processor"],
+                buckets=[0, 1, 2, 3, 5, 8, 10, 15, 20, 30, 50],
+            )
+            __class__.ontology_selection_duration_metric = Histogram(
+                'tg_ontology_selection_duration_seconds',
+                'Similarity selection time per chunk',
+                ["processor"],
+                buckets=BUCKETS_STANDARD,
+            )
+            __class__.ontology_no_match_metric = Counter(
+                'tg_ontology_no_match_total',
+                'Chunks with no ontology match',
+                ["processor"],
+            )
 
         # Register specifications
         self.register_specification(
@@ -181,7 +229,11 @@ class Processor(FlowProcessor):
                 )
                 for ont_id, ontology in loader.get_all_ontologies().items():
                     await ontology_embedder.embed_ontology(ontology)
-                logger.info(f"Embedded {ontology_embedder.get_embedded_count()} ontology elements for flow {flow_id}")
+                embedded_count = ontology_embedder.get_embedded_count()
+                logger.info(f"Embedded {embedded_count} ontology elements for flow {flow_id}")
+                __class__.ontology_element_metric.labels(
+                    processor=self.id,
+                ).set(embedded_count)
 
             # Initialize ontology selector
             ontology_selector = OntologySelector(
@@ -246,6 +298,10 @@ class Processor(FlowProcessor):
                 f"Loaded {len(ontologies)} ontology definitions "
                 f"for {workspace}"
             )
+
+            __class__.ontology_loaded_metric.labels(
+                processor=self.id, workspace=workspace,
+            ).set(len(ontologies))
 
             # Determine what changed for this workspace
             ws_loaded_ids = self.loaded_ontology_ids.get(workspace, set())
@@ -313,16 +369,31 @@ class Processor(FlowProcessor):
         chunk = v.chunk.decode("utf-8")
         logger.debug(f"Processing chunk: {chunk[:200]}...")
 
+        t0 = time.monotonic()
+        extractor_label = "ontology"
+
         try:
             # Process text into segments
             segments = self.text_processor.process_chunk(chunk, extract_phrases=True)
             logger.debug(f"Split chunk into {len(segments)} segments")
 
             # Select relevant ontology subset (using flow-specific selector)
+            t_sel = time.monotonic()
             ontology_subsets = await components['selector'].select_ontology_subset(segments)
+            __class__.ontology_selection_duration_metric.labels(
+                processor=self.id,
+            ).observe(time.monotonic() - t_sel)
 
             if not ontology_subsets:
                 logger.warning("No relevant ontology elements found for chunk")
+                __class__.ontology_no_match_metric.labels(
+                    processor=self.id,
+                ).inc()
+                labels = dict(processor=self.id, extractor=extractor_label)
+                __class__.extraction_duration_metric.labels(**labels).observe(
+                    time.monotonic() - t0,
+                )
+                __class__.extraction_empty_metric.labels(**labels).inc()
                 return
 
             # Merge subsets if multiple ontologies matched
@@ -330,6 +401,15 @@ class Processor(FlowProcessor):
                 ontology_subset = components['selector'].merge_subsets(ontology_subsets)
             else:
                 ontology_subset = ontology_subsets[0]
+
+            selected_count = (
+                len(ontology_subset.classes)
+                + len(ontology_subset.object_properties)
+                + len(ontology_subset.datatype_properties)
+            )
+            __class__.ontology_selection_count_metric.labels(
+                processor=self.id,
+            ).observe(selected_count)
 
             logger.debug(f"Selected ontology subset with {len(ontology_subset.classes)} classes, "
                         f"{len(ontology_subset.object_properties)} object properties, "
@@ -386,6 +466,16 @@ class Processor(FlowProcessor):
 
             logger.info(f"Extracted {len(triples)} content triples + {len(ontology_triples)} ontology triples "
                        f"= {len(all_triples)} total triples and {len(entity_contexts)} entity contexts")
+
+            labels = dict(processor=self.id, extractor=extractor_label)
+            __class__.extraction_duration_metric.labels(**labels).observe(
+                time.monotonic() - t0,
+            )
+            __class__.extraction_triple_metric.labels(**labels).inc(
+                len(triples),
+            )
+            if not triples:
+                __class__.extraction_empty_metric.labels(**labels).inc()
 
         except Exception as e:
             logger.error(f"OntoRAG extraction exception: {e}", exc_info=True)

--- a/trustgraph-flow/trustgraph/extract/kg/relationships/extract.py
+++ b/trustgraph-flow/trustgraph/extract/kg/relationships/extract.py
@@ -7,7 +7,9 @@ graph edges.
 
 import json
 import logging
+import time
 import urllib.parse
+from prometheus_client import Counter, Histogram
 
 # Module logger
 logger = logging.getLogger(__name__)
@@ -43,6 +45,25 @@ class Processor(FlowProcessor):
                 "concurrency": concurrency,
             }
         )
+
+        if not hasattr(__class__, "extraction_duration_metric"):
+            from trustgraph.base.metrics import BUCKETS_LLM
+            __class__.extraction_duration_metric = Histogram(
+                'tg_extraction_duration_seconds',
+                'Wall-clock time per chunk extraction',
+                ["processor", "extractor"],
+                buckets=BUCKETS_LLM,
+            )
+            __class__.extraction_triple_metric = Counter(
+                'tg_extraction_triple_total',
+                'Triples produced per extractor',
+                ["processor", "extractor"],
+            )
+            __class__.extraction_empty_metric = Counter(
+                'tg_extraction_empty_total',
+                'Chunks that yielded zero extractions',
+                ["processor", "extractor"],
+            )
 
         self.register_specification(
             ConsumerSpec(
@@ -95,6 +116,9 @@ class Processor(FlowProcessor):
         chunk = v.chunk.decode("utf-8")
 
         logger.debug(f"Processing chunk: {chunk[:100]}..." if len(chunk) > 100 else f"Processing chunk: {chunk}")
+
+        t0 = time.monotonic()
+        extractor_label = "relationships"
 
         try:
 
@@ -211,6 +235,16 @@ class Processor(FlowProcessor):
                     ),
                     batch
                 )
+
+            labels = dict(processor=self.id, extractor=extractor_label)
+            __class__.extraction_duration_metric.labels(
+                **labels,
+            ).observe(time.monotonic() - t0)
+            __class__.extraction_triple_metric.labels(
+                **labels,
+            ).inc(len(extracted_triples))
+            if not extracted_triples:
+                __class__.extraction_empty_metric.labels(**labels).inc()
 
         except Exception as e:
             logger.error(f"Relationship extraction exception: {e}", exc_info=True)

--- a/trustgraph-flow/trustgraph/gateway/auth.py
+++ b/trustgraph-flow/trustgraph/gateway/auth.py
@@ -23,6 +23,7 @@ import uuid
 from dataclasses import dataclass, field
 
 from aiohttp import web
+from prometheus_client import Counter, Enum, Gauge
 
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import ed25519
@@ -129,6 +130,31 @@ class IamAuth:
         self.backend = backend
         self.id = id
 
+        if not hasattr(__class__, "_metrics_initialized"):
+            __class__._metrics_initialized = True
+            __class__.signing_key_state_metric = Enum(
+                'tg_gateway_signing_key_state',
+                'Whether the IAM signing public key has been fetched',
+                [],
+                states=['absent', 'present'],
+            )
+            __class__.known_workspaces_metric = Gauge(
+                'tg_gateway_known_workspaces',
+                'Number of workspaces known to the gateway',
+                [],
+            )
+            __class__.auth_failure_metric = Counter(
+                'tg_gateway_auth_failure_total',
+                'Authentication failure count',
+                ["reason"],
+            )
+            __class__.authz_decision_metric = Counter(
+                'tg_gateway_authz_decision_total',
+                'Authorisation decisions',
+                ["outcome"],
+            )
+            __class__.signing_key_state_metric.state("absent")
+
         # Populated at start() via IAM.
         self._signing_public_pem = None
 
@@ -191,6 +217,7 @@ class IamAuth:
             pem = await self._with_client(_fetch)
             if pem:
                 self._signing_public_pem = pem
+                __class__.signing_key_state_metric.state("present")
                 logger.info(
                     "IamAuth: fetched IAM signing public key "
                     f"({len(pem)} bytes)"
@@ -285,16 +312,21 @@ class IamAuth:
         if not self._signing_public_pem:
             await self._fetch_signing_key()
         if not self._signing_public_pem:
+            __class__.auth_failure_metric.labels(reason="no-signing-key").inc()
             raise _auth_failure()
         try:
             claims = _verify_jwt_eddsa(token, self._signing_public_pem)
         except Exception as e:
             logger.debug(f"JWT validation failed: {type(e).__name__}: {e}")
+            __class__.auth_failure_metric.labels(reason="invalid-jwt").inc()
             raise _auth_failure()
 
         sub = claims.get("sub", "")
         ws = claims.get("default_workspace", "")
         if not sub or not ws:
+            __class__.auth_failure_metric.labels(
+                reason="jwt-missing-claims",
+            ).inc()
             raise _auth_failure()
 
         return Identity(
@@ -316,9 +348,15 @@ class IamAuth:
                 f"Anonymous authentication rejected: "
                 f"{type(e).__name__}: {e}"
             )
+            __class__.auth_failure_metric.labels(
+                reason="anonymous-rejected",
+            ).inc()
             raise _auth_failure()
 
         if not user_id or not default_workspace:
+            __class__.auth_failure_metric.labels(
+                reason="anonymous-rejected",
+            ).inc()
             raise _auth_failure()
 
         return Identity(
@@ -356,9 +394,15 @@ class IamAuth:
                     f"API key resolution failed: "
                     f"{type(e).__name__}: {e}"
                 )
+                __class__.auth_failure_metric.labels(
+                    reason="invalid-api-key",
+                ).inc()
                 raise _auth_failure()
 
             if not user_id or not default_workspace:
+                __class__.auth_failure_metric.labels(
+                    reason="invalid-api-key",
+                ).inc()
                 raise _auth_failure()
 
             identity = Identity(
@@ -409,7 +453,9 @@ class IamAuth:
         if cached and cached[1] > now:
             allow, _ = cached
             if not allow:
+                __class__.authz_decision_metric.labels(outcome="deny").inc()
                 raise _access_denied()
+            __class__.authz_decision_metric.labels(outcome="allow").inc()
             return
 
         async with self._authz_cache_lock:
@@ -417,7 +463,13 @@ class IamAuth:
             if cached and cached[1] > now:
                 allow, _ = cached
                 if not allow:
+                    __class__.authz_decision_metric.labels(
+                        outcome="deny",
+                    ).inc()
                     raise _access_denied()
+                __class__.authz_decision_metric.labels(
+                    outcome="allow",
+                ).inc()
                 return
 
             try:
@@ -434,11 +486,18 @@ class IamAuth:
                     f"failing closed for "
                     f"{identity.principal_id!r} cap={capability!r}"
                 )
+                __class__.authz_decision_metric.labels(
+                    outcome="error",
+                ).inc()
                 raise _auth_failure()
 
             ttl = max(0, min(int(ttl or 0), AUTHZ_CACHE_TTL_MAX))
             self._authz_cache[key] = (bool(allow), now + ttl)
 
             if not allow:
+                __class__.authz_decision_metric.labels(
+                    outcome="deny",
+                ).inc()
                 raise _access_denied()
+            __class__.authz_decision_metric.labels(outcome="allow").inc()
             return

--- a/trustgraph-flow/trustgraph/gateway/config/receiver.py
+++ b/trustgraph-flow/trustgraph/gateway/config/receiver.py
@@ -9,6 +9,7 @@ import asyncio
 import uuid
 import logging
 import json
+from prometheus_client import Gauge
 
 from ... schema import ConfigPush, ConfigRequest, ConfigResponse
 from ... schema import config_push_queue, config_request_queue
@@ -17,6 +18,12 @@ from ... base.request_response_client import RequestResponseClient
 
 logger = logging.getLogger("config.receiver")
 logger.setLevel(logging.INFO)
+
+
+_flow_count_gauge = Gauge(
+    'tg_gateway_active_flow_count',
+    'Number of active flows tracked by the gateway',
+)
 
 
 class ConfigReceiver:
@@ -58,6 +65,11 @@ class ConfigReceiver:
                 for ws in (v.workspace_changes.deleted or []):
                     self.auth.known_workspaces.discard(ws)
                     logger.info(f"Workspace deregistered: {ws}")
+                from ..auth import IamAuth
+                if hasattr(IamAuth, 'known_workspaces_metric'):
+                    IamAuth.known_workspaces_metric.set(
+                        len(self.auth.known_workspaces),
+                    )
 
             flow_workspaces = changes.get("flow", [])
             if changes and not flow_workspaces:
@@ -150,6 +162,10 @@ class ConfigReceiver:
 
                 self.flows[workspace] = ws_flows
 
+                _flow_count_gauge.set(
+                    sum(len(v) for v in self.flows.values())
+                )
+
                 return
 
             except Exception as e:
@@ -195,6 +211,11 @@ class ConfigReceiver:
 
                     if self.auth:
                         self.auth.known_workspaces = discovered
+                        from ..auth import IamAuth
+                        if hasattr(IamAuth, 'known_workspaces_metric'):
+                            IamAuth.known_workspaces_metric.set(
+                                len(discovered),
+                            )
 
                     logger.info(
                         f"Known workspaces: {discovered}"

--- a/trustgraph-flow/trustgraph/gateway/dispatch/manager.py
+++ b/trustgraph-flow/trustgraph/gateway/dispatch/manager.py
@@ -309,6 +309,7 @@ class DispatcherManager:
                         request_queue = request_queue,
                         response_queue = response_queue,
                     )
+                    dispatcher.service_kind = kind
 
                     await dispatcher.start()
                     self.dispatchers[key] = dispatcher
@@ -464,6 +465,7 @@ class DispatcherManager:
                             consumer = f"{self.prefix}-{workspace}-{flow}-{kind}-request",
                             subscriber = f"{self.prefix}-{workspace}-{flow}-{kind}-request",
                         )
+                        dispatcher.service_kind = kind
                     elif kind in sender_dispatchers:
                         dispatcher = sender_dispatchers[kind](
                             backend = self.backend,

--- a/trustgraph-flow/trustgraph/gateway/dispatch/requestor.py
+++ b/trustgraph-flow/trustgraph/gateway/dispatch/requestor.py
@@ -1,11 +1,34 @@
 
 import asyncio
 import logging
+import time
+from prometheus_client import Counter, Histogram
 
 from ... base.request_response_client import RequestResponseClient
 
 logger = logging.getLogger("requestor")
 logger.setLevel(logging.INFO)
+
+_gateway_metrics_initialized = False
+
+def _init_gateway_metrics():
+    global _gateway_metrics_initialized
+    if _gateway_metrics_initialized:
+        return
+    _gateway_metrics_initialized = True
+
+    from trustgraph.base.metrics import BUCKETS_SESSION
+    ServiceRequestor.gateway_request_metric = Counter(
+        'tg_gateway_request_total',
+        'Gateway dispatched operations',
+        ["service", "status"],
+    )
+    ServiceRequestor.gateway_request_duration_metric = Histogram(
+        'tg_gateway_request_duration_seconds',
+        'Gateway end-to-end request latency (seconds)',
+        ["service"],
+        buckets=BUCKETS_SESSION,
+    )
 
 class ServiceRequestor:
 
@@ -16,6 +39,7 @@ class ServiceRequestor:
             response_queue, response_schema,
             subscription="api-gateway", consumer_name="api-gateway",
             timeout=600,
+            service_kind=None,
     ):
 
         self.backend = backend
@@ -24,17 +48,21 @@ class ServiceRequestor:
         self.response_queue = response_queue
         self.response_schema = response_schema
         self.timeout = timeout
+        self.service_kind = service_kind
         self.client = None
         self.running = True
 
     async def start(self):
         self.running = True
+        _init_gateway_metrics()
         self.client = await RequestResponseClient.create(
             backend=self.backend,
             request_topic=self.request_queue,
             response_topic=self.response_queue,
             request_schema=self.request_schema,
             response_schema=self.response_schema,
+            processor_id="api-gateway",
+            target_service=self.service_kind,
         )
 
     async def stop(self):
@@ -51,6 +79,9 @@ class ServiceRequestor:
 
     async def process(self, request, responder=None):
 
+        svc = self.service_kind or "unknown"
+        t0 = time.monotonic()
+
         try:
 
             if responder is None:
@@ -60,12 +91,24 @@ class ServiceRequestor:
                 )
 
                 if resp.error:
+                    __class__.gateway_request_metric.labels(
+                        service=svc, status="error",
+                    ).inc()
+                    __class__.gateway_request_duration_metric.labels(
+                        service=svc,
+                    ).observe(time.monotonic() - t0)
                     return { "error": {
                         "type": resp.error.type,
                         "message": resp.error.message,
                     } }
 
                 result, fin = self.from_response(resp)
+                __class__.gateway_request_metric.labels(
+                    service=svc, status="ok",
+                ).inc()
+                __class__.gateway_request_duration_metric.labels(
+                    service=svc,
+                ).observe(time.monotonic() - t0)
                 return result
 
             async for resp in self.client.request_stream(
@@ -79,17 +122,36 @@ class ServiceRequestor:
                         "message": resp.error.message,
                     } }
                     await responder(err, True)
+                    __class__.gateway_request_metric.labels(
+                        service=svc, status="error",
+                    ).inc()
+                    __class__.gateway_request_duration_metric.labels(
+                        service=svc,
+                    ).observe(time.monotonic() - t0)
                     return err
 
                 result, fin = self.from_response(resp)
                 await responder(result, fin)
 
                 if fin:
+                    __class__.gateway_request_metric.labels(
+                        service=svc, status="ok",
+                    ).inc()
+                    __class__.gateway_request_duration_metric.labels(
+                        service=svc,
+                    ).observe(time.monotonic() - t0)
                     return result
 
         except Exception as e:
 
             logging.error(f"Exception: {e}")
+
+            __class__.gateway_request_metric.labels(
+                service=svc, status="error",
+            ).inc()
+            __class__.gateway_request_duration_metric.labels(
+                service=svc,
+            ).observe(time.monotonic() - t0)
 
             err = { "error": {
                 "type": "gateway-error",

--- a/trustgraph-flow/trustgraph/iam/service/service.py
+++ b/trustgraph-flow/trustgraph/iam/service/service.py
@@ -8,6 +8,8 @@ Shape mirrors trustgraph.config.service.
 
 import logging
 import os
+import time
+from prometheus_client import Counter, Gauge, Histogram
 
 from trustgraph.schema import Error
 from trustgraph.schema import IamRequest, IamResponse
@@ -115,6 +117,37 @@ class Processor(AsyncProcessor):
             }
         )
 
+        if not hasattr(__class__, "_metrics_initialized"):
+            from trustgraph.base.metrics import BUCKETS_STANDARD
+            __class__._metrics_initialized = True
+            __class__.iam_request_metric = Counter(
+                'tg_iam_request_total',
+                'IAM service requests by operation and outcome',
+                ["operation", "outcome"],
+            )
+            __class__.iam_request_duration_metric = Histogram(
+                'tg_iam_request_duration_seconds',
+                'IAM service per-operation latency',
+                ["operation"],
+                buckets=BUCKETS_STANDARD,
+            )
+            __class__.iam_user_count_metric = Gauge(
+                'tg_iam_user_count',
+                'Total number of IAM users',
+            )
+            __class__.iam_workspace_count_metric = Gauge(
+                'tg_iam_workspace_count',
+                'Total number of IAM workspaces',
+            )
+            __class__.iam_api_key_created_metric = Counter(
+                'tg_iam_api_key_created_total',
+                'Total API keys created (lifetime)',
+            )
+            __class__.iam_api_key_revoked_metric = Counter(
+                'tg_iam_api_key_revoked_total',
+                'Total API keys revoked (lifetime)',
+            )
+
         self.iam_request_topic = iam_req_q
         self.iam_response_topic = iam_resp_q
 
@@ -165,6 +198,26 @@ class Processor(AsyncProcessor):
         # Token-mode auto-bootstrap runs before we accept requests so
         # the first inbound call always sees a populated table.
         await self.iam.auto_bootstrap_if_token_mode()
+
+        await self._refresh_inventory_gauges()
+
+    _INVENTORY_OPS = frozenset({
+        "create-user", "delete-user",
+        "create-workspace", "disable-workspace",
+        "bootstrap",
+    })
+
+    async def _refresh_inventory_gauges(self):
+        try:
+            ts = self.iam.table_store
+            users = await ts.list_users()
+            __class__.iam_user_count_metric.set(len(users))
+            workspaces = await ts.list_workspaces()
+            __class__.iam_workspace_count_metric.set(len(workspaces))
+        except Exception as e:
+            logger.debug(
+                f"Inventory gauge refresh failed: {e}", exc_info=True,
+            )
 
     async def _config_put(self, workspace, type, key, value):
         client = await self._create_config_client()
@@ -234,22 +287,45 @@ class Processor(AsyncProcessor):
     async def on_iam_request(self, msg, consumer, flow):
 
         id = None
+        op = "unknown"
+        t0 = time.monotonic()
         try:
             v = msg.value()
+            op = v.operation or "unknown"
             id = msg.properties()["id"]
             logger.debug(
-                f"Handling IAM request {id} op={v.operation!r}"
+                f"Handling IAM request {id} op={op!r}"
             )
             resp = await self.iam.handle(v)
             await self.iam_response_producer.send(
                 resp, properties={"id": id},
             )
             await self._emit_audit(v, resp)
+            outcome = "error" if resp.error else "ok"
+            __class__.iam_request_metric.labels(
+                operation=op, outcome=outcome,
+            ).inc()
+            __class__.iam_request_duration_metric.labels(
+                operation=op,
+            ).observe(time.monotonic() - t0)
+            if not resp.error:
+                if op in self._INVENTORY_OPS:
+                    await self._refresh_inventory_gauges()
+                if op == "create-api-key":
+                    __class__.iam_api_key_created_metric.inc()
+                elif op == "revoke-api-key":
+                    __class__.iam_api_key_revoked_metric.inc()
         except Exception as e:
             logger.error(
                 f"IAM request failed: {type(e).__name__}: {e}",
                 exc_info=True,
             )
+            __class__.iam_request_metric.labels(
+                operation=op, outcome="exception",
+            ).inc()
+            __class__.iam_request_duration_metric.labels(
+                operation=op,
+            ).observe(time.monotonic() - t0)
             resp = IamResponse(
                 error=Error(type="internal-error", message=str(e)),
             )

--- a/trustgraph-flow/trustgraph/metering/counter.py
+++ b/trustgraph-flow/trustgraph/metering/counter.py
@@ -22,14 +22,14 @@ class Processor(FlowProcessor):
 
         if not hasattr(__class__, "token_metric"):
             __class__.token_metric = Counter(
-                'tokens',
+                'tg_metering_tokens_total',
                 'Token count',
                 ['model', 'direction']
             )
 
         if not hasattr(__class__, "cost_metric"):
             __class__.cost_metric = Counter(
-                'cost',
+                'tg_metering_cost_usd_total',
                 'Cost in USD',
                 ['model', 'direction']
             )


### PR DESCRIPTION
## Summary

- **Layer 1 (Infrastructure)**: Add `tg_` namespace prefix to all metrics, remove dead `SubscriberMetrics`, exclude config consumers from work metrics (`instrument=False`), add config version gauge, separate `TooManyRequests` from error counters, add centrally defined histogram bucket presets (`BUCKETS_STANDARD`, `BUCKETS_LLM`, `BUCKETS_SESSION`)
- **Layer 2 (Service base classes)**: Add `DownstreamMetrics` (duration/timeout/error) in `RequestResponseClient`, add embeddings/reranker/query service metrics, add store write metrics (duration/batch size/error) to all three store base classes covering all 10 backend implementations
- **Layer 3 (Application)**: Agent orchestration metrics (session outcomes, iteration count, per-tool invocation/duration/error, LLM reasoning duration), gateway dispatcher/auth/config metrics, knowledge extraction pipeline metrics (shared across definitions/relationships/ontology extractors with extractor label, plus ontology-specific selection metrics), IAM service metrics (per-operation request/duration, user/workspace inventory gauges, API key lifecycle counters)

Tech spec: `docs/tech-specs/metrics-refactor.md`

35 files changed across `trustgraph-base` and `trustgraph-flow`. Pipeline depth tracking deferred to phase 2.

## Test plan

- [x] Verify unit tests pass: `pytest tests/unit/test_base/test_metrics.py`
- [ ] Deploy and confirm `/metrics` endpoint exposes all new `tg_`-prefixed metrics
- [ ] Verify config consumers do NOT emit `tg_consumer_*` metrics
- [ ] Verify `TooManyRequests` increments `tg_consumer_rate_limited_total`, not `tg_consumer_error_total`
- [ ] Confirm extraction metrics distinguish extractors via `extractor` label (definitions, relationships, ontology)
- [ ] Confirm IAM inventory gauges (`tg_iam_user_count`, `tg_iam_workspace_count`) reflect actual state after create/delete operations
- [ ] Confirm gateway `tg_gateway_active_flow_count` updates on flow start/stop
- [ ] Confirm no old metric names (without `tg_` prefix) appear in `/metrics` output