### PR TITLE
Bump dependency version ranges to 2.9

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup packages
-        run: make update-package-versions VERSION=2.8.999
+        run: make update-package-versions VERSION=2.9.999
 
       - name: Setup environment
         run: python3 -m venv env

--- a/trustgraph-bedrock/pyproject.toml
+++ b/trustgraph-bedrock/pyproject.toml
@@ -10,7 +10,7 @@ description = "TrustGraph provides a means to run a pipeline of flexible AI proc
 readme = "README.md"
 requires-python = ">=3.8"
 dependencies = [
-    "trustgraph-base>=2.8,<2.9",
+    "trustgraph-base>=2.9,<2.10",
     "pulsar-client",
     "prometheus-client",
     "boto3",

--- a/trustgraph-cli/pyproject.toml
+++ b/trustgraph-cli/pyproject.toml
@@ -10,7 +10,7 @@ description = "TrustGraph provides a means to run a pipeline of flexible AI proc
 readme = "README.md"
 requires-python = ">=3.8"
 dependencies = [
-    "trustgraph-base>=2.8,<2.9",
+    "trustgraph-base>=2.9,<2.10",
     "requests",
     "pulsar-client",
     "aiohttp",

--- a/trustgraph-docling/pyproject.toml
+++ b/trustgraph-docling/pyproject.toml
@@ -10,7 +10,7 @@ description = "TrustGraph document decoder powered by Docling — lightweight al
 readme = "README.md"
 requires-python = ">=3.8"
 dependencies = [
-    "trustgraph-base>=2.8,<2.9",
+    "trustgraph-base>=2.9,<2.10",
     "pulsar-client",
     "prometheus-client",
     "docling",

--- a/trustgraph-embeddings-hf/pyproject.toml
+++ b/trustgraph-embeddings-hf/pyproject.toml
@@ -10,8 +10,8 @@ description = "HuggingFace embeddings support for TrustGraph."
 readme = "README.md"
 requires-python = ">=3.8"
 dependencies = [
-    "trustgraph-base>=2.8,<2.9",
-    "trustgraph-flow>=2.8,<2.9",
+    "trustgraph-base>=2.9,<2.10",
+    "trustgraph-flow>=2.9,<2.10",
     "torch",
     "urllib3",
     "transformers",

--- a/trustgraph-flow/pyproject.toml
+++ b/trustgraph-flow/pyproject.toml
@@ -10,7 +10,7 @@ description = "TrustGraph provides a means to run a pipeline of flexible AI proc
 readme = "README.md"
 requires-python = ">=3.8"
 dependencies = [
-    "trustgraph-base>=2.8,<2.9",
+    "trustgraph-base>=2.9,<2.10",
     "aiohttp",
     "anthropic",
     "scylla-driver",

--- a/trustgraph-ocr/pyproject.toml
+++ b/trustgraph-ocr/pyproject.toml
@@ -10,7 +10,7 @@ description = "TrustGraph provides a means to run a pipeline of flexible AI proc
 readme = "README.md"
 requires-python = ">=3.8"
 dependencies = [
-    "trustgraph-base>=2.8,<2.9",
+    "trustgraph-base>=2.9,<2.10",
     "pulsar-client",
     "prometheus-client",
     "boto3",

--- a/trustgraph-unstructured/pyproject.toml
+++ b/trustgraph-unstructured/pyproject.toml
@@ -10,7 +10,7 @@ description = "TrustGraph provides a means to run a pipeline of flexible AI proc
 readme = "README.md"
 requires-python = ">=3.8"
 dependencies = [
-    "trustgraph-base>=2.8,<2.9",
+    "trustgraph-base>=2.9,<2.10",
     "pulsar-client",
     "prometheus-client",
     "python-magic",

--- a/trustgraph-vertexai/pyproject.toml
+++ b/trustgraph-vertexai/pyproject.toml
@@ -10,7 +10,7 @@ description = "TrustGraph provides a means to run a pipeline of flexible AI proc
 readme = "README.md"
 requires-python = ">=3.8"
 dependencies = [
-    "trustgraph-base>=2.8,<2.9",
+    "trustgraph-base>=2.9,<2.10",
     "pulsar-client",
     "google-genai",
     "google-api-core",

--- a/trustgraph/pyproject.toml
+++ b/trustgraph/pyproject.toml
@@ -10,13 +10,13 @@ description = "TrustGraph provides a means to run a pipeline of flexible AI proc
 readme = "README.md"
 requires-python = ">=3.8"
 dependencies = [
-    "trustgraph-base>=2.8,<2.9",
-    "trustgraph-bedrock>=2.8,<2.9",
-    "trustgraph-cli>=2.8,<2.9",
-    "trustgraph-embeddings-hf>=2.8,<2.9",
-    "trustgraph-flow>=2.8,<2.9",
-    "trustgraph-unstructured>=2.8,<2.9",
-    "trustgraph-vertexai>=2.8,<2.9",
+    "trustgraph-base>=2.9,<2.10",
+    "trustgraph-bedrock>=2.9,<2.10",
+    "trustgraph-cli>=2.9,<2.10",
+    "trustgraph-embeddings-hf>=2.9,<2.10",
+    "trustgraph-flow>=2.9,<2.10",
+    "trustgraph-unstructured>=2.9,<2.10",
+    "trustgraph-vertexai>=2.9,<2.10",
 ]
 classifiers = [
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
## Summary
- Bump all internal dependency ranges from `>=2.8,<2.9` to `>=2.9,<2.10` across 9 pyproject.toml files
- Bump CI pull-request workflow `VERSION` from `2.8.999` to `2.9.999`

## Test plan
- [x] CI passes with updated version ranges
- [x] `make update-package-versions VERSION=2.9.999` works correctly
