### PR TITLE
Disable torch.compile JIT in Docling container

### DIFF
--- a/containers/Containerfile.docling
+++ b/containers/Containerfile.docling
@@ -5,7 +5,9 @@
 
 FROM docker.io/fedora:42 AS base
 
-ENV PIP_BREAK_SYSTEM_PACKAGES=1
+ENV \
+  PIP_BREAK_SYSTEM_PACKAGES=1 \
+  TORCH_COMPILE_DISABLE=1
 
 # This is cached, same as other containers
 RUN dnf install -y python3.11 && \


### PR DESCRIPTION
## Summary
- Adds `TORCH_COMPILE_DISABLE=1` to the Docling container environment
- Upstream models started relying on `torch.compile` JIT compilation, which requires a C++ compiler not present in the container, causing Docling to fail
- Disabling JIT is preferred over adding a full C++ toolchain, as the compiled code offers marginal real-world performance improvement

## Test plan
- [x] Build the Docling container and verify it starts without torch.compile errors
- [x] Verify document processing works correctly with JIT disabled
