### PR TITLE
Truncate reranker input text to prevent timeout

### DIFF
--- a/trustgraph-flow/trustgraph/retrieval/graph_rag/graph_rag.py
+++ b/trustgraph-flow/trustgraph/retrieval/graph_rag/graph_rag.py
@@ -138,6 +138,7 @@ class Query:
             self, rag, collection, verbose,
             entity_limit=50, triple_limit=30, max_subgraph_size=1000,
             max_path_length=2, edge_limit=25, max_reranker_input=350,
+            max_reranker_text_length=240,
             track_usage=None,
     ):
         self.rag = rag
@@ -149,6 +150,7 @@ class Query:
         self.max_path_length = max_path_length
         self.edge_limit = edge_limit
         self.max_reranker_input = max_reranker_input
+        self.max_reranker_text_length = max_reranker_text_length
         self.track_usage = track_usage
 
     async def extract_concepts(self, query):
@@ -431,6 +433,9 @@ class Query:
                         continue
                     text = f"{ls} {lo}"
 
+                if len(text) > self.max_reranker_text_length:
+                    text = text[:self.max_reranker_text_length]
+
                 idx = len(filtered_triples)
                 filtered_triples.append((s, p, o))
                 labeled_hop.append((ls, lp, lo))
@@ -641,6 +646,7 @@ class GraphRag:
             self, query, collection = "default",
             entity_limit = 50, triple_limit = 30, max_subgraph_size = 1000,
             max_path_length = 2, edge_limit = 25, max_reranker_input = 350,
+            max_reranker_text_length = 240,
             streaming = False,
             chunk_callback = None,
             explain_callback = None, save_answer_callback = None,
@@ -695,6 +701,7 @@ class GraphRag:
             max_path_length = max_path_length,
             edge_limit = edge_limit,
             max_reranker_input = max_reranker_input,
+            max_reranker_text_length = max_reranker_text_length,
             track_usage = track_usage,
         )
 

--- a/trustgraph-flow/trustgraph/retrieval/graph_rag/rag.py
+++ b/trustgraph-flow/trustgraph/retrieval/graph_rag/rag.py
@@ -38,6 +38,9 @@ class Processor(FlowProcessor):
         max_path_length = params.get("max_path_length", 2)
         edge_limit = params.get("edge_limit", 25)
         max_reranker_input = params.get("max_reranker_input", 350)
+        max_reranker_text_length = params.get(
+            "max_reranker_text_length", 240
+        )
 
         super(Processor, self).__init__(
             **params | {
@@ -49,6 +52,7 @@ class Processor(FlowProcessor):
                 "max_path_length": max_path_length,
                 "edge_limit": edge_limit,
                 "max_reranker_input": max_reranker_input,
+                "max_reranker_text_length": max_reranker_text_length,
             }
         )
 
@@ -58,6 +62,7 @@ class Processor(FlowProcessor):
         self.default_max_path_length = max_path_length
         self.default_edge_limit = edge_limit
         self.default_max_reranker_input = max_reranker_input
+        self.default_max_reranker_text_length = max_reranker_text_length
 
         # Workspace isolation is enforced by the flow layer (flow.workspace).
         # Per-request caching (see GraphRag) keeps within-request state
@@ -239,6 +244,7 @@ class Processor(FlowProcessor):
                     max_path_length = max_path_length,
                     edge_limit = edge_limit,
                     max_reranker_input = max_reranker_input,
+                    max_reranker_text_length = self.default_max_reranker_text_length,
                     streaming = True,
                     chunk_callback = send_chunk,
                     explain_callback = send_explainability,
@@ -255,6 +261,7 @@ class Processor(FlowProcessor):
                     max_path_length = max_path_length,
                     edge_limit = edge_limit,
                     max_reranker_input = max_reranker_input,
+                    max_reranker_text_length = self.default_max_reranker_text_length,
                     explain_callback = send_explainability,
                     save_answer_callback = save_answer,
                     parent_uri = v.parent_uri,
@@ -357,6 +364,13 @@ class Processor(FlowProcessor):
             type=int,
             default=350,
             help=f'Max candidate edges sent to the reranker per hop (default: 350)'
+        )
+
+        parser.add_argument(
+            '--max-reranker-text-length',
+            type=int,
+            default=240,
+            help=f'Max character length of text sent to the reranker per edge (default: 240)'
         )
 
         # Note: Explainability triples are now stored in the request's collection


### PR DESCRIPTION
## Summary

- Long label text (5000+ chars) sent to the cross-encoder reranker causes it to hang, exceeding the 60s timeout and making GraphRAG appear to freeze on subsequent invocations.
- Added `max_reranker_text_length` parameter (default 240 chars) that truncates each document's text before scoring. Full labels are preserved for selected edges — only the reranker input is capped.
- Configurable via `--max-reranker-text-length` CLI arg.

## Test plan

- [x] Run GraphRAG query against a knowledge graph with long-text labels
- [x] Verify reranker completes within timeout
- [x] Verify selected edges still carry full (untruncated) labels in the response