### PR TITLE
fix(cassandra): page the delete-path scans so collections delete fully (#1066)

### DIFF
--- a/tests/unit/test_direct/test_entity_centric_delete_pagination.py
+++ b/tests/unit/test_direct/test_entity_centric_delete_pagination.py
@@ -1,0 +1,170 @@
+"""Pagination regression tests for EntityCentricKnowledgeGraph.async_delete_collection
+
+Issue #1066: async_delete_collection read the quad manifest with async_execute, which
+materialises only the FIRST result page. Deleting a collection larger than fetch_size
+therefore removed only that page while logging success and dropping the collection's
+config entry, leaving the bulk of the data behind and unreachable through the API.
+
+The harness below models both halves of the driver contract faithfully rather than
+stubbing the helpers out, so the tests distinguish a paging read from a single-page one:
+
+  session.execute(stmt, params)        -> a multi-page ResultSet   (what async_scan uses)
+  session.execute_async(q, params)     -> first page only, via callbacks
+                                          (what async_execute uses, mirroring the driver)
+
+No production function is patched, so a reverted fix genuinely fails these tests.
+"""
+
+import pytest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+
+def _row(s, d='', otype='u'):
+    return SimpleNamespace(d=d, s=s, p='p' + s, o='o' + s, otype=otype, dtype='', lang='')
+
+
+# Three pages, two quads each. A truncating read sees only the first two rows.
+PAGES = [
+    [_row('s1'), _row('s2')],
+    [_row('s3'), _row('s4')],
+    [_row('s5'), _row('s6')],
+]
+TOTAL_QUADS = sum(len(p) for p in PAGES)
+
+
+class FakePagedResultSet:
+    """Minimal stand-in for the driver's ResultSet paging contract."""
+
+    def __init__(self, pages):
+        self._pages = [list(page) for page in pages]
+        self._index = 0
+
+    @property
+    def current_rows(self):
+        return self._pages[self._index]
+
+    @property
+    def has_more_pages(self):
+        return self._index < len(self._pages) - 1
+
+    def fetch_next_page(self):
+        if not self.has_more_pages:
+            raise AssertionError("fetch_next_page() called with no further pages")
+        self._index += 1
+
+    def __iter__(self):
+        # The sync path iterates the ResultSet, which transparently spans pages.
+        for page in self._pages:
+            for row in page:
+                yield row
+
+
+class FakeResponseFuture:
+    """execute_async() result: materialises only the first page, like the driver."""
+
+    def __init__(self, first_page):
+        self._first_page = list(first_page)
+
+    def add_callbacks(self, on_result, on_error):
+        on_result(self._first_page)
+
+
+class RecordingBatch:
+    """Records (statement, params) instead of validating driver statement types."""
+
+    instances = []
+
+    def __init__(self, *args, **kwargs):
+        self.added = []
+        RecordingBatch.instances.append(self)
+
+    def add(self, statement, parameters=None):
+        self.added.append((statement, parameters))
+
+
+def _session_serving(pages):
+    session = MagicMock()
+    # Each prepare() must yield a DISTINCT statement, otherwise every prepared
+    # statement is the same MagicMock and the assertions cannot tell the
+    # entity-partition deletes apart from the collection-row deletes.
+    session.prepare.side_effect = lambda *a, **k: MagicMock(name='prepared')
+    session.execute.return_value = FakePagedResultSet(pages)
+    session.execute_async.side_effect = (
+        lambda *a, **k: FakeResponseFuture(pages[0] if pages else [])
+    )
+    return session
+
+
+@pytest.fixture
+def make_kg():
+    from trustgraph.direct.cassandra_kg import EntityCentricKnowledgeGraph
+
+    def _build(pages):
+        with patch('trustgraph.direct.cassandra_kg.Cluster') as cluster_cls:
+            session = _session_serving(pages)
+            cluster = MagicMock()
+            cluster.connect.return_value = session
+            cluster_cls.return_value = cluster
+            graph = EntityCentricKnowledgeGraph(hosts=['localhost'], keyspace='ks')
+            # Re-arm after schema creation consumed the result set.
+            session.execute.return_value = FakePagedResultSet(pages)
+            return graph, session
+
+    return _build
+
+
+def _row_deletes(graph):
+    return [
+        params
+        for batch in RecordingBatch.instances
+        for stmt, params in batch.added
+        if stmt is graph.delete_collection_row_stmt
+    ]
+
+
+async def test_async_delete_collection_deletes_every_page(make_kg):
+    """#1066: every page of the quad manifest must be deleted, not just the first."""
+    graph, session = make_kg(PAGES)
+
+    RecordingBatch.instances = []
+    with patch('trustgraph.direct.cassandra_kg.BatchStatement', RecordingBatch):
+        await graph.async_delete_collection('c1')
+
+    deletes = _row_deletes(graph)
+    assert len(deletes) == TOTAL_QUADS, (
+        f"deleted {len(deletes)} of {TOTAL_QUADS} quads — rows beyond the first page "
+        f"were left behind (issue #1066)"
+    )
+    assert {p[2] for p in deletes} == {f's{i}' for i in range(1, 7)}
+
+
+async def test_async_delete_collection_drains_the_result_set(make_kg):
+    """The scan must reach the final page, so no rows are silently left behind."""
+    graph, session = make_kg(PAGES)
+    RecordingBatch.instances = []
+    with patch('trustgraph.direct.cassandra_kg.BatchStatement', RecordingBatch):
+        await graph.async_delete_collection('c1')
+
+    assert session.execute.return_value.has_more_pages is False, \
+        "result set was not drained to the last page"
+
+
+async def test_async_delete_collection_single_page_unchanged(make_kg):
+    """A collection that fits in one page behaves exactly as before the fix."""
+    graph, session = make_kg([PAGES[0]])
+    RecordingBatch.instances = []
+    with patch('trustgraph.direct.cassandra_kg.BatchStatement', RecordingBatch):
+        await graph.async_delete_collection('c1')
+
+    assert len(_row_deletes(graph)) == 2
+
+
+def test_sync_delete_collection_spans_pages(make_kg):
+    """The sync path was already correct; pinned so the two paths stay symmetric."""
+    graph, session = make_kg(PAGES)
+    RecordingBatch.instances = []
+    with patch('trustgraph.direct.cassandra_kg.BatchStatement', RecordingBatch):
+        graph.delete_collection('c1')
+
+    assert len(_row_deletes(graph)) == TOTAL_QUADS

--- a/tests/unit/test_storage/test_rows_cassandra_delete_pagination.py
+++ b/tests/unit/test_storage/test_rows_cassandra_delete_pagination.py
@@ -1,0 +1,149 @@
+"""Pagination regression tests for the Cassandra row-storage delete paths.
+
+Same defect class as issue #1066, found while auditing the other `async_execute` callers
+as that issue suggests. `delete_collection` and `delete_collection_schema` discover the
+partitions to delete with `async_execute`, which materialises only the FIRST result page.
+Both then delete the `row_partitions` manifest rows for the collection — so a truncated
+discovery does not merely leave rows behind, it removes the index that would let anything
+find them again.
+
+Method-binding onto a MagicMock follows the existing style in
+tests/unit/test_storage/test_rows_cassandra_storage.py, which avoids standing up the whole
+flow-processor framework. No production function is patched: the fake session models both
+halves of the driver contract, so a reverted fix genuinely fails these tests.
+"""
+
+import asyncio
+import pytest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from trustgraph.storage.rows.cassandra.write import Processor
+
+
+def _partition(i):
+    return SimpleNamespace(schema_name=f'schema{i}', index_name=f'index{i}')
+
+
+# Three pages of partitions; a truncating discovery sees only the first two.
+PAGES = [
+    [_partition(1), _partition(2)],
+    [_partition(3), _partition(4)],
+    [_partition(5), _partition(6)],
+]
+TOTAL_PARTITIONS = sum(len(p) for p in PAGES)
+
+
+class FakePagedResultSet:
+    def __init__(self, pages):
+        self._pages = [list(p) for p in pages]
+        self._index = 0
+
+    @property
+    def current_rows(self):
+        return self._pages[self._index]
+
+    @property
+    def has_more_pages(self):
+        return self._index < len(self._pages) - 1
+
+    def fetch_next_page(self):
+        if not self.has_more_pages:
+            raise AssertionError("fetch_next_page() with no further pages")
+        self._index += 1
+
+    def __iter__(self):
+        for page in self._pages:
+            for row in page:
+                yield row
+
+
+class FakeResponseFuture:
+    """execute_async(): materialises only the first page, like the driver."""
+
+    def __init__(self, first_page):
+        self._first_page = list(first_page)
+
+    def add_callbacks(self, on_result, on_error):
+        on_result(self._first_page)
+
+
+def _processor(pages):
+    """A MagicMock processor with the real delete methods bound onto it."""
+    session = MagicMock()
+    session.execute.return_value = FakePagedResultSet(pages)
+    session.execute_async.side_effect = (
+        lambda *a, **k: FakeResponseFuture(pages[0] if pages else [])
+    )
+
+    proc = MagicMock()
+    proc.session = session
+    proc.known_keyspaces = {'ws'}          # skip the keyspace-existence probe
+    proc._setup_lock = asyncio.Lock()
+    proc.connect_cassandra = lambda: None
+    proc.sanitize_name = Processor.sanitize_name.__get__(proc, Processor)
+    proc.delete_collection = Processor.delete_collection.__get__(proc, Processor)
+    proc.delete_collection_schema = (
+        Processor.delete_collection_schema.__get__(proc, Processor)
+    )
+    return proc, session
+
+
+def _deleted_index_names(session):
+    """index_name values passed to the per-partition row deletes."""
+    names = []
+    for call in session.execute_async.call_args_list:
+        args = call.args
+        if len(args) >= 2 and isinstance(args[1], (tuple, list)):
+            params = args[1]
+            if len(params) == 3:
+                names.append(params[2])
+    return names
+
+
+async def test_delete_collection_deletes_partitions_from_every_page():
+    """#1066 class: all discovered partitions must be deleted, not just the first page."""
+    proc, session = _processor(PAGES)
+
+    await proc.delete_collection('ws', 'c1')
+
+    deleted = _deleted_index_names(session)
+    assert len(deleted) == TOTAL_PARTITIONS, (
+        f"deleted {len(deleted)} of {TOTAL_PARTITIONS} partitions — partitions beyond "
+        f"the first page were left behind, and the row_partitions manifest is removed "
+        f"afterwards, so they become unreachable"
+    )
+    assert set(deleted) == {f'index{i}' for i in range(1, 7)}
+
+
+async def test_delete_collection_drains_the_result_set():
+    proc, session = _processor(PAGES)
+    await proc.delete_collection('ws', 'c1')
+    assert session.execute.return_value.has_more_pages is False, \
+        "partition discovery did not reach the last page"
+
+
+async def test_delete_collection_single_page_unchanged():
+    """A collection whose partitions fit in one page behaves as before."""
+    proc, session = _processor([PAGES[0]])
+    await proc.delete_collection('ws', 'c1')
+    assert len(_deleted_index_names(session)) == 2
+
+
+async def test_delete_collection_schema_deletes_partitions_from_every_page():
+    """Same defect in the per-schema delete path."""
+    proc, session = _processor(PAGES)
+
+    await proc.delete_collection_schema('ws', 'c1', 'schema1')
+
+    deleted = _deleted_index_names(session)
+    assert len(deleted) == TOTAL_PARTITIONS, (
+        f"deleted {len(deleted)} of {TOTAL_PARTITIONS} partitions in "
+        f"delete_collection_schema"
+    )
+
+
+async def test_delete_collection_schema_drains_the_result_set():
+    proc, session = _processor(PAGES)
+    await proc.delete_collection_schema('ws', 'c1', 'schema1')
+    assert session.execute.return_value.has_more_pages is False

--- a/trustgraph-flow/trustgraph/direct/cassandra_kg.py
+++ b/trustgraph-flow/trustgraph/direct/cassandra_kg.py
@@ -8,7 +8,7 @@ from cassandra.auth import PlainTextAuthProvider
 from cassandra.query import BatchStatement, SimpleStatement
 import ssl
 
-from ..tables.cassandra_async import async_execute
+from ..tables.cassandra_async import async_execute, async_scan
 
 # Global list to track clusters for cleanup
 _active_clusters = []
@@ -1217,7 +1217,10 @@ class EntityCentricKnowledgeGraph:
         logger.info(f"Created collection metadata for {collection}")
 
     async def async_delete_collection(self, collection):
-        rows = await async_execute(
+        # This enumerates every quad in the collection, so it must page.
+        # async_execute materialises only the first result page, which silently
+        # left ~78% of a 23k-quad collection behind while reporting success.
+        rows = await async_scan(
             self.session,
             f"SELECT d, s, p, o, otype, dtype, lang FROM {self.collection_table} WHERE collection = %s",
             (collection,)

--- a/trustgraph-flow/trustgraph/storage/rows/cassandra/write.py
+++ b/trustgraph-flow/trustgraph/storage/rows/cassandra/write.py
@@ -30,7 +30,7 @@ from .... schema import RowSchema, Field
 from .... base import FlowProcessor, ConsumerSpec
 from .... base import CollectionConfigHandler
 from .... base.cassandra_config import add_cassandra_args, resolve_cassandra_config
-from .... tables.cassandra_async import async_execute
+from .... tables.cassandra_async import async_execute, async_scan
 
 # Module logger
 logger = logging.getLogger(__name__)
@@ -515,7 +515,10 @@ class Processor(CollectionConfigHandler, FlowProcessor):
         """
 
         try:
-            partition_list = await async_execute(
+            # Pages: this enumerates every partition for the collection, and the
+            # row_partitions manifest is deleted below — so a truncated read would
+            # orphan the surviving rows with no index left to find them by.
+            partition_list = await async_scan(
                 self.session, select_partitions_cql, (collection,)
             )
         except Exception as e:
@@ -583,7 +586,8 @@ class Processor(CollectionConfigHandler, FlowProcessor):
         """
 
         try:
-            partition_list = await async_execute(
+            # Pages, for the same reason as delete_collection above.
+            partition_list = await async_scan(
                 self.session, select_partitions_cql, (collection, schema_name)
             )
         except Exception as e:


### PR DESCRIPTION
Fixes #1066.

## Summary

`async_execute` materialises only the first result page. Three delete paths used it to enumerate everything they were about to remove, so a collection larger than `fetch_size` (5000) was only partly deleted while the operation logged success:

| File | Function |
|---|---|
| `trustgraph-flow/trustgraph/direct/cassandra_kg.py` | `async_delete_collection` ← reported in #1066 |
| `trustgraph-flow/trustgraph/storage/rows/cassandra/write.py` | `delete_collection` |
| `trustgraph-flow/trustgraph/storage/rows/cassandra/write.py` | `delete_collection_schema` |

All three now use `async_scan`, which iterates every page and discards each page as it goes, so peak memory stays bounded by `fetch_size` rather than by the size of the collection.

**Why `async_scan` and not `async_execute_paged`** (the issue suggested the latter): `async_scan` returns a *flat* list, so it is a drop-in for `async_execute` and none of the iteration code below the call sites had to change. `async_execute_paged` returns a list of pages, which would need flattening at each site and holds every page at once. Both were already present and used elsewhere in the tree; neither is new here.

## The two extra sites

@zsoltboko's report ends with "Worth auditing the other `async_execute` callers for the same unbounded-scan pattern", so I did. The two row-storage sites are the same defect, and they are arguably worse than the reported one: both delete the `row_partitions` manifest rows for the collection *after* the truncated discovery, so the surviving rows do not merely persist — they lose the index that would let anything find them again.

I swept all 87 `await async_execute(` call sites in the repo, resolving multi-line and variable-held SQL. Exactly four are unbounded `SELECT`s, three of which are the delete paths above. The fourth is `tables/config.py:116` `get_version`, which is `SELECT version FROM version WHERE id = …` — a single-row point lookup, correctly left alone. Every other caller carries an explicit `LIMIT`, is a point lookup, or is a write. So this should be the complete set.

## Test plan

Two new test modules, 9 tests, placed next to their subjects:

- `tests/unit/test_direct/test_entity_centric_delete_pagination.py` (4)
- `tests/unit/test_storage/test_rows_cassandra_delete_pagination.py` (5)

The harness models **both halves** of the driver contract instead of stubbing the helpers out, which is what makes the tests discriminating:

```
session.execute(stmt, params)     -> multi-page ResultSet   (what async_scan uses)
session.execute_async(q, params)  -> first page only, via callbacks
                                     (what async_execute uses, mirroring the driver)
```

No production function is patched, so reverting the fix genuinely fails these tests. The storage tests bind the real methods onto a `MagicMock` processor, following the existing style in `tests/unit/test_storage/test_rows_cassandra_storage.py`, which avoids standing up the whole flow-processor framework.

**Negative controls** — revert one source file, keep the tests:

| Reverted | Result |
|---|---|
| `cassandra_kg.py` only | **2 failed / 2 passed** |
| `write.py` only | **4 failed / 1 passed** |

In both cases the failures are exactly the paging assertions, while the *guard* tests pass unpatched — `..._single_page_unchanged` (a collection that fits in one page must behave as before) and `test_sync_delete_collection_spans_pages` (the sync path was already correct and stays pinned). That is the point of including them: they assert preserved behaviour, so they must not move.

**Full unit suite** (`pytest tests/unit`, Python 3.13.4):

| | Result |
|---|---|
| `master` @ `27e0ab8` | 1 failed, **3090 passed**, 51 skipped |
| this branch | 1 failed, **3099 passed**, 51 skipped |

`+9 passed` is exactly the tests added. The one failure is identical on both sides and unrelated: `tests/unit/test_cli/test_load_structured_data.py::TestLoadStructuredDataUnit::test_invalid_descriptor_format`.

## Limitations, stated plainly

- **Not reproduced against live Cassandra.** I have no Docker on this machine, so I verified at the driver boundary with the paging harness above rather than against a real multi-page result set. The reporter's `cqlsh` counts are the end-to-end evidence; a confirming run against a >5000-quad collection would be worth doing before release.
- **`tests/unit/test_decoding` was excluded from both runs** (3 collection errors, identical before and after). It needs `trustgraph-docling`, which I did not install because it pulls a torch stack. Nothing in this change is near the decoding path.
- I installed `trustgraph-base`, `-flow`, `-cli`, `-vertexai`, `-bedrock`, `-mcp` from source with plain `pip install .` as `pull-request.yaml` does, generating the `*_version.py` files with `VERSION=2.8.999`. `make` is unavailable on Windows so I replicated that Makefile target directly; no generated version file is in the diff.
- Base branch is `master`, matching the most recent external merges (#1053, #1051, #1044). Happy to retarget at a release branch if that is preferred for a data-loss fix.

I will sign the CLA when the bot prompts.
