### PR TITLE
Fix vertexai container build: replace google-cloud-aiplatform with google-genai

### DIFF
--- a/containers/Containerfile.vertexai
+++ b/containers/Containerfile.vertexai
@@ -14,7 +14,7 @@ RUN dnf install -y python3.13 && \
   pip3 install --no-cache-dir --upgrade 'pip>=26.0' 'setuptools>=78.1.1' && \
   pip3 install --no-cache-dir build wheel aiohttp && \
   pip3 install --no-cache-dir pulsar-client==3.11.0 && \
-  pip3 install --no-cache-dir google-cloud-aiplatform && \
+  pip3 install --no-cache-dir google-genai google-api-core && \
   dnf clean all
 
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Replace `google-cloud-aiplatform` with `google-genai` and `google-api-core` in `Containerfile.vertexai` to match the actual `pyproject.toml` dependencies
- Fixes broken container builds caused by `google-cloud-aiplatform==1.163.0` shipping a `.pth` file targeting Python 3.12 namespaces, which prevents pip from running under Python 3.13

## Test plan

- [x] Verify vertexai container builds successfully on both amd64 and arm64
- [x] Verify `text-completion-vertexai` and `text-completion-googleaistudio` entry points start