### PR TITLE
Back-port: replace google-cloud-aiplatform with google-genai in VertexAI container

### DIFF
--- a/containers/Containerfile.vertexai
+++ b/containers/Containerfile.vertexai
@@ -14,7 +14,7 @@ RUN dnf install -y python3.13 && \
   pip3 install --no-cache-dir --upgrade 'pip>=26.0' 'setuptools>=78.1.1' && \
   pip3 install --no-cache-dir build wheel aiohttp && \
   pip3 install --no-cache-dir pulsar-client==3.11.0 && \
-  pip3 install --no-cache-dir google-cloud-aiplatform && \
+  pip3 install --no-cache-dir google-genai google-api-core && \
   dnf clean all
 
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Cherry-pick of #1081 to `release/v2.6`
- Replaces `google-cloud-aiplatform` with `google-genai google-api-core` in the VertexAI Containerfile
- Fixes build failure caused by a broken `.pth` namespace package file from `google-cloud-aiplatform` that corrupts the Python environment under Python 3.13

## Test plan
- [x] VertexAI container builds successfully on arm64 and amd64
