### PR TITLE
fix(cli): validate language tags before emitting them

### DIFF
--- a/tests/unit/test_cli/test_graph_to_turtle.py
+++ b/tests/unit/test_cli/test_graph_to_turtle.py
@@ -1,0 +1,32 @@
+"""
+Term-conversion tests for the Turtle dumper: term_to_rdflib follows the same
+"return None to skip" contract as the N-Quads encoder, and show_graph only
+serializes once the whole stream has been consumed, so a term that raises
+instead of returning None loses the entire dump.
+"""
+
+import rdflib
+
+from trustgraph.cli.graph_to_turtle import term_to_rdflib
+
+from tests.unit.test_cli.conftest import iri, lit
+
+
+class TestTermToRdflib:
+
+    def test_iri_and_literal_flavours_convert(self):
+        assert term_to_rdflib(iri("http://example.com/s")) == \
+            rdflib.term.URIRef("http://example.com/s")
+        assert term_to_rdflib(lit("plain value")) == rdflib.term.Literal("plain value")
+        assert term_to_rdflib(lit("bonjour", lang="fr")) == \
+            rdflib.term.Literal("bonjour", lang="fr")
+        assert term_to_rdflib(lit("bonjour", lang="fr-CA")) == \
+            rdflib.term.Literal("bonjour", lang="fr-CA")
+
+    def test_malformed_iri_is_skipped(self):
+        assert term_to_rdflib(iri("http://example.com/bad iri")) is None
+
+    def test_unusable_language_tag_is_skipped_not_raised(self):
+        for bad in ["fr CA", "en_US", "en\n", 'en> "x" <urn:evil', 7]:
+            assert term_to_rdflib(lit("bonjour", lang=bad)) is None, \
+                f"tag {bad!r} was not skipped"

--- a/tests/unit/test_cli/test_nquads.py
+++ b/tests/unit/test_cli/test_nquads.py
@@ -78,14 +78,49 @@ class TestNquadsRoundTrip:
             # literal in predicate position: invalid RDF
             {"s": iri("http://example.com/s"), "p": lit("not-a-predicate"),
              "o": lit("x")},
+            # language tag outside the LANGTAG production: emitting it raw
+            # would break the line and make the whole member unparseable
+            {"s": iri("http://example.com/s"), "p": iri("http://example.com/label"),
+             "o": lit("bonjour", lang="fr CA")},
             # one good triple to prove the stream continues past skips
             {"s": iri("http://example.com/s"), "p": iri("http://example.com/p"),
              "o": lit("good")},
         ]]
         ds, written, skipped = roundtrip(batches)
 
-        assert (written, skipped) == (1, 3)
+        assert (written, skipped) == (1, 4)
         assert len(list(ds.quads((None, None, None, None)))) == 1
+
+    def test_unusable_language_tags_are_skipped_not_emitted(self):
+        """One bad tag must not cost the whole member.
+
+        parse_nquads hands the entire member to rdflib at once, and its
+        N-Quads parser aborts on the first malformed line, so a tag emitted
+        raw takes every other triple in the bundle down with it.
+        """
+        good = {"s": iri("http://example.com/s"), "p": iri("http://example.com/p"),
+                "o": lit("good")}
+
+        for bad in ["fr CA", "en_US", "en\n", 'en> "x" <urn:evil', 7]:
+            batches = [[
+                {"s": iri("http://example.com/s"),
+                 "p": iri("http://example.com/label"),
+                 "o": lit("bonjour", lang=bad)},
+                good,
+            ]]
+            ds, written, skipped = roundtrip(batches)
+            assert (written, skipped) == (1, 1), f"tag {bad!r} was not skipped"
+            assert len(list(ds.quads((None, None, None, None)))) == 1
+
+        # subtags are part of the production and must still survive
+        for ok in ["fr", "fr-CA", "de-DE-1996"]:
+            batches = [[{"s": iri("http://example.com/s"),
+                         "p": iri("http://example.com/label"),
+                         "o": lit("bonjour", lang=ok)}]]
+            ds, written, skipped = roundtrip(batches)
+            assert (written, skipped) == (1, 0), f"tag {ok!r} was wrongly skipped"
+            obj = next(iter(ds.quads((None, None, None, None))))[2]
+            assert obj == rdflib.Literal("bonjour", lang=ok)
 
     def test_streaming_shape_one_line_per_triple(self):
         line = triple_to_nquad(

--- a/trustgraph-cli/trustgraph/cli/graph_to_turtle.py
+++ b/trustgraph-cli/trustgraph/cli/graph_to_turtle.py
@@ -12,6 +12,8 @@ import os
 
 from trustgraph.api import Api
 
+from . nquads import valid_language_tag
+
 default_url = os.getenv("TRUSTGRAPH_URL", 'http://localhost:8888/')
 default_collection = 'default'
 default_token = os.getenv("TRUSTGRAPH_TOKEN", None)
@@ -36,6 +38,11 @@ def term_to_rdflib(term):
         datatype = term.get("d")
         language = term.get("l")
         if language:
+            # Skip malformed tags: Literal(lang=...) raises on them, and
+            # the graph is only serialized once the whole stream has been
+            # consumed, so an escaping exception loses the entire dump.
+            if not valid_language_tag(language):
+                return None
             return rdflib.term.Literal(value, lang=language)
         elif datatype:
             return rdflib.term.Literal(value, datatype=rdflib.term.URIRef(datatype))

--- a/trustgraph-cli/trustgraph/cli/nquads.py
+++ b/trustgraph-cli/trustgraph/cli/nquads.py
@@ -32,6 +32,21 @@ _ESCAPES = [
 # for large exports (it runs per term).
 _BAD_IRI = re.compile(r'[\x00-\x20<>"{}|^\x60]')
 
+# The body of the LANGTAG production, [a-zA-Z]+ ('-' [a-zA-Z0-9]+)*, which
+# Turtle shares and which is the shape rdflib's Literal(lang=...) accepts.
+# fullmatch, not a trailing $: $ also matches before a trailing newline, so
+# "en\n" would pass and split the quad across two lines.
+_LANGTAG = re.compile(r"[a-zA-Z]+(?:-[a-zA-Z0-9]+)*")
+
+
+def valid_language_tag(language):
+    """True when language can be emitted after the '@' of a LANGTAG.
+
+    The wire schema types the language field as a free-form str, so an
+    unusable tag arrives here as data, not as a bug.
+    """
+    return isinstance(language, str) and _LANGTAG.fullmatch(language) is not None
+
 
 def _escape_literal(value):
     for raw, esc in _ESCAPES:
@@ -67,6 +82,8 @@ def encode_term(term, is_object=False):
         language = term.get("l")
         datatype = term.get("d")
         if language:
+            if not valid_language_tag(language):
+                return None
             return f'"{value}"@{language}'
         if datatype:
             dt = _encode_iri(datatype)


### PR DESCRIPTION
## Problem

A `.tgx` bundle exported by `tg-export-workspace` can be reported as complete and lossless and still be entirely unimportable, if any one triple in it carries a language tag that isn't a valid `LANGTAG`.

`trustgraph-cli/trustgraph/cli/nquads.py:69-70` is the one place in the module where a wire value is interpolated without being checked first:

```python
        if language:
            return f'"{value}"@{language}'
```

Everything else in `encode_term` is validated — IRIs and datatype IRIs go through `_encode_iri`, which returns `None` on any character `IRIREF` forbids, and literal text goes through `_escape_literal`. The language field is typed as a free-form `str` on the wire (`trustgraph-base/trustgraph/schema/core/primitives.py:38`) with no validation upstream, so a tag containing a space, an underscore, a newline or a `>` reaches this line and is emitted raw. The resulting line is not valid N-Quads, but `serialize_nquads` counts it as `written` and returns `skipped=0`.

That is worse than a lost triple, because `parse_nquads` hands the whole bundle member to rdflib in one call and rdflib's N-Quads parser aborts on the first malformed line. One bad tag takes every other triple in the member with it, at exactly the export/import boundary the format exists for.

The same unvalidated field is a crash in the sibling exporter. `trustgraph-cli/trustgraph/cli/graph_to_turtle.py:38-39` does:

```python
        if language:
            return rdflib.term.Literal(value, lang=language)
```

`term_to_rdflib` follows the same "return `None` to skip" contract as `encode_term` — `show_graph` skips a triple when any term is `None`, and the IRI branch already returns `None` for a malformed IRI — but `rdflib.term.Literal(..., lang=...)` *raises* rather than returning a falsy value, and nothing catches it. Because `g.serialize(...)` only runs after the whole stream has been consumed, `tg-graph-to-turtle` aborts with a traceback and emits no output at all.

## Reproduction

Three triples, one bad tag in the middle:

```python
import io
from trustgraph.cli.nquads import serialize_nquads, parse_nquads
from trustgraph.cli.graph_to_turtle import term_to_rdflib

GRAPH = "urn:trustgraph:collection:default"
S = {"t": "i", "i": "http://example.com/s"}
P = {"t": "i", "i": "http://example.com/label"}

batch = [
    {"s": S, "p": P, "o": {"t": "l", "v": "hello"}},
    {"s": S, "p": P, "o": {"t": "l", "v": "bonjour", "l": "fr CA"}},
    {"s": S, "p": P, "o": {"t": "l", "v": "hallo", "l": "de"}},
]

out = io.StringIO()
w, s = serialize_nquads([batch], GRAPH, out)
print(f"serialize_nquads reported: written={w} skipped={s}")
try:
    print(f"parse_nquads recovered {len(parse_nquads(out.getvalue().encode()))} triples")
except Exception as e:
    print(f"parse_nquads RAISED: {type(e).__name__}: {str(e).splitlines()[0]}")

try:
    print("term_to_rdflib ->", term_to_rdflib({"t": "l", "v": "bonjour", "l": "fr CA"}))
except Exception as e:
    print(f"term_to_rdflib RAISED: {type(e).__name__}: {e}")
```

Before:

```
serialize_nquads reported: written=3 skipped=0
parse_nquads RAISED: ParserError: Invalid line (Failed to eat [ \t]*\.[ \t]*(#.*)? at CA <urn:trustgraph:collection:default> .):
term_to_rdflib RAISED: ValueError: 'fr CA' is not a valid language tag!
```

After:

```
serialize_nquads reported: written=2 skipped=1
parse_nquads recovered 2 triples
term_to_rdflib -> None
```

## Change

Adds `valid_language_tag()` beside `_encode_iri` in `nquads.py` and gates both exporters on it.

The pattern is the body of the `LANGTAG` production, `[a-zA-Z]+ ('-' [a-zA-Z0-9]+)*`, which is also what rdflib's `Literal(lang=...)` enforces (`_lang_tag_regex` in `rdflib/term.py`) and what Turtle uses, so the two exporters agree with each other and with the library they hand output to. One deliberate difference from rdflib: it is matched with `fullmatch` rather than a trailing `$`. Python's `$` also matches before a trailing newline, so `rdflib.Literal("v", lang="en\n")` is accepted today and serializes to a `"v"@en\n` that rdflib itself then cannot read back. `fullmatch` closes that.

**Skip rather than raise.** Both files already distinguish the two cases: a per-term defect in the data returns `None` and is counted (`_encode_iri`, the RDF-star branch, literals outside object position; `show_graph`'s `continue`), while the one thing `serialize_nquads` raises on is the caller-supplied `graph_iri`, which invalidates every line rather than one. A language tag is data arriving off the wire, so it belongs in the first group — it lands in the `skipped` total the function already reports, which keeps the counts honest instead of reporting a corrupt export as clean. Raising would also mean a single bad tag anywhere in a collection fails the whole `tg-export-workspace` run, which is the failure mode this is trying to remove.

`graph_to_turtle`'s `datatype` handling is unvalidated in the same way (`rdflib.term.URIRef(datatype)`, line 41); it fails later, at serialization, rather than in the loop, and is left alone here to keep this change to one thing.

## Tests

- `tests/unit/test_cli/test_nquads.py` — a malformed tag added as a fourth entry to `test_malformed_and_unrepresentable_terms_are_skipped_not_emitted`, counts `(1, 3)` → `(1, 4)`; plus `test_unusable_language_tags_are_skipped_not_emitted`, which walks the tag shapes that break the grammar (`"fr CA"`, `"en_US"`, `"en\n"`, a quote-injecting `'en> "x" <urn:evil'`, a non-`str`), asserts each is skipped while the following good triple still round-trips, and asserts subtagged tags (`fr`, `fr-CA`, `de-DE-1996`) are *not* over-rejected.
- `tests/unit/test_cli/test_graph_to_turtle.py` — new; `term_to_rdflib` is pure, so it covers convert/skip directly, including the malformed-IRI case that already worked.

On master with only the test changes applied, 3 of the 8 fail:

```
FAILED tests/unit/test_cli/test_nquads.py::TestNquadsRoundTrip::test_malformed_and_unrepresentable_terms_are_skipped_not_emitted
FAILED tests/unit/test_cli/test_nquads.py::TestNquadsRoundTrip::test_unusable_language_tags_are_skipped_not_emitted
FAILED tests/unit/test_cli/test_graph_to_turtle.py::TestTermToRdflib::test_unusable_language_tag_is_skipped_not_raised
========================= 3 failed, 5 passed in 0.24s ==========================
```

the first two on `rdflib.exceptions.ParserError: Invalid line ... "bonjour"@fr CA <urn:trustgraph:collection:default> .`, the third on `ValueError: 'fr CA' is not a valid language tag!` raised out of `term_to_rdflib`. With the fix: `8 passed`.

Full suite, same set CI runs, python 3.13:

```
pytest tests/unit          3112 passed, 51 skipped
pytest tests/contract       125 passed,  3 skipped
pytest tests/integration -m 'not slow'
                            238 passed, 12 skipped, 5 deselected
```

(`tests/unit/test_decoding` was excluded locally only — `python-magic` can't find `libmagic` on this machine; it is unaffected by this change and runs normally in the CI container.)
