### PR TITLE
fix(api): align REST triples query with explainability

### DIFF
--- a/tests/unit/test_api/test_flow_explainability.py
+++ b/tests/unit/test_api/test_flow_explainability.py
@@ -1,0 +1,110 @@
+"""Contract tests for REST triples queries used by explainability."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from trustgraph.api.explainability import (
+    ExplainabilityClient,
+    Question,
+    RDF_TYPE,
+    TG_GRAPH_RAG_QUESTION,
+    TG_QUERY,
+    TG_QUESTION,
+)
+from trustgraph.api.flow import FlowInstance
+from trustgraph.knowledge import Literal, Uri
+
+
+def _make_flow(response):
+    parent = MagicMock()
+    parent.api.workspace = "workspace-a"
+    parent.request.return_value = response
+    return FlowInstance(parent, "default"), parent
+
+
+@pytest.mark.parametrize("graph", ["urn:graph:retrieval", "*"])
+def test_rest_triples_query_accepts_string_terms_and_graph(graph):
+    flow, parent = _make_flow({"response": []})
+
+    result = flow.triples_query(
+        s="urn:entity:subject",
+        p="urn:relation:predicate",
+        o="urn:entity:object",
+        g=graph,
+        collection="explainability",
+        limit=25,
+    )
+
+    assert result == []
+    parent.request.assert_called_once_with(
+        path="default/service/triples",
+        request={
+            "workspace": "workspace-a",
+            "limit": 25,
+            "collection": "explainability",
+            "s": {"t": "i", "i": "urn:entity:subject"},
+            "p": {"t": "i", "i": "urn:relation:predicate"},
+            "o": {"t": "i", "i": "urn:entity:object"},
+            "g": graph,
+        },
+    )
+
+
+def test_rest_triples_query_preserves_typed_terms_without_graph():
+    flow, parent = _make_flow({"response": []})
+
+    flow.triples_query(
+        s=Uri("urn:entity:subject"),
+        p=Uri("urn:relation:label"),
+        o=Literal("https://example.org/display-name"),
+    )
+
+    request = parent.request.call_args.kwargs["request"]
+    assert request["s"] == {"t": "i", "i": "urn:entity:subject"}
+    assert request["p"] == {"t": "i", "i": "urn:relation:label"}
+    assert request["o"] == {
+        "t": "l",
+        "v": "https://example.org/display-name",
+    }
+    assert "g" not in request
+
+
+def test_explainability_client_uses_rest_flow_contract():
+    question_uri = "urn:trustgraph:question:123"
+    response = {
+        "response": [
+            {
+                "s": {"t": "i", "i": question_uri},
+                "p": {"t": "i", "i": RDF_TYPE},
+                "o": {"t": "i", "i": TG_QUESTION},
+            },
+            {
+                "s": {"t": "i", "i": question_uri},
+                "p": {"t": "i", "i": RDF_TYPE},
+                "o": {"t": "i", "i": TG_GRAPH_RAG_QUESTION},
+            },
+            {
+                "s": {"t": "i", "i": question_uri},
+                "p": {"t": "i", "i": TG_QUERY},
+                "o": {"t": "l", "v": "What caused the deviation?"},
+            },
+        ]
+    }
+    flow, parent = _make_flow(response)
+    client = ExplainabilityClient(flow, max_retries=2, retry_delay=0.0)
+
+    entity = client.fetch_entity(
+        question_uri,
+        graph="urn:graph:retrieval",
+        collection="explainability",
+    )
+
+    assert isinstance(entity, Question)
+    assert entity.query == "What caused the deviation?"
+    assert parent.request.call_count == 2
+    for call in parent.request.call_args_list:
+        request = call.kwargs["request"]
+        assert request["s"] == {"t": "i", "i": question_uri}
+        assert request["g"] == "urn:graph:retrieval"
+        assert request["collection"] == "explainability"

--- a/trustgraph-base/trustgraph/api/explainability.py
+++ b/trustgraph-base/trustgraph/api/explainability.py
@@ -11,6 +11,8 @@ import time
 from dataclasses import dataclass, field
 from typing import Optional, List, Dict, Any, Tuple, Union
 
+from .types import Triple
+
 # Provenance predicates
 TG = "https://trustgraph.ai/ns/"
 TG_QUERY = TG + "query"
@@ -464,13 +466,20 @@ def extract_term_value(term: Dict[str, Any]) -> Any:
         return term.get("i") or term.get("v") or term.get("iri") or term.get("value") or str(term)
 
 
-def wire_triples_to_tuples(wire_triples: List[Dict[str, Any]]) -> List[Tuple[str, str, Any]]:
-    """Convert wire-format triples to (s, p, o) tuples."""
+def wire_triples_to_tuples(
+    wire_triples: List[Union[Dict[str, Any], Triple]]
+) -> List[Tuple[str, str, Any]]:
+    """Convert wire-format or REST API triples to (s, p, o) tuples."""
     result = []
     for t in wire_triples:
-        s = extract_term_value(t.get("s", {}))
-        p = extract_term_value(t.get("p", {}))
-        o = extract_term_value(t.get("o", {}))
+        if isinstance(t, Triple):
+            s = str(t.s)
+            p = str(t.p)
+            o = str(t.o)
+        else:
+            s = extract_term_value(t.get("s", {}))
+            p = extract_term_value(t.get("p", {}))
+            o = extract_term_value(t.get("o", {}))
         result.append((s, p, o))
     return result
 

--- a/trustgraph-base/trustgraph/api/flow.py
+++ b/trustgraph-base/trustgraph/api/flow.py
@@ -755,7 +755,7 @@ class FlowInstance:
         raise ProtocolException("Response not formatted correctly")
 
     def triples_query(
-            self, s=None, p=None, o=None,
+            self, s=None, p=None, o=None, g=None,
             collection=None, limit=10000
     ):
         """
@@ -765,9 +765,10 @@ class FlowInstance:
         object patterns. Unspecified parameters act as wildcards.
 
         Args:
-            s: Subject URI (optional, use None for wildcard)
-            p: Predicate URI (optional, use None for wildcard)
-            o: Object URI or Literal (optional, use None for wildcard)
+            s: Subject URI as Uri or string (optional, None for wildcard)
+            p: Predicate URI as Uri or string (optional, None for wildcard)
+            o: Object as Uri, Literal, or string (optional, None for wildcard)
+            g: Named graph identifier (None for default graph, "*" for all)
             collection: Collection identifier (optional)
             limit: Maximum results to return (default: 10000)
 
@@ -775,7 +776,7 @@ class FlowInstance:
             list[Triple]: List of matching Triple objects
 
         Raises:
-            RuntimeError: If s or p is not a Uri, or o is not Uri/Literal
+            RuntimeError: If a query term has an unsupported type
 
         Example:
             ```python
@@ -803,19 +804,33 @@ class FlowInstance:
             input["collection"] = collection
 
         if s:
+            if isinstance(s, str) and not isinstance(s, (Uri, Literal)):
+                s = Uri(s)
             if not isinstance(s, Uri):
-                raise RuntimeError("s must be Uri")
+                raise RuntimeError("s must be Uri or str")
             input["s"] = from_value(s)
 
         if p:
+            if isinstance(p, str) and not isinstance(p, (Uri, Literal)):
+                p = Uri(p)
             if not isinstance(p, Uri):
-                raise RuntimeError("p must be Uri")
+                raise RuntimeError("p must be Uri or str")
             input["p"] = from_value(p)
 
         if o:
+            if isinstance(o, str) and not isinstance(o, (Uri, Literal)):
+                if o.startswith("<") and o.endswith(">"):
+                    o = Uri(o[1:-1])
+                elif o.startswith(("http://", "https://", "urn:")):
+                    o = Uri(o)
+                else:
+                    o = Literal(o)
             if not isinstance(o, Uri) and not isinstance(o, Literal):
-                raise RuntimeError("o must be Uri or Literal")
+                raise RuntimeError("o must be Uri, Literal, or str")
             input["o"] = from_value(o)
+
+        if g is not None:
+            input["g"] = g
 
         object = self.request(
             "service/triples",


### PR DESCRIPTION
## Summary

- add named-graph (`g`) and string-term support to the synchronous REST `FlowInstance.triples_query()` API
- let explainability parsing accept both wire-format dictionaries and REST `Triple` objects
- add contract tests that exercise a real REST `FlowInstance` with only the HTTP transport mocked

## Problem

`ExplainabilityClient` calls `triples_query()` with string RDF terms and a named graph, but the synchronous REST implementation in v2.8.15 rejects `g` and requires `Uri`/`Literal` objects. After the query succeeds, REST returns `Triple` objects while the explainability converter expects dictionaries. The existing mocked tests bypassed this adapter boundary.

The server request translator already supports `g`; this change aligns the REST client with that wire contract and the existing socket client behavior.

## Tests

- `pytest tests/unit/test_api/test_flow_explainability.py tests/unit/test_provenance/test_explainability.py tests/contract/test_provenance_wire_format.py -q` — 59 passed
- broader API/provenance/provenance-contract suite — 271 passed