### PR TITLE
Add gateway passthrough mechanism for enterprise services

### DIFF
--- a/trustgraph-base/trustgraph/schema/services/__init__.py
+++ b/trustgraph-base/trustgraph/schema/services/__init__.py
@@ -19,3 +19,4 @@ from .sparql_query import *
 from .reranker import *
 from .audit import *
 from .image_to_text import *
+from .passthrough import *

--- a/trustgraph-base/trustgraph/schema/services/passthrough.py
+++ b/trustgraph-base/trustgraph/schema/services/passthrough.py
@@ -1,0 +1,15 @@
+from dataclasses import dataclass, field
+
+from ..core.primitives import Error
+
+
+@dataclass
+class PassthroughRequest:
+    payload: dict = field(default_factory=dict)
+
+
+@dataclass
+class PassthroughResponse:
+    payload: dict = field(default_factory=dict)
+    error: Error | None = None
+    is_final: bool = True

--- a/trustgraph-flow/trustgraph/gateway/dispatch/manager.py
+++ b/trustgraph-flow/trustgraph/gateway/dispatch/manager.py
@@ -39,6 +39,7 @@ from . document_embeddings_query import DocumentEmbeddingsQueryRequestor
 from . row_embeddings_query import RowEmbeddingsQueryRequestor
 from . mcp_tool import McpToolRequestor
 from . reranker import RerankerRequestor
+from . passthrough import PassthroughRequestor
 from . text_load import TextLoad
 from . document_load import DocumentLoad
 
@@ -458,6 +459,16 @@ class DispatcherManager:
 
                     if kind in request_response_dispatchers:
                         dispatcher = request_response_dispatchers[kind](
+                            backend = self.backend,
+                            request_queue = qconfig["request"],
+                            response_queue = qconfig["response"],
+                            timeout = self.timeout,
+                            consumer = f"{self.prefix}-{workspace}-{flow}-{kind}-request",
+                            subscriber = f"{self.prefix}-{workspace}-{flow}-{kind}-request",
+                        )
+                        dispatcher.service_kind = kind
+                    elif kind.startswith("thru/"):
+                        dispatcher = PassthroughRequestor(
                             backend = self.backend,
                             request_queue = qconfig["request"],
                             response_queue = qconfig["response"],

--- a/trustgraph-flow/trustgraph/gateway/dispatch/passthrough.py
+++ b/trustgraph-flow/trustgraph/gateway/dispatch/passthrough.py
@@ -1,0 +1,27 @@
+from ... schema import PassthroughRequest, PassthroughResponse
+
+from . requestor import ServiceRequestor
+
+
+class PassthroughRequestor(ServiceRequestor):
+    def __init__(
+            self, backend, request_queue, response_queue, timeout,
+            consumer, subscriber,
+    ):
+
+        super(PassthroughRequestor, self).__init__(
+            backend=backend,
+            request_queue=request_queue,
+            response_queue=response_queue,
+            request_schema=PassthroughRequest,
+            response_schema=PassthroughResponse,
+            subscription=subscriber,
+            consumer_name=consumer,
+            timeout=timeout,
+        )
+
+    def to_request(self, body):
+        return PassthroughRequest(payload=body)
+
+    def from_response(self, message):
+        return message.payload, message.is_final

--- a/trustgraph-flow/trustgraph/gateway/endpoint/manager.py
+++ b/trustgraph-flow/trustgraph/gateway/endpoint/manager.py
@@ -243,6 +243,16 @@ class EndpointManager:
                 in_band_auth=True,
             ),
 
+            # Per-flow passthrough services — must be registered
+            # before the general service route so aiohttp matches
+            # the more specific thru/ prefix first.
+            _RoutedVariableEndpoint(
+                endpoint_path="/api/v1/flow/{flow}/service/{kind:thru/.+}",
+                auth=auth,
+                dispatcher=dispatcher_manager.dispatch_flow_service(),
+                registry_prefix="flow-service",
+            ),
+
             # Per-flow request/response services — gated per
             # ``flow-service:<kind>`` registry entry.
             _RoutedVariableEndpoint(

--- a/trustgraph-flow/trustgraph/gateway/registry.py
+++ b/trustgraph-flow/trustgraph/gateway/registry.py
@@ -119,7 +119,24 @@ def register(op: Operation) -> None:
 
 
 def lookup(name: str) -> Operation | None:
-    return _REGISTRY.get(name)
+    op = _REGISTRY.get(name)
+    if op is not None:
+        return op
+
+    # Passthrough flow services: flow-service:thru/<anything> is
+    # allowed for any authenticated caller with flow-level access.
+    # The gateway forwards the payload without interpretation; the
+    # downstream service handles its own authorisation.
+    if name.startswith("flow-service:thru/"):
+        return Operation(
+            name=name,
+            capability=AUTHENTICATED,
+            resource_level=ResourceLevel.FLOW,
+            extract_resource=_flow_from_match_info,
+            extract_parameters=_no_parameters,
+        )
+
+    return None
 
 
 def all_operations() -> list[Operation]:


### PR DESCRIPTION
## Summary

- Adds a generic `thru/` prefix passthrough path through the API gateway, allowing enterprise services (e.g. attestation engine) to communicate through the gateway without requiring core to know about them
- New `PassthroughRequest`/`PassthroughResponse` schema types with opaque JSON payload forwarding
- Dynamic registry lookup for `flow-service:thru/*` names so WebSocket mux and HTTP routes resolve without static registration

## Changes

- `trustgraph-base`: `PassthroughRequest`/`PassthroughResponse` dataclasses in schema services
- `trustgraph-flow`: `PassthroughRequestor` ServiceRequestor subclass, aiohttp route for `/api/v1/flow/{flow}/service/thru/{kind}`, dispatch manager branch for `thru/` kinds, dynamic registry lookup for passthrough operations

## Test plan

- [x] Verify existing gateway routes still work (no regression from route ordering)
- [x] Send a passthrough request to `thru/test-service` and confirm it reaches Pulsar queues
- [x] Verify WebSocket mux resolves `thru/` kinds with AUTHENTICATED flow-level access
- [x] Confirm non-thru service routes are unaffected
