### PR TITLE
Update MCP SDK imports for v2 compatibility

### DIFF
--- a/trustgraph-flow/trustgraph/agent/mcp_tool/service.py
+++ b/trustgraph-flow/trustgraph/agent/mcp_tool/service.py
@@ -6,7 +6,7 @@ name + parameters, output is the response, either a string or an object.
 
 import json
 import logging
-from mcp.client.streamable_http import streamablehttp_client
+from mcp.client.streamable_http import streamable_http_client
 from mcp import ClientSession
 
 from ... base import ToolService
@@ -75,7 +75,7 @@ class Service(ToolService):
             logger.info(f"Invoking {remote_name} at {url}")
 
             # Connect to a streamable HTTP server with headers
-            async with streamablehttp_client(url, headers=headers) as (
+            async with streamable_http_client(url, headers=headers) as (
                     read_stream,
                     write_stream,
                     _,
@@ -93,8 +93,8 @@ class Service(ToolService):
                         parameters
                     )
 
-                    if result.structuredContent:
-                        return result.structuredContent
+                    if result.structured_content:
+                        return result.structured_content
                     elif hasattr(result, "content"):
                             return "".join([
                                 x.text

--- a/trustgraph-mcp/trustgraph/mcp_server/mcp.py
+++ b/trustgraph-mcp/trustgraph/mcp_server/mcp.py
@@ -12,7 +12,8 @@ from dataclasses import dataclass, field
 from collections.abc import AsyncIterator
 from functools import partial
 
-from mcp.server.fastmcp import FastMCP, Context
+from mcp.server import MCPServer
+from mcp.server.mcpserver.server import Context
 from mcp.server.auth.provider import AccessToken, TokenVerifier
 from mcp.server.auth.middleware.auth_context import get_access_token
 
@@ -95,7 +96,7 @@ class AppContext:
 
 @asynccontextmanager
 async def app_lifespan(
-    server: FastMCP,
+    server: MCPServer,
     websocket_url: str = "ws://api-gateway:8888/api/v1/socket",
 ) -> AsyncIterator[AppContext]:
     """Manage per-server state: the pool of per-caller WebSocket
@@ -351,11 +352,9 @@ class McpServer:
             resource_server_url=auth_resource_url or f"http://{host}:{port}",
         )
 
-        self.mcp = FastMCP(
+        self.mcp = MCPServer(
             "TrustGraph",
             dependencies=["trustgraph-base"],
-            host=self.host,
-            port=self.port,
             lifespan=lifespan_with_url,
             token_verifier=PassthroughTokenVerifier(),
             auth=auth_settings,
@@ -398,7 +397,11 @@ class McpServer:
 
     def run(self):
         """Run the MCP server"""
-        self.mcp.run(transport="streamable-http")
+        self.mcp.run(
+            transport="streamable-http",
+            host=self.host,
+            port=self.port,
+        )
 
     async def _get_manager(self, ctx):
         """Get an authenticated WebSocket manager for the current caller.


### PR DESCRIPTION
## Summary

- Update `trustgraph-mcp` and `trustgraph-flow` for MCP Python SDK v2 breaking changes
- `FastMCP` → `MCPServer`, `Context` import path updated, `host`/`port` moved to `run()`
- `streamablehttp_client` → `streamable_http_client`, `structuredContent` → `structured_content`

## Test plan

- [ ] `mcp-server` starts successfully with `mcp==2.0.0`
- [ ] MCP tool invocation works end-to-end through `mcp-tool` service
- [ ] Container builds for both `Containerfile.mcp` and `Containerfile.flow`