### PR TITLE
Fix passthrough routing, RequestResponseSpec regression, and add SparqlClientSpec

### DIFF
--- a/trustgraph-base/trustgraph/base/__init__.py
+++ b/trustgraph-base/trustgraph/base/__init__.py
@@ -28,6 +28,7 @@ from . graph_embeddings_query_service import GraphEmbeddingsQueryService
 from . document_embeddings_query_service import DocumentEmbeddingsQueryService
 from . graph_embeddings_client import GraphEmbeddingsClientSpec
 from . triples_client import TriplesClientSpec
+from . sparql_client import SparqlClientSpec
 from . document_embeddings_client import DocumentEmbeddingsClientSpec
 from . agent_service import AgentService
 from . graph_rag_client import GraphRagClientSpec

--- a/trustgraph-base/trustgraph/base/request_response_spec.py
+++ b/trustgraph-base/trustgraph/base/request_response_spec.py
@@ -53,7 +53,9 @@ def _make_impl_wrapper(rr_client, impl_cls):
     """Create a domain-specific wrapper that delegates request() to the
     RequestResponseClient while inheriting business methods from impl_cls."""
 
-    class Wrapper(impl_cls):
+    bases = (impl_cls,) if impl_cls is not None else ()
+
+    class Wrapper(*bases):
         def __init__(self):
             self._rr_client = rr_client
 

--- a/trustgraph-base/trustgraph/base/sparql_client.py
+++ b/trustgraph-base/trustgraph/base/sparql_client.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from . request_response_spec import RequestResponseSpec
+from .. schema import SparqlQueryRequest, SparqlQueryResponse
+
+
+class SparqlClient:
+
+    async def query(self, query, collection="default", limit=10000,
+                    timeout=300):
+        resp = await self.request(
+            SparqlQueryRequest(
+                query=query,
+                collection=collection,
+                limit=limit,
+            ),
+            timeout=timeout,
+        )
+
+        if resp.error:
+            raise RuntimeError(resp.error.message)
+
+        return resp
+
+
+class SparqlClientSpec(RequestResponseSpec):
+    def __init__(
+            self, request_name, response_name,
+    ):
+        super(SparqlClientSpec, self).__init__(
+            request_name=request_name,
+            request_schema=SparqlQueryRequest,
+            response_name=response_name,
+            response_schema=SparqlQueryResponse,
+            impl=SparqlClient,
+        )

--- a/trustgraph-flow/trustgraph/gateway/dispatch/manager.py
+++ b/trustgraph-flow/trustgraph/gateway/dispatch/manager.py
@@ -452,10 +452,12 @@ class DispatcherManager:
                 if key not in self.dispatchers:
                     intf_defs = self.flows[flow_key]["interfaces"]
 
-                    if kind not in intf_defs:
+                    intf_kind = kind.removeprefix("thru/")
+
+                    if intf_kind not in intf_defs:
                         raise RuntimeError("This kind not supported by flow")
 
-                    qconfig = intf_defs[kind]
+                    qconfig = intf_defs[intf_kind]
 
                     if kind in request_response_dispatchers:
                         dispatcher = request_response_dispatchers[kind](


### PR DESCRIPTION
## Summary
- Strip `thru/` prefix when looking up flow interfaces so passthrough services use their real service name in flow config (e.g. `attestation-engine` not `thru/attestation-engine`)
- Fix `TypeError: NoneType takes no arguments` in `_make_impl_wrapper` when `impl` is `None` — regression from metrics refactor #1075 affecting `structured-query` and any `RequestResponseSpec` without an impl class
- Add `SparqlClientSpec` with a `query()` convenience method, following the same pattern as `TriplesClientSpec` and `GraphRagClientSpec`

## Test plan
- [x] Verify passthrough services (e.g. `thru/attestation-engine`) resolve correctly via gateway websocket
- [x] Verify `structured-query` starts without `NoneType takes no arguments` error
- [x] Verify `SparqlClientSpec` can be used by downstream services
