### PR TITLE
Fix extraction metrics, queue dumper, and error handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ container-bedrock container-vertexai \
 container-hf container-ocr \
 container-unstructured container-docling container-mcp
 
-some-containers: container-base container-flow
+some-containers: container-base container-flow container-docling
 # container-unstructured
 
 push:

--- a/trustgraph-base/trustgraph/base/document_embeddings_store_service.py
+++ b/trustgraph-base/trustgraph/base/document_embeddings_store_service.py
@@ -74,7 +74,7 @@ class DocumentEmbeddingsStoreService(FlowProcessor):
             ).observe(time.monotonic() - t0)
             __class__.store_write_batch_metric.labels(
                 processor=self.id,
-            ).observe(len(request.vectors) if request.vectors else 0)
+            ).observe(len(request.chunks) if request.chunks else 0)
 
         except TooManyRequests as e:
             raise e

--- a/trustgraph-base/trustgraph/base/graph_embeddings_store_service.py
+++ b/trustgraph-base/trustgraph/base/graph_embeddings_store_service.py
@@ -74,7 +74,7 @@ class GraphEmbeddingsStoreService(FlowProcessor):
             ).observe(time.monotonic() - t0)
             __class__.store_write_batch_metric.labels(
                 processor=self.id,
-            ).observe(len(request.vectors) if request.vectors else 0)
+            ).observe(len(request.entities) if request.entities else 0)
 
         except TooManyRequests as e:
             raise e

--- a/trustgraph-base/trustgraph/base/text_completion_client.py
+++ b/trustgraph-base/trustgraph/base/text_completion_client.py
@@ -30,6 +30,9 @@ class TextCompletionClient:
         if resp.error:
             raise RuntimeError(resp.error.message)
 
+        if resp.response is None:
+            raise RuntimeError("LLM returned empty response")
+
         return TextCompletionResult(
             text = resp.response,
             in_token = resp.in_token,

--- a/trustgraph-cli/trustgraph/cli/dump_queues.py
+++ b/trustgraph-cli/trustgraph/cli/dump_queues.py
@@ -99,17 +99,28 @@ async def monitor_queue(consumer, queue_name, central_queue, shutdown_event):
     try:
         while not shutdown_event.is_set():
             try:
-                msg = await asyncio.wait_for(consumer.receive(), timeout=0.5)
-                timestamp = datetime.now()
-                formatted = format_message(queue_name, msg)
+                receive_task = asyncio.ensure_future(consumer.receive())
+                shutdown_task = asyncio.ensure_future(shutdown_event.wait())
 
-                # Forward to central queue for writing
-                await central_queue.put((timestamp, queue_name, formatted))
+                done, pending = await asyncio.wait(
+                    [receive_task, shutdown_task],
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
 
-                await consumer.acknowledge(msg)
-            except asyncio.TimeoutError:
-                # No message, check shutdown flag again
-                continue
+                if shutdown_task in done:
+                    receive_task.cancel()
+                    break
+
+                if receive_task in done:
+                    shutdown_task.cancel()
+                    msg = receive_task.result()
+                    timestamp = datetime.now()
+                    formatted = format_message(queue_name, msg)
+                    await central_queue.put((timestamp, queue_name, formatted))
+                    await consumer.acknowledge(msg)
+
+            except asyncio.CancelledError:
+                break
 
     except Exception as e:
         if not shutdown_event.is_set():

--- a/trustgraph-flow/trustgraph/extract/kg/definitions/extract.py
+++ b/trustgraph-flow/trustgraph/extract/kg/definitions/extract.py
@@ -9,7 +9,11 @@ import json
 import time
 import urllib.parse
 import logging
-from prometheus_client import Counter, Histogram
+
+from .. extract_metrics import (
+    extraction_duration_metric, extraction_triple_metric,
+    extraction_entity_metric, extraction_empty_metric,
+)
 
 from .... schema import Chunk, Triple, Triples, Metadata, Term, IRI, LITERAL
 
@@ -47,30 +51,6 @@ class Processor(FlowProcessor):
                 "concurrency": concurrency,
             }
         )
-
-        if not hasattr(__class__, "extraction_duration_metric"):
-            from trustgraph.base.metrics import BUCKETS_LLM
-            __class__.extraction_duration_metric = Histogram(
-                'tg_extraction_duration_seconds',
-                'Wall-clock time per chunk extraction',
-                ["processor", "extractor"],
-                buckets=BUCKETS_LLM,
-            )
-            __class__.extraction_entity_metric = Counter(
-                'tg_extraction_entity_total',
-                'Entities extracted',
-                ["processor", "extractor"],
-            )
-            __class__.extraction_triple_metric = Counter(
-                'tg_extraction_triple_total',
-                'Triples produced per extractor',
-                ["processor", "extractor"],
-            )
-            __class__.extraction_empty_metric = Counter(
-                'tg_extraction_empty_total',
-                'Chunks that yielded zero extractions',
-                ["processor", "extractor"],
-            )
 
         self.register_specification(
             ConsumerSpec(
@@ -261,17 +241,17 @@ class Processor(FlowProcessor):
                 )
 
             labels = dict(processor=self.id, extractor=extractor_label)
-            __class__.extraction_duration_metric.labels(
+            extraction_duration_metric.labels(
                 **labels,
             ).observe(time.monotonic() - t0)
-            __class__.extraction_triple_metric.labels(
+            extraction_triple_metric.labels(
                 **labels,
             ).inc(len(extracted_triples))
-            __class__.extraction_entity_metric.labels(
+            extraction_entity_metric.labels(
                 **labels,
             ).inc(len(entities))
             if not extracted_triples:
-                __class__.extraction_empty_metric.labels(**labels).inc()
+                extraction_empty_metric.labels(**labels).inc()
 
         except Exception as e:
             logger.error(f"Definitions extraction exception: {e}", exc_info=True)

--- a/trustgraph-flow/trustgraph/extract/kg/extract_metrics.py
+++ b/trustgraph-flow/trustgraph/extract/kg/extract_metrics.py
@@ -1,0 +1,27 @@
+from prometheus_client import Counter, Histogram
+from trustgraph.base.metrics import BUCKETS_LLM
+
+extraction_duration_metric = Histogram(
+    'tg_extraction_duration_seconds',
+    'Wall-clock time per chunk extraction',
+    ["processor", "extractor"],
+    buckets=BUCKETS_LLM,
+)
+
+extraction_triple_metric = Counter(
+    'tg_extraction_triple_total',
+    'Triples produced per extractor',
+    ["processor", "extractor"],
+)
+
+extraction_entity_metric = Counter(
+    'tg_extraction_entity_total',
+    'Entities extracted',
+    ["processor", "extractor"],
+)
+
+extraction_empty_metric = Counter(
+    'tg_extraction_empty_total',
+    'Chunks that yielded zero extractions',
+    ["processor", "extractor"],
+)

--- a/trustgraph-flow/trustgraph/extract/kg/ontology/extract.py
+++ b/trustgraph-flow/trustgraph/extract/kg/ontology/extract.py
@@ -10,6 +10,11 @@ import time
 from typing import List, Dict, Any, Optional
 from prometheus_client import Counter, Histogram, Gauge
 
+from .. extract_metrics import (
+    extraction_duration_metric, extraction_triple_metric,
+    extraction_empty_metric,
+)
+
 from .... schema import Chunk, Triple, Triples, Metadata, Term, IRI, LITERAL
 from .... schema import EntityContext, EntityContexts
 from .... schema import PromptRequest, PromptResponse
@@ -70,24 +75,8 @@ class Processor(FlowProcessor):
             }
         )
 
-        if not hasattr(__class__, "extraction_duration_metric"):
-            from trustgraph.base.metrics import BUCKETS_LLM, BUCKETS_STANDARD
-            __class__.extraction_duration_metric = Histogram(
-                'tg_extraction_duration_seconds',
-                'Wall-clock time per chunk extraction',
-                ["processor", "extractor"],
-                buckets=BUCKETS_LLM,
-            )
-            __class__.extraction_triple_metric = Counter(
-                'tg_extraction_triple_total',
-                'Triples produced per extractor',
-                ["processor", "extractor"],
-            )
-            __class__.extraction_empty_metric = Counter(
-                'tg_extraction_empty_total',
-                'Chunks that yielded zero extractions',
-                ["processor", "extractor"],
-            )
+        if not hasattr(__class__, "ontology_loaded_metric"):
+            from trustgraph.base.metrics import BUCKETS_STANDARD
             __class__.ontology_loaded_metric = Gauge(
                 'tg_ontology_loaded_count',
                 'Number of ontology definitions loaded from config',
@@ -390,10 +379,10 @@ class Processor(FlowProcessor):
                     processor=self.id,
                 ).inc()
                 labels = dict(processor=self.id, extractor=extractor_label)
-                __class__.extraction_duration_metric.labels(**labels).observe(
+                extraction_duration_metric.labels(**labels).observe(
                     time.monotonic() - t0,
                 )
-                __class__.extraction_empty_metric.labels(**labels).inc()
+                extraction_empty_metric.labels(**labels).inc()
                 return
 
             # Merge subsets if multiple ontologies matched
@@ -468,14 +457,14 @@ class Processor(FlowProcessor):
                        f"= {len(all_triples)} total triples and {len(entity_contexts)} entity contexts")
 
             labels = dict(processor=self.id, extractor=extractor_label)
-            __class__.extraction_duration_metric.labels(**labels).observe(
+            extraction_duration_metric.labels(**labels).observe(
                 time.monotonic() - t0,
             )
-            __class__.extraction_triple_metric.labels(**labels).inc(
+            extraction_triple_metric.labels(**labels).inc(
                 len(triples),
             )
             if not triples:
-                __class__.extraction_empty_metric.labels(**labels).inc()
+                extraction_empty_metric.labels(**labels).inc()
 
         except Exception as e:
             logger.error(f"OntoRAG extraction exception: {e}", exc_info=True)

--- a/trustgraph-flow/trustgraph/extract/kg/relationships/extract.py
+++ b/trustgraph-flow/trustgraph/extract/kg/relationships/extract.py
@@ -9,7 +9,11 @@ import json
 import logging
 import time
 import urllib.parse
-from prometheus_client import Counter, Histogram
+
+from .. extract_metrics import (
+    extraction_duration_metric, extraction_triple_metric,
+    extraction_empty_metric,
+)
 
 # Module logger
 logger = logging.getLogger(__name__)
@@ -45,25 +49,6 @@ class Processor(FlowProcessor):
                 "concurrency": concurrency,
             }
         )
-
-        if not hasattr(__class__, "extraction_duration_metric"):
-            from trustgraph.base.metrics import BUCKETS_LLM
-            __class__.extraction_duration_metric = Histogram(
-                'tg_extraction_duration_seconds',
-                'Wall-clock time per chunk extraction',
-                ["processor", "extractor"],
-                buckets=BUCKETS_LLM,
-            )
-            __class__.extraction_triple_metric = Counter(
-                'tg_extraction_triple_total',
-                'Triples produced per extractor',
-                ["processor", "extractor"],
-            )
-            __class__.extraction_empty_metric = Counter(
-                'tg_extraction_empty_total',
-                'Chunks that yielded zero extractions',
-                ["processor", "extractor"],
-            )
 
         self.register_specification(
             ConsumerSpec(
@@ -237,14 +222,14 @@ class Processor(FlowProcessor):
                 )
 
             labels = dict(processor=self.id, extractor=extractor_label)
-            __class__.extraction_duration_metric.labels(
+            extraction_duration_metric.labels(
                 **labels,
             ).observe(time.monotonic() - t0)
-            __class__.extraction_triple_metric.labels(
+            extraction_triple_metric.labels(
                 **labels,
             ).inc(len(extracted_triples))
             if not extracted_triples:
-                __class__.extraction_empty_metric.labels(**labels).inc()
+                extraction_empty_metric.labels(**labels).inc()
 
         except Exception as e:
             logger.error(f"Relationship extraction exception: {e}", exc_info=True)

--- a/trustgraph-flow/trustgraph/gateway/auth.py
+++ b/trustgraph-flow/trustgraph/gateway/auth.py
@@ -289,6 +289,9 @@ class IamAuth:
             identity = await self._verify_jwt(token)
             self._annotate_request(request, identity)
             return identity
+        __class__.auth_failure_metric.labels(
+            reason="malformed-credential",
+        ).inc()
         raise _auth_failure()
 
     @staticmethod

--- a/trustgraph-flow/trustgraph/template/prompt_manager.py
+++ b/trustgraph-flow/trustgraph/template/prompt_manager.py
@@ -167,6 +167,9 @@ class PromptManager:
 
         resp = await llm(**prompt)
 
+        if resp is None:
+            raise RuntimeError("LLM returned no response")
+
         if resp_type == "text":
             return resp
 


### PR DESCRIPTION
## Summary

- **DuplicateTimeseries fix**: Move shared extraction metrics to module-level `extract_metrics.py` so extractors running in the same ProcessGroup don't register duplicate metric names
- **tg-dump-queues fix**: Replace `asyncio.wait_for` with `asyncio.wait` to stop Pulsar futures being cancelled and messages lost
- **Store metrics fix**: Correct schema attribute references in graph embeddings (`.vectors` → `.entities`) and document embeddings (`.vectors` → `.chunks`) batch size metrics
- **Error handling**: Add null guard in `prompt_manager` and `text_completion_client` for LLM returning no response, and add auth failure metric for malformed credentials

## Test plan

- [x] Run extraction pipeline and verify `tg_extraction_triple_total` increments for both `definitions` and `relationships` extractors
- [x] Verify no `DuplicateTimeseries` errors in logs when extractors run in same ProcessGroup
- [x] Run `tg-dump-queues` and confirm messages are captured in `queue.log`
- [x] Verify `tg_document_embeddings_store_write_batch_size` and `tg_graph_embeddings_store_write_batch_size` record without errors
- [x] Send malformed Bearer tokens and verify `tg_gateway_auth_failure_total{reason="malformed-credential"}` increments
