### PR TITLE
fix(mcp): support v1 and v2 streamable HTTP clients

### DIFF
--- a/tests/unit/test_agent/test_mcp_tool_transport_compat.py
+++ b/tests/unit/test_agent/test_mcp_tool_transport_compat.py
@@ -1,0 +1,130 @@
+"""MCP transport contract tests for the outbound tool service."""
+
+import pytest
+from pydantic import BaseModel
+
+from trustgraph.agent.mcp_tool import service as mcp_tool_service
+
+try:
+    from mcp.server import MCPServer
+except ImportError:
+    from mcp.server.fastmcp import FastMCP
+
+    MCPServer = None
+
+
+class EchoResult(BaseModel):
+    echo: str
+
+
+class HeaderCapture:
+    """ASGI wrapper that records the HTTP headers seen by the MCP server."""
+
+    def __init__(self, app):
+        self.app = app
+        self.requests = []
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] == "http":
+            self.requests.append({
+                name.decode("latin-1").lower(): value.decode("latin-1")
+                for name, value in scope["headers"]
+            })
+        await self.app(scope, receive, send)
+
+
+def create_test_server():
+    """Create the native server for the installed MCP major version."""
+    if MCPServer is not None:
+        server = MCPServer("test-mcp-server")
+
+        def app_factory():
+            return server.streamable_http_app(
+                json_response=True,
+                stateless_http=True,
+                host="testserver",
+            )
+    else:
+        server = FastMCP(
+            "test-mcp-server",
+            json_response=True,
+            stateless_http=True,
+            host="testserver",
+        )
+        app_factory = server.streamable_http_app
+
+    return server, app_factory
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("auth_token", "expected_authorization"),
+    [
+        ("test-token", "Bearer test-token"),
+        ("", None),
+        (None, None),
+    ],
+)
+async def test_invoke_tool_uses_supported_streamable_http_contract(
+        monkeypatch,
+        auth_token,
+        expected_authorization,
+):
+    """Exercise the real MCP transport and session over an in-process server."""
+    server, app_factory = create_test_server()
+
+    @server.tool()
+    def echo(value: str) -> EchoResult:
+        return EchoResult(echo=value)
+
+    app = app_factory()
+    captured_app = HeaderCapture(app)
+
+    http_module = (
+        mcp_tool_service.create_mcp_http_client.__globals__.get("httpx2")
+        or mcp_tool_service.create_mcp_http_client.__globals__["httpx"]
+    )
+    real_async_client = http_module.AsyncClient
+    client_options = []
+
+    def create_in_process_client(*args, **kwargs):
+        client_options.append(kwargs.copy())
+        kwargs["transport"] = http_module.ASGITransport(app=captured_app)
+        kwargs["base_url"] = "http://testserver"
+        return real_async_client(*args, **kwargs)
+
+    monkeypatch.setattr(
+        http_module,
+        "AsyncClient",
+        create_in_process_client,
+    )
+
+    tool_config = {
+        "url": "http://testserver/mcp",
+        "remote-name": "echo",
+    }
+    if auth_token is not None:
+        tool_config["auth-token"] = auth_token
+
+    service = object.__new__(mcp_tool_service.Service)
+    service.mcp_services = {
+        "test-workspace": {"local-echo": tool_config},
+    }
+
+    async with app.router.lifespan_context(app):
+        result = await service.invoke_tool(
+            "test-workspace",
+            "local-echo",
+            {"value": "hello"},
+        )
+
+    assert result == {"echo": "hello"} or (
+        isinstance(result, str) and "hello" in result
+    )
+    assert len(client_options) == 1
+    assert client_options[0]["follow_redirects"] is True
+    assert isinstance(client_options[0]["timeout"], http_module.Timeout)
+    assert captured_app.requests
+
+    for headers in captured_app.requests:
+        assert headers.get("authorization") == expected_authorization

--- a/trustgraph-flow/pyproject.toml
+++ b/trustgraph-flow/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "langchain-community",
     "langchain-core",
     "langchain-text-splitters",
-    "mcp",
+    "mcp>=1.8,<3",
     "minio",
     "mistralai<2.0.0",
     "neo4j",

--- a/trustgraph-flow/trustgraph/agent/mcp_tool/service.py
+++ b/trustgraph-flow/trustgraph/agent/mcp_tool/service.py
@@ -6,15 +6,45 @@ name + parameters, output is the response, either a string or an object.
 
 import json
 import logging
-from mcp.client.streamable_http import streamable_http_client
+from contextlib import asynccontextmanager
+
 from mcp import ClientSession
+from mcp.shared._httpx_utils import create_mcp_http_client
 
 from ... base import ToolService
+
+try:
+    from mcp.client.streamable_http import streamable_http_client
+    _MCP_USES_CALLER_HTTP_CLIENT = True
+except ImportError:
+    from mcp.client.streamable_http import (
+        streamablehttp_client as streamable_http_client,
+    )
+    _MCP_USES_CALLER_HTTP_CLIENT = False
 
 # Module logger
 logger = logging.getLogger(__name__)
 
 default_ident = "mcp-tool"
+
+
+@asynccontextmanager
+async def connect_streamable_http(url, headers):
+    """Yield the read/write streams across MCP's two HTTP client APIs."""
+    if _MCP_USES_CALLER_HTTP_CLIENT:
+        async with create_mcp_http_client(headers=headers) as http_client:
+            async with streamable_http_client(
+                url,
+                http_client=http_client,
+            ) as streams:
+                yield streams[:2]
+    else:
+        async with streamable_http_client(
+            url,
+            headers=headers,
+        ) as streams:
+            yield streams[:2]
+
 
 class Service(ToolService):
 
@@ -68,21 +98,22 @@ class Service(ToolService):
 
             # Build headers with optional bearer token
             headers = {}
-            if "auth-token" in ws_services[name]:
-                token = ws_services[name]["auth-token"]
+            token = ws_services[name].get("auth-token")
+            if token:
                 headers["Authorization"] = f"Bearer {token}"
 
             logger.info(f"Invoking {remote_name} at {url}")
 
-            # Connect to a streamable HTTP server with headers
-            async with streamable_http_client(url, headers=headers) as (
-                    read_stream,
-                    write_stream,
-                    _,
-            ):
+            async with connect_streamable_http(
+                url,
+                headers,
+            ) as (read_stream, write_stream):
 
                 # Create a session using the client streams
-                async with ClientSession(read_stream, write_stream) as session:
+                async with ClientSession(
+                    read_stream,
+                    write_stream,
+                ) as session:
 
                     # Initialize the connection
                     await session.initialize()
@@ -93,13 +124,25 @@ class Service(ToolService):
                         parameters
                     )
 
-                    if result.structured_content:
-                        return result.structured_content
+                    structured_content = getattr(
+                        result,
+                        "structured_content",
+                        None,
+                    )
+                    if structured_content is None:
+                        structured_content = getattr(
+                            result,
+                            "structuredContent",
+                            None,
+                        )
+
+                    if structured_content:
+                        return structured_content
                     elif hasattr(result, "content"):
-                            return "".join([
-                                x.text
-                                for x in result.content
-                            ])
+                        return "".join([
+                            x.text
+                            for x in result.content
+                        ])
                     else:
                         return "No content"
 


### PR DESCRIPTION
## Summary

Complete the outbound MCP tool service migration while preserving MCP v1 deployments back to the introduction of Streamable HTTP.

PR #1083 updated the transport import and result field names, but the service still passed the removed `headers=` argument to `streamable_http_client` and assumed the former three-value transport tuple. Current MCP v2 releases therefore fail before session initialization. MCP v1 also has two transport API generations that need a small boundary adapter.

## Changes

- support `mcp>=1.8,<3`; v1.8 is the first Python SDK release containing the Streamable HTTP client module
- adapt the old v1 `streamablehttp_client(headers=...)` and current `streamable_http_client(http_client=...)` connection APIs in one context manager
- keep one shared MCP session and tool-call path after transport setup
- consume the first two transport streams so both the v1 three-value and v2 two-value results work
- accept old `structuredContent`, current `structured_content`, and content-only results
- leave the existing auth test file unchanged and add a separate real transport contract test

## Validation

The new test starts the installed SDK's native MCP server, performs initialization plus a real tool call, and captures the actual HTTP request headers. Bearer, empty-token, and no-token cases pass on:

- `mcp==1.8.0` (first Streamable HTTP release)
- `mcp==1.23.3` (last old client API)
- `mcp==1.24.0` (first current client API)
- `mcp==1.29.1` (last v1 release)
- `mcp==2.0.0`
- `mcp==2.1.0` (current release)

On `mcp==2.1.0`, the expanded related agent suite passes all 50 tests.