### PR TITLE
Remove template-index; discover templates by key prefix

### DIFF
--- a/tests/integration/test_agent_kg_extraction_integration.py
+++ b/tests/integration/test_agent_kg_extraction_integration.py
@@ -104,7 +104,6 @@ class TestAgentKgExtractionIntegration:
         # Mock configuration
         config = {
             "system": json.dumps("You are a knowledge extraction agent."),
-            "template-index": json.dumps(["agent-kg-extract"]),
             "template.agent-kg-extract": json.dumps({
                 "prompt": "Extract entities and relationships from: {{ text }}",
                 "response-type": "json"

--- a/tests/integration/test_template_service_integration.py
+++ b/tests/integration/test_template_service_integration.py
@@ -22,7 +22,6 @@ class TestTemplateServiceSimple:
         """Sample configuration for testing"""
         return {
             "system": json.dumps("You are a helpful assistant."),
-            "template-index": json.dumps(["greeting", "json_test"]),
             "template.greeting": json.dumps({
                 "prompt": "Hello {{ name }}, welcome to {{ system_name }}!",
                 "response-type": "text"
@@ -142,7 +141,6 @@ class TestTemplateServiceSimple:
         # Test configuration with single prompt
         config = {
             "system": json.dumps("Test system"),
-            "template-index": json.dumps(["test"]),
             "template.test": json.dumps({
                 "prompt": "Test {{ value }}",
                 "response-type": "text"

--- a/tests/unit/test_knowledge_graph/test_agent_extraction.py
+++ b/tests/unit/test_knowledge_graph/test_agent_extraction.py
@@ -372,7 +372,6 @@ This is not JSON at all
         config = {
             "prompt": {
                 "system": json.dumps("Test system"),
-                "template-index": json.dumps(["agent-kg-extract"]),
                 "template.agent-kg-extract": json.dumps({
                     "prompt": "Extract knowledge from: {{ text }}",
                     "response-type": "json"

--- a/tests/unit/test_prompt_manager.py
+++ b/tests/unit/test_prompt_manager.py
@@ -21,7 +21,6 @@ class TestPromptManager:
         """Sample configuration dict for PromptManager"""
         return {
             "system": json.dumps("You are a helpful assistant."),
-            "template-index": json.dumps(["simple_text", "json_response", "complex_template"]),
             "template.simple_text": json.dumps({
                 "prompt": "Hello {{ name }}, welcome to {{ system_name }}!",
                 "response-type": "text"
@@ -88,7 +87,6 @@ class TestPromptManager:
         pm = PromptManager()
         config = {
             "system": json.dumps("Test"),
-            "template-index": json.dumps(["test"]),
             "template.test": json.dumps({
                 "prompt": "Value is: {{ value }}",
                 "response-type": "text"
@@ -254,7 +252,6 @@ class TestPromptManager:
         pm = PromptManager()
         config = {
             "system": json.dumps("Test"),
-            "template-index": json.dumps(["no_schema"]),
             "template.no_schema": json.dumps({
                 "prompt": "Generate any JSON",
                 "response-type": "json"
@@ -291,7 +288,6 @@ class TestPromptManager:
         pm = PromptManager()
         config = {
             "system": json.dumps("Test"),
-            "template-index": json.dumps(["nested"]),
             "template.nested": json.dumps({
                 "prompt": "{{ greeting }} from {{ company }} in {{ year }}!",
                 "response-type": "text"
@@ -362,7 +358,6 @@ class TestPromptManager:
         pm = PromptManager()
         config = {
             "system": json.dumps("Test"),
-            "template-index": json.dumps(["json_response"]),
             "template.json_response": json.dumps({
                 "prompt": "Generate JSON",
                 "response-type": "json"
@@ -390,7 +385,6 @@ class TestPromptManagerJsonl:
         """Configuration with JSONL response type prompts"""
         return {
             "system": json.dumps("You are an extraction assistant."),
-            "template-index": json.dumps(["extract_simple", "extract_with_schema", "extract_mixed"]),
             "template.extract_simple": json.dumps({
                 "prompt": "Extract entities from: {{ text }}",
                 "response-type": "jsonl"

--- a/tests/unit/test_prompt_manager_edge_cases.py
+++ b/tests/unit/test_prompt_manager_edge_cases.py
@@ -23,7 +23,6 @@ class TestPromptManagerEdgeCases:
         pm = PromptManager()
         config = {
             "system": json.dumps("Test"),
-            "template-index": json.dumps(["large_json"]),
             "template.large_json": json.dumps({
                 "prompt": "Generate large dataset",
                 "response-type": "json"
@@ -60,7 +59,6 @@ class TestPromptManagerEdgeCases:
         pm = PromptManager()
         config = {
             "system": json.dumps("Test"),
-            "template-index": json.dumps(["unicode"]),
             "template.unicode": json.dumps({
                 "prompt": "Process text: {{ text }}",
                 "response-type": "text"
@@ -85,7 +83,6 @@ class TestPromptManagerEdgeCases:
         pm = PromptManager()
         config = {
             "system": json.dumps("Test"),
-            "template-index": json.dumps(["text_with_json"]),
             "template.text_with_json": json.dumps({
                 "prompt": "Explain this data",
                 "response-type": "text"  # Text response, not JSON
@@ -116,7 +113,6 @@ class TestPromptManagerEdgeCases:
         pm = PromptManager()
         config = {
             "system": json.dumps("Test"),
-            "template-index": json.dumps(["multi_json"]),
             "template.multi_json": json.dumps({
                 "prompt": "Generate examples",
                 "response-type": "json"
@@ -148,7 +144,6 @@ class TestPromptManagerEdgeCases:
         pm = PromptManager()
         config = {
             "system": json.dumps("Test"),
-            "template-index": json.dumps(["json_comments"]),
             "template.json_comments": json.dumps({
                 "prompt": "Generate config",
                 "response-type": "json"
@@ -178,7 +173,6 @@ class TestPromptManagerEdgeCases:
         pm = PromptManager()
         config = {
             "system": json.dumps("Test"),
-            "template-index": json.dumps(["basic_template"]),
             "template.basic_template": json.dumps({
                 "prompt": """
                     Normal: {{ variable }}
@@ -203,7 +197,6 @@ class TestPromptManagerEdgeCases:
         pm = PromptManager()
         config = {
             "system": json.dumps("Test"),
-            "template-index": json.dumps(["empty_json"]),
             "template.empty_json": json.dumps({
                 "prompt": "Generate empty data",
                 "response-type": "json"
@@ -233,7 +226,6 @@ class TestPromptManagerEdgeCases:
         pm = PromptManager()
         config = {
             "system": json.dumps("Test"),
-            "template-index": json.dumps(["malformed"]),
             "template.malformed": json.dumps({
                 "prompt": "Generate data",
                 "response-type": "json"
@@ -255,7 +247,6 @@ class TestPromptManagerEdgeCases:
         pm = PromptManager()
         config = {
             "system": json.dumps("Test"),
-            "template-index": json.dumps(["recursive"]),
             "template.recursive": json.dumps({
                 "prompt": "{{ recursive_var }}",
                 "response-type": "text"
@@ -282,7 +273,6 @@ class TestPromptManagerEdgeCases:
         pm = PromptManager()
         config = {
             "system": json.dumps("Test"),
-            "template-index": json.dumps(["long"]),
             "template.long": json.dumps({
                 "prompt": long_template,
                 "response-type": "text"
@@ -311,7 +301,6 @@ class TestPromptManagerEdgeCases:
         pm = PromptManager()
         config = {
             "system": json.dumps("Test"),
-            "template-index": json.dumps(["strict_schema"]),
             "template.strict_schema": json.dumps({
                 "prompt": "Generate user",
                 "response-type": "json",
@@ -343,7 +332,6 @@ class TestPromptManagerEdgeCases:
         pm = PromptManager()
         config = {
             "system": json.dumps("Test"),
-            "template-index": json.dumps(["timeout_test"]),
             "template.timeout_test": json.dumps({
                 "prompt": "Test prompt",
                 "response-type": "text"
@@ -362,7 +350,6 @@ class TestPromptManagerEdgeCases:
         pm = PromptManager()
         config = {
             "system": json.dumps("Test"),
-            "template-index": json.dumps(["filters"]),
             "template.filters": json.dumps({
                 "prompt": """
                     {% if items %}
@@ -400,7 +387,6 @@ class TestPromptManagerEdgeCases:
         pm = PromptManager()
         config = {
             "system": json.dumps("Test"),
-            "template-index": json.dumps(["concurrent"]),
             "template.concurrent": json.dumps({
                 "prompt": "User: {{ user }}",
                 "response-type": "text"

--- a/trustgraph-cli/trustgraph/cli/set_prompt.py
+++ b/trustgraph-cli/trustgraph/cli/set_prompt.py
@@ -4,7 +4,7 @@ Sets a prompt template.
 
 import argparse
 import os
-from trustgraph.api import Api, ConfigKey, ConfigValue
+from trustgraph.api import Api, ConfigValue
 import json
 import tabulate
 import textwrap
@@ -27,12 +27,6 @@ def set_prompt(url, id, prompt, response, schema, token=None, workspace="default
 
     api = Api(url, token=token, workspace=workspace).config()
 
-    values = api.get([
-        ConfigKey(type="prompt", key="template-index")
-    ])
-
-    ix = json.loads(values[0].value)
-
     object = {
         "id": id,
         "prompt": prompt,
@@ -46,13 +40,7 @@ def set_prompt(url, id, prompt, response, schema, token=None, workspace="default
     if schema:
         object["schema"] = schema
 
-    if id not in ix:
-        ix.append(id)
-
-    values = api.put([
-        ConfigValue(
-            type="prompt", key="template-index", value=json.dumps(ix)
-        ),
+    api.put([
         ConfigValue(
             type="prompt", key=f"template.{id}", value=json.dumps(object)
         )

--- a/trustgraph-cli/trustgraph/cli/set_token_costs.py
+++ b/trustgraph-cli/trustgraph/cli/set_token_costs.py
@@ -4,7 +4,7 @@ Sets a model's token costs.
 
 import argparse
 import os
-from trustgraph.api import Api, ConfigKey, ConfigValue
+from trustgraph.api import Api, ConfigValue
 import json
 import tabulate
 import textwrap
@@ -31,12 +31,6 @@ def set_prompt(url, id, prompt, response, schema, workspace="default"):
 
     api = Api(url, workspace=workspace)
 
-    values = api.config_get([
-        ConfigKey(type="prompt", key="template-index")
-    ])
-
-    ix = json.loads(values[0].value)
-
     object = {
         "id": id,
         "prompt": prompt,
@@ -50,13 +44,7 @@ def set_prompt(url, id, prompt, response, schema, workspace="default"):
     if schema:
         object["schema"] = schema
 
-    if id not in ix:
-        ix.append(id)
-
-    values = api.config_put([
-        ConfigValue(
-            type="prompt", key="template-index", value=json.dumps(ix)
-        ),
+    api.config_put([
         ConfigValue(
             type="prompt", key=f"template.{id}", value=json.dumps(object)
         )

--- a/trustgraph-cli/trustgraph/cli/show_prompts.py
+++ b/trustgraph-cli/trustgraph/cli/show_prompts.py
@@ -17,17 +17,21 @@ def show_config(url, token=None, workspace="default"):
 
     api = Api(url, token=token, workspace=workspace).config()
 
-    values = api.get([
+    system_values = api.get([
         ConfigKey(type="prompt", key="system"),
-        ConfigKey(type="prompt", key="template-index")
     ])
 
-    system = json.loads(values[0].value)
-    ix = json.loads(values[1].value)
+    system = json.loads(system_values[0].value)
+
+    all_keys = api.list(type="prompt")
+    ix = sorted([
+        k for k in all_keys
+        if k.startswith("template.")
+    ])
 
     values = api.get([
-        ConfigKey(type="prompt", key=f"template.{v}")
-        for v in ix
+        ConfigKey(type="prompt", key=k)
+        for k in ix
     ])
 
     print()
@@ -43,6 +47,7 @@ def show_config(url, token=None, workspace="default"):
 
     for n, key in enumerate(ix):
 
+        key = key.removeprefix("template.")
         data = json.loads(values[n].value)
 
         table = []

--- a/trustgraph-cli/trustgraph/cli/verify_system_status.py
+++ b/trustgraph-cli/trustgraph/cli/verify_system_status.py
@@ -231,18 +231,10 @@ def check_prompts(url: str, timeout: int, tr, token: Optional[str] = None, works
         api = Api(url, token=token, timeout=timeout, workspace=workspace)
         config = api.config()
 
-        # Import ConfigKey here to avoid top-level import issues
-        from trustgraph.api.types import ConfigKey
-        import json
+        all_keys = config.list(type="prompt")
+        ix = [k for k in all_keys if k.startswith("template.")]
 
-        # Get the template-index which lists all prompts
-        values = config.get([
-            ConfigKey(type="prompt", key="template-index")
-        ])
-
-        ix = json.loads(values[0].value)
-
-        if ix and len(ix) > 0:
+        if ix:
             return True, tr.t("cli.verify_system_status.prompts.found", count=len(ix))
         else:
             return False, tr.t("cli.verify_system_status.prompts.none")

--- a/trustgraph-flow/trustgraph/template/prompt_manager.py
+++ b/trustgraph-flow/trustgraph/template/prompt_manager.py
@@ -36,17 +36,17 @@ class PromptManager:
         except (KeyError, TypeError, json.JSONDecodeError):
             system = "Be helpful."
 
-        try:
-            ix = json.loads(config["template-index"])
-        except (KeyError, TypeError, json.JSONDecodeError):
-            ix = []
-
         prompts = {}
 
-        for k in ix:
+        prefix = "template."
 
-            pc = config[f"template.{k}"]
-            data = json.loads(pc)
+        for cfg_key, cfg_val in config.items():
+
+            if not cfg_key.startswith(prefix):
+                continue
+
+            k = cfg_key[len(prefix):]
+            data = json.loads(cfg_val)
 
             prompt = data.get("prompt")
             rtype = data.get("response-type", "text")

--- a/trustgraph-mcp/trustgraph/mcp_server/mcp.py
+++ b/trustgraph-mcp/trustgraph/mcp_server/mcp.py
@@ -1109,9 +1109,13 @@ class McpServer:
         async for response in gen:
             config = response.get("config", {})
             prompt_config = config.get("prompt", {})
-            template_index = prompt_config.get("template-index", "[]")
-            prompts = json.loads(template_index) if isinstance(template_index, str) else template_index
-            return GetPromptsResponse(prompts=prompts)
+            prefix = "template."
+            prompts = [
+                k.removeprefix(prefix)
+                for k in prompt_config
+                if k.startswith(prefix)
+            ]
+            return GetPromptsResponse(prompts=sorted(prompts))
 
     async def get_prompt(
             self,


### PR DESCRIPTION
## Summary
- Eliminates the redundant `template-index` config key that had to be manually kept in sync with actual `template.*` keys
- Templates are now discovered by filtering config keys for the `template.` prefix
- Updated all consumers: PromptManager, CLI tools (show-prompts, set-prompt, set-token-costs, verify-system-status), and MCP server

## Test plan
- [x] All existing unit tests pass after removing `template-index` from test configs
- [x] All existing integration tests pass
- [x] Verify `tg-show-prompts` lists templates correctly against a running instance
- [x] Verify `tg-set-prompt` creates templates without needing a template-index update
