### PR TITLE
Pin nltk>=3.10.2 to fix inisec.py import crash

### DIFF
--- a/trustgraph-flow/pyproject.toml
+++ b/trustgraph-flow/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "minio",
     "mistralai<2.0.0",
     "neo4j",
-    "nltk",
+    "nltk>=3.10.2",
     "ollama",
     "openai",
     "pinecone[grpc]",


### PR DESCRIPTION
## Summary

- NLTK 3.10.1 added `inisec.py`, a meta-path import hook that blocks stdlib imports when CWD is on `sys.path`. With `WORKDIR /` in the container, `Path.relative_to(Path("/"))` succeeds for every path, so the hook blocks `xml.etree` and crashes `kg-extract-ontology` on startup.
- Pin `nltk>=3.10.2` which removed `inisec.py` (released 5 days ago).

## Test plan

- [ ] Rebuild flow container and verify `kg-extract-ontology` starts without `ImportError`
