### PR TITLE
fix: avoid bare except in show token costs

### DIFF
--- a/tests/unit/test_cli/test_show_token_costs.py
+++ b/tests/unit/test_cli/test_show_token_costs.py
@@ -1,0 +1,52 @@
+import pytest
+from unittest.mock import Mock, patch
+
+from trustgraph.api import ProtocolException
+from trustgraph.cli.show_token_costs import show_config
+
+
+@patch("trustgraph.cli.show_token_costs.Api")
+def test_show_config_handles_invalid_token_cost(mock_api, capsys):
+    config_api = Mock()
+    mock_api.return_value.config.return_value = config_api
+
+    config_api.list.return_value = ["test-model"]
+
+    result = Mock()
+    result.value = "not valid json"
+    config_api.get.return_value = [result]
+
+    show_config("http://localhost:8888")
+
+    output = capsys.readouterr().out
+
+    assert "test-model" in output
+    assert "-" in output
+
+
+@patch("trustgraph.cli.show_token_costs.Api")
+def test_show_config_does_not_swallow_keyboard_interrupt(mock_api):
+    config_api = Mock()
+    mock_api.return_value.config.return_value = config_api
+
+    config_api.list.return_value = ["test-model"]
+    config_api.get.side_effect = KeyboardInterrupt
+
+    with pytest.raises(KeyboardInterrupt):
+        show_config("http://localhost:8888")
+
+
+@patch("trustgraph.cli.show_token_costs.Api")
+def test_show_config_handles_protocol_error(mock_api, capsys):
+    config_api = Mock()
+    mock_api.return_value.config.return_value = config_api
+
+    config_api.list.return_value = ["test-model"]
+    config_api.get.side_effect = ProtocolException("bad response")
+
+    show_config("http://localhost:8888")
+
+    output = capsys.readouterr().out
+
+    assert "test-model" in output
+    assert "-" in output

--- a/trustgraph-cli/trustgraph/cli/show_token_costs.py
+++ b/trustgraph-cli/trustgraph/cli/show_token_costs.py
@@ -4,7 +4,7 @@ Dumps out token cost configuration
 
 import argparse
 import os
-from trustgraph.api import Api, ConfigKey
+from trustgraph.api import Api, ConfigKey, ProtocolException
 import json
 import tabulate
 import textwrap
@@ -37,7 +37,13 @@ def show_config(url, token=None, workspace="default"):
                 fmt(values.get("input_price")),
                 fmt(values.get("output_price")),
             ))
-        except:
+        except (
+            ProtocolException,
+            IndexError,
+            AttributeError,
+            TypeError,
+            ValueError,
+        ):
             costs.append((
                 model, "-", "-"
             ))


### PR DESCRIPTION
Addresses a small part of #783.

This change replaces the bare `except:` in `show_token_costs.py`
with specific exceptions related to configuration retrieval,
parsing, and formatting.

It preserves the existing fallback behavior for invalid token-cost
configuration and `ProtocolException`, while allowing interrupts such
as `KeyboardInterrupt` and `SystemExit` to propagate normally.

Tests added for:
- invalid token-cost JSON
- `ProtocolException` handling
- `KeyboardInterrupt` propagation

Tested with:

```bash
PYTHONPATH="trustgraph-cli:trustgraph-base" \
python -m pytest tests/unit/test_cli/test_show_token_costs.py -v