### PR TITLE
feat: make prompt and librarian client timeouts configurable (#874)

### DIFF
--- a/tests/unit/test_base/test_client_timeouts.py
+++ b/tests/unit/test_base/test_client_timeouts.py
@@ -1,0 +1,302 @@
+"""
+Prompt and librarian client timeouts (#874 slice 2): a spec resolves its
+timeout from an explicit constructor value, then the processor's CLI
+attribute, then the class default, and threads it into the client it creates.
+"""
+
+import argparse
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from trustgraph.base.request_response_spec import (
+    RequestResponseSpec, _make_impl_wrapper,
+)
+from trustgraph.base.prompt_client import PromptClientSpec, PromptClient
+from trustgraph.base.config_client import ConfigClientSpec
+from trustgraph.base.librarian_spec import LibrarianSpec
+from trustgraph.base.async_librarian_client import AsyncLibrarianClient
+from trustgraph.base.request_response_client import RequestResponseClient
+from trustgraph.schema import LibrarianRequest, PromptResponse
+
+
+REAL_WAIT_FOR = asyncio.wait_for
+
+RR_CREATE = "trustgraph.base.request_response_client.RequestResponseClient.create"
+LIB_CREATE = "trustgraph.base.async_librarian_client.AsyncLibrarianClient.create"
+
+TOPICS = {
+    "topics": {
+        "prompt-request": "q:prompt:req",
+        "prompt-response": "q:prompt:resp",
+        "config-request": "q:config:req",
+        "config-response": "q:config:resp",
+        "librarian-request": "q:lib:req",
+        "librarian-response": "q:lib:resp",
+    }
+}
+
+
+def make_processor(**attrs):
+    # SimpleNamespace, not MagicMock: a missing attribute must be missing.
+    return SimpleNamespace(async_backend=AsyncMock(), id="proc1", **attrs)
+
+
+def make_flow():
+    flow = MagicMock()
+    flow.workspace = "ws"
+    flow.name = "f"
+    flow.consumer = {}
+    return flow
+
+
+def generic_spec(**kwargs):
+    return RequestResponseSpec(
+        request_name="prompt-request",
+        request_schema=object,
+        response_name="prompt-response",
+        response_schema=object,
+        impl=None,
+        **kwargs,
+    )
+
+
+def prompt_spec(**kwargs):
+    return PromptClientSpec(
+        request_name="prompt-request", response_name="prompt-response", **kwargs,
+    )
+
+
+def config_spec(**kwargs):
+    return ConfigClientSpec(
+        request_name="config-request", response_name="config-response", **kwargs,
+    )
+
+
+class TestResolveTimeout:
+
+    def test_generic_default_matches_previous_wrapper_literal(self):
+        assert generic_spec().resolve_timeout(make_processor()) == 300
+
+    def test_base_spec_ignores_processor_attributes(self):
+        proc = make_processor(prompt_timeout=45, librarian_timeout=30)
+        assert generic_spec().resolve_timeout(proc) == 300
+
+    @pytest.mark.parametrize("make, attr, default", [
+        (prompt_spec, "prompt_timeout", 600),
+        (config_spec, "config_timeout", 60),
+        (LibrarianSpec, "librarian_timeout", 120),
+    ])
+    def test_class_default_then_processor_then_explicit(self, make, attr, default):
+        assert make().resolve_timeout(make_processor()) == default
+        assert make().resolve_timeout(make_processor(**{attr: 45})) == 45
+        assert make(timeout=9).resolve_timeout(make_processor(**{attr: 45})) == 9
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("make, attrs, target, expected", [
+        (lambda: generic_spec(timeout=42), {}, RR_CREATE, 42),
+        (prompt_spec, {"prompt_timeout": 45}, RR_CREATE, 45),
+        (LibrarianSpec, {"librarian_timeout": 30}, LIB_CREATE, 30),
+    ])
+    async def test_register_threads_timeout_into_client(
+            self, make, attrs, target, expected):
+        create = AsyncMock(return_value=MagicMock())
+        with patch(target, new=create):
+            await make().register(make_flow(), make_processor(**attrs), TOPICS)
+        assert create.call_args.kwargs["default_timeout"] == expected
+
+
+class TestImplWrapperTimeout:
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("kwargs, forwarded", [({}, None), ({"timeout": 7}, 7)])
+    async def test_request_forwards_timeout(self, kwargs, forwarded):
+        rr = MagicMock()
+        rr.request = AsyncMock(return_value="ok")
+        wrapper = _make_impl_wrapper(rr, None)
+
+        assert await wrapper.request("req", **kwargs) == "ok"
+        assert rr.request.call_args.kwargs["timeout"] == forwarded
+
+
+class TestRegisteredPromptWrapper:
+
+    @pytest.mark.asyncio
+    async def test_bare_request_reaches_client_with_prompt_default(self):
+        # A real RequestResponseClient (no pub/sub), so the number that
+        # reaches wait_for is the effective default, not a forwarded None.
+        async def create(**kwargs):
+            client = RequestResponseClient(
+                default_timeout=kwargs["default_timeout"],
+            )
+            client.producer = AsyncMock()
+            return client
+
+        wait_for = AsyncMock(return_value="resp")
+        with patch(RR_CREATE, new=create), patch(
+            "trustgraph.base.request_response_client.asyncio.wait_for",
+            new=wait_for,
+        ):
+            wrapper = await prompt_spec().register(
+                make_flow(), make_processor(), TOPICS,
+            )
+            assert await wrapper.request("req") == "resp"
+
+        assert wait_for.call_args.kwargs["timeout"] == 600
+
+
+class TestPromptClientMethods:
+
+    def client(self):
+        client = PromptClient.__new__(PromptClient)
+        client.request = AsyncMock(
+            return_value=PromptResponse(text="x", object=None, error=None),
+        )
+        return client
+
+    @pytest.mark.asyncio
+    async def test_methods_forward_none_by_default(self):
+        client = self.client()
+        await client.question("q")
+        assert client.request.call_args.kwargs["timeout"] is None
+
+        await client.extract_definitions("t")
+        assert client.request.call_args.kwargs["timeout"] is None
+
+    @pytest.mark.asyncio
+    async def test_methods_forward_explicit_timeout(self):
+        client = self.client()
+        await client.question("q", timeout=5)
+        assert client.request.call_args.kwargs["timeout"] == 5
+
+        await client.extract_relationships("t", timeout=6)
+        assert client.request.call_args.kwargs["timeout"] == 6
+
+
+class TestAsyncLibrarianClientTimeout:
+
+    def client(self, response, **kwargs):
+        # The producer answers its own request so the real wait_for completes.
+        client = AsyncLibrarianClient(**kwargs)
+
+        async def send(request, properties):
+            request_id = properties["id"]
+            if request_id in client._streams:
+                await client._streams[request_id].put(response)
+            else:
+                client._pending[request_id].set_result(response)
+
+        client._producer = MagicMock(send=AsyncMock(side_effect=send))
+        return client
+
+    def wait_for(self):
+        return patch(
+            "trustgraph.base.async_librarian_client.asyncio.wait_for",
+            new=AsyncMock(side_effect=REAL_WAIT_FOR),
+        )
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("ctor, call, expected", [
+        ({}, {}, 120),
+        ({"default_timeout": 33}, {}, 33),
+        ({"default_timeout": 33}, {"timeout": 5}, 5),
+    ])
+    async def test_request_resolves_timeout(self, ctor, call, expected):
+        client = self.client(MagicMock(error=None), **ctor)
+        with self.wait_for() as wait_for:
+            await client.request(
+                LibrarianRequest(operation="list-documents"), **call,
+            )
+        assert wait_for.call_args.kwargs["timeout"] == expected
+
+    @pytest.mark.asyncio
+    async def test_stream_uses_constructor_default(self):
+        final = MagicMock(error=None, is_final=True)
+        client = self.client(final, default_timeout=33)
+        with self.wait_for() as wait_for:
+            chunks = await client.stream(
+                LibrarianRequest(operation="stream-document"),
+            )
+        assert chunks == [final]
+        assert wait_for.call_args.kwargs["timeout"] == 33
+
+    @pytest.mark.asyncio
+    async def test_fetch_helpers_defer_to_default(self):
+        response = MagicMock(error=None, document_metadata="meta")
+        client = self.client(response, default_timeout=33)
+        with self.wait_for() as wait_for:
+            assert await client.fetch_document_metadata("d1") == "meta"
+        assert wait_for.call_args.kwargs["timeout"] == 33
+
+    @pytest.mark.asyncio
+    async def test_create_threads_default_timeout(self):
+        with patch(
+            "trustgraph.base.async_librarian_client.asyncio.create_task",
+            new=lambda coro, **kw: coro.close(),
+        ):
+            client = await AsyncLibrarianClient.create(
+                backend=AsyncMock(), request_topic="r", response_topic="s",
+                default_timeout=33,
+            )
+        assert client.default_timeout == 33
+
+
+class TestTimeoutArgs:
+
+    def test_flow_processor_add_args(self):
+        from trustgraph.base.flow_processor import FlowProcessor
+
+        parser = argparse.ArgumentParser()
+        FlowProcessor.add_args(parser)
+
+        args = parser.parse_args([])
+        assert args.prompt_timeout == 600
+        assert args.librarian_timeout == 120
+
+        args = parser.parse_args(
+            ["--prompt-timeout", "30", "--librarian-timeout", "15"],
+        )
+        assert args.prompt_timeout == 30
+        assert args.librarian_timeout == 15
+
+    def test_workspace_processor_has_neither_flag(self):
+        from trustgraph.base.workspace_processor import WorkspaceProcessor
+
+        parser = argparse.ArgumentParser()
+        WorkspaceProcessor.add_args(parser)
+
+        args = parser.parse_args([])
+        assert not hasattr(args, "librarian_timeout")
+        assert not hasattr(args, "prompt_timeout")
+
+    def test_librarian_arg_is_opt_in_for_workspace_processors(self):
+        from trustgraph.base.workspace_processor import WorkspaceProcessor
+
+        parser = argparse.ArgumentParser()
+        WorkspaceProcessor.add_args(parser)
+        WorkspaceProcessor.add_librarian_args(parser)
+
+        assert parser.parse_args([]).librarian_timeout == 120
+        assert parser.parse_args(["--librarian-timeout", "15"]).librarian_timeout == 15
+
+    def _flow_processor(self, **extra):
+        with patch(
+            "trustgraph.base.async_processor.get_async_pubsub"
+        ) as pubsub:
+            pubsub.return_value = MagicMock()
+            from trustgraph.base.flow_processor import FlowProcessor
+            return FlowProcessor(
+                id="test-flow-processor", taskgroup=AsyncMock(), **extra,
+            )
+
+    def test_processor_attribute_defaults(self):
+        p = self._flow_processor()
+        assert p.prompt_timeout == 600
+        assert p.librarian_timeout == 120
+
+    def test_processor_attributes_from_params(self):
+        p = self._flow_processor(prompt_timeout=30, librarian_timeout=15)
+        assert p.prompt_timeout == 30
+        assert p.librarian_timeout == 15

--- a/trustgraph-base/trustgraph/base/async_librarian_client.py
+++ b/trustgraph-base/trustgraph/base/async_librarian_client.py
@@ -15,10 +15,13 @@ from ..schema import LibrarianRequest, LibrarianResponse, DocumentMetadata
 
 logger = logging.getLogger(__name__)
 
+default_librarian_timeout = 120
+
 
 class AsyncLibrarianClient:
 
-    def __init__(self):
+    def __init__(self, default_timeout=default_librarian_timeout):
+        self.default_timeout = default_timeout
         self._producer = None
         self._consumer = None
         self._receiver_task = None
@@ -29,9 +32,9 @@ class AsyncLibrarianClient:
     @classmethod
     async def create(
         cls, backend, request_topic, response_topic,
-        subscription=None,
+        subscription=None, default_timeout=default_librarian_timeout,
     ):
-        client = cls()
+        client = cls(default_timeout=default_timeout)
 
         client._producer = await backend.create_producer(
             topic=request_topic,
@@ -63,6 +66,9 @@ class AsyncLibrarianClient:
     async def start(self):
         pass
 
+    def _timeout(self, timeout):
+        return self.default_timeout if timeout is None else timeout
+
     async def _response_loop(self):
         try:
             while self.running:
@@ -87,7 +93,8 @@ class AsyncLibrarianClient:
                 f"Librarian response loop error: {e}", exc_info=True,
             )
 
-    async def request(self, request, timeout=120):
+    async def request(self, request, timeout=None):
+        timeout = self._timeout(timeout)
         request_id = str(uuid.uuid4())
 
         future = asyncio.get_event_loop().create_future()
@@ -111,7 +118,8 @@ class AsyncLibrarianClient:
             self._pending.pop(request_id, None)
             raise RuntimeError("Timeout waiting for librarian response")
 
-    async def stream(self, request, timeout=120):
+    async def stream(self, request, timeout=None):
+        timeout = self._timeout(timeout)
         request_id = str(uuid.uuid4())
 
         q = asyncio.Queue()
@@ -180,7 +188,7 @@ class AsyncLibrarianClient:
 
         logger.info("AsyncLibrarianClient closed")
 
-    async def fetch_document_content(self, document_id, timeout=120):
+    async def fetch_document_content(self, document_id, timeout=None):
         req = LibrarianRequest(
             operation="stream-document",
             document_id=document_id,
@@ -199,13 +207,13 @@ class AsyncLibrarianClient:
 
         return base64.b64encode(raw)
 
-    async def fetch_document_text(self, document_id, timeout=120):
+    async def fetch_document_text(self, document_id, timeout=None):
         content = await self.fetch_document_content(
             document_id, timeout=timeout,
         )
         return base64.b64decode(content).decode("utf-8")
 
-    async def fetch_document_metadata(self, document_id, timeout=120):
+    async def fetch_document_metadata(self, document_id, timeout=None):
         req = LibrarianRequest(
             operation="get-document-metadata",
             document_id=document_id,
@@ -215,7 +223,7 @@ class AsyncLibrarianClient:
 
     async def save_child_document(self, doc_id, parent_id, content,
                                   document_type="chunk", title=None,
-                                  kind="text/plain", timeout=120):
+                                  kind="text/plain", timeout=None):
         if isinstance(content, str):
             content = content.encode("utf-8")
 
@@ -238,7 +246,7 @@ class AsyncLibrarianClient:
 
     async def save_document(self, doc_id, content, title=None,
                             document_type="answer", kind="text/plain",
-                            timeout=120):
+                            timeout=None):
         if isinstance(content, str):
             content = content.encode("utf-8")
 

--- a/trustgraph-base/trustgraph/base/config_client.py
+++ b/trustgraph-base/trustgraph/base/config_client.py
@@ -1,5 +1,6 @@
 
 from . request_response_spec import RequestResponseSpec
+from . async_processor import default_config_timeout
 from .. schema import ConfigRequest, ConfigResponse, ConfigKey, ConfigValue
 
 CONFIG_TIMEOUT = 10
@@ -108,8 +109,12 @@ class ConfigClient:
 
 
 class ConfigClientSpec(RequestResponseSpec):
+
+    timeout_param = "config_timeout"
+    default_timeout = default_config_timeout
+
     def __init__(
-            self, request_name, response_name,
+            self, request_name, response_name, timeout=None,
     ):
         super(ConfigClientSpec, self).__init__(
             request_name=request_name,
@@ -117,4 +122,5 @@ class ConfigClientSpec(RequestResponseSpec):
             response_name=response_name,
             response_schema=ConfigResponse,
             impl=ConfigClient,
+            timeout=timeout,
         )

--- a/trustgraph-base/trustgraph/base/flow_processor.py
+++ b/trustgraph-base/trustgraph/base/flow_processor.py
@@ -16,6 +16,7 @@ from .. schema import config_push_queue
 from .. log_level import LogLevel
 from . workspace_processor import WorkspaceProcessor
 from . flow import Flow
+from . prompt_client import default_prompt_timeout
 
 # Module logger
 logger = logging.getLogger(__name__)
@@ -28,6 +29,10 @@ class FlowProcessor(WorkspaceProcessor):
 
         # Initialise base class
         super(FlowProcessor, self).__init__(**params)
+
+        self.prompt_timeout = int(params.get(
+            "prompt_timeout", default_prompt_timeout
+        ))
 
         # Register configuration handler for this processor's config type
         self.register_config_handler(
@@ -114,6 +119,15 @@ class FlowProcessor(WorkspaceProcessor):
     def add_args(parser: ArgumentParser) -> None:
 
         WorkspaceProcessor.add_args(parser)
+        WorkspaceProcessor.add_librarian_args(parser)
+
+        parser.add_argument(
+            '--prompt-timeout',
+            type=int,
+            default=default_prompt_timeout,
+            help=f'Prompt request timeout in seconds '
+                 f'(default: {default_prompt_timeout})',
+        )
 
         # parser.add_argument(
         #     '--rate-limit-retry',

--- a/trustgraph-base/trustgraph/base/librarian_spec.py
+++ b/trustgraph-base/trustgraph/base/librarian_spec.py
@@ -3,18 +3,22 @@ from __future__ import annotations
 import uuid
 from typing import Any
 
-from . spec import Spec
+from . spec import Spec, TimeoutSpec
+from . async_librarian_client import AsyncLibrarianClient, default_librarian_timeout
 
 
-class LibrarianSpec(Spec):
+class LibrarianSpec(TimeoutSpec, Spec):
+
+    timeout_param = "librarian_timeout"
+    default_timeout = default_librarian_timeout
+
     def __init__(self, request_name="librarian-request",
-                 response_name="librarian-response"):
+                 response_name="librarian-response", timeout=None):
         self.request_name = request_name
         self.response_name = response_name
+        self.timeout = timeout
 
     async def register(self, flow: Any, processor: Any, definition: dict[str, Any]) -> Any:
-
-        from .async_librarian_client import AsyncLibrarianClient
 
         subscription = (
             processor.id + "--" + flow.workspace + "--" +
@@ -26,6 +30,7 @@ class LibrarianSpec(Spec):
             request_topic=definition["topics"][self.request_name],
             response_topic=definition["topics"][self.response_name],
             subscription=subscription,
+            default_timeout=self.resolve_timeout(processor),
         )
 
         flow.librarian = client

--- a/trustgraph-base/trustgraph/base/prompt_client.py
+++ b/trustgraph-base/trustgraph/base/prompt_client.py
@@ -8,6 +8,8 @@ from typing import Optional, Any
 from . request_response_spec import RequestResponseSpec
 from .. schema import PromptRequest, PromptResponse
 
+default_prompt_timeout = 600
+
 @dataclass
 class PromptResult:
     response_type: str              # "text", "json", or "jsonl"
@@ -20,7 +22,7 @@ class PromptResult:
 
 class PromptClient:
 
-    async def prompt(self, id, variables, timeout=600, streaming=False, chunk_callback=None):
+    async def prompt(self, id, variables, timeout=None, streaming=False, chunk_callback=None):
 
         if not streaming:
 
@@ -136,28 +138,28 @@ class PromptClient:
                 model=last_resp.model,
             )
 
-    async def extract_definitions(self, text, timeout=600):
+    async def extract_definitions(self, text, timeout=None):
         return await self.prompt(
             id = "extract-definitions",
             variables = { "text": text },
             timeout = timeout,
         )
 
-    async def extract_relationships(self, text, timeout=600):
+    async def extract_relationships(self, text, timeout=None):
         return await self.prompt(
             id = "extract-relationships",
             variables = { "text": text },
             timeout = timeout,
         )
 
-    async def extract_objects(self, text, schema, timeout=600):
+    async def extract_objects(self, text, schema, timeout=None):
         return await self.prompt(
             id = "extract-rows",
             variables = { "text": text, "schema": schema, },
             timeout = timeout,
         )
 
-    async def document_prompt(self, query, documents, timeout=600, streaming=False, chunk_callback=None):
+    async def document_prompt(self, query, documents, timeout=None, streaming=False, chunk_callback=None):
         return await self.prompt(
             id = "document-prompt",
             variables = {
@@ -169,7 +171,7 @@ class PromptClient:
             chunk_callback = chunk_callback,
         )
 
-    async def agent_react(self, variables, timeout=600, streaming=False, chunk_callback=None):
+    async def agent_react(self, variables, timeout=None, streaming=False, chunk_callback=None):
         return await self.prompt(
             id = "agent-react",
             variables = variables,
@@ -178,7 +180,7 @@ class PromptClient:
             chunk_callback = chunk_callback,
         )
 
-    async def question(self, question, timeout=600):
+    async def question(self, question, timeout=None):
         return await self.prompt(
             id = "question",
             variables = {
@@ -188,8 +190,12 @@ class PromptClient:
         )
 
 class PromptClientSpec(RequestResponseSpec):
+
+    timeout_param = "prompt_timeout"
+    default_timeout = default_prompt_timeout
+
     def __init__(
-            self, request_name, response_name,
+            self, request_name, response_name, timeout=None,
     ):
         super(PromptClientSpec, self).__init__(
             request_name = request_name,
@@ -197,4 +203,5 @@ class PromptClientSpec(RequestResponseSpec):
             response_name = response_name,
             response_schema = PromptResponse,
             impl = PromptClient,
+            timeout = timeout,
         )

--- a/trustgraph-base/trustgraph/base/request_response_spec.py
+++ b/trustgraph-base/trustgraph/base/request_response_spec.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from . spec import Spec
+from . spec import Spec, TimeoutSpec
 
 # Module logger
 logger = logging.getLogger(__name__)
@@ -12,10 +12,13 @@ logger = logging.getLogger(__name__)
 # use another service in request/response mode.  Uses two topics:
 # - we send on the request topic as a producer
 # - we receive on the response topic as a subscriber
-class RequestResponseSpec(Spec):
+class RequestResponseSpec(TimeoutSpec, Spec):
+
+    default_timeout = 300
+
     def __init__(
             self, request_name, request_schema, response_name,
-            response_schema, impl=None, optional=False
+            response_schema, impl=None, optional=False, timeout=None,
     ):
         self.request_name = request_name
         self.request_schema = request_schema
@@ -23,6 +26,7 @@ class RequestResponseSpec(Spec):
         self.response_schema = response_schema
         self.impl = impl
         self.optional = optional
+        self.timeout = timeout
 
     async def register(self, flow: Any, processor: Any, definition: dict[str, Any]) -> Any:
 
@@ -42,6 +46,7 @@ class RequestResponseSpec(Spec):
             response_schema=self.response_schema,
             processor_id=getattr(processor, 'id', None),
             target_service=self.request_name,
+            default_timeout=self.resolve_timeout(processor),
         )
 
         wrapper = _make_impl_wrapper(rr_client, self.impl)
@@ -59,7 +64,7 @@ def _make_impl_wrapper(rr_client, impl_cls):
         def __init__(self):
             self._rr_client = rr_client
 
-        async def request(self, req, timeout=300, recipient=None):
+        async def request(self, req, timeout=None, recipient=None):
             if recipient is None:
                 return await self._rr_client.request(req, timeout=timeout)
 

--- a/trustgraph-base/trustgraph/base/spec.py
+++ b/trustgraph-base/trustgraph/base/spec.py
@@ -7,3 +7,22 @@ class Spec:
 
     def add(self, flow, processor, definition):
         pass
+
+
+class TimeoutSpec:
+    # Mixin for specs that create a client. An explicit constructor value
+    # wins over the processor attribute named by timeout_param, which wins
+    # over the class default.
+    timeout_param = None
+    default_timeout = None
+    timeout = None
+
+    def resolve_timeout(self, processor):
+        # Reads a plain attribute: a Mock processor yields a Mock, not None.
+        if self.timeout is not None:
+            return self.timeout
+        if self.timeout_param is not None:
+            value = getattr(processor, self.timeout_param, None)
+            if value is not None:
+                return value
+        return self.default_timeout

--- a/trustgraph-base/trustgraph/base/workspace_processor.py
+++ b/trustgraph-base/trustgraph/base/workspace_processor.py
@@ -5,6 +5,7 @@ from argparse import ArgumentParser
 import logging
 
 from . async_processor import AsyncProcessor
+from . async_librarian_client import default_librarian_timeout
 
 logger = logging.getLogger(__name__)
 
@@ -17,6 +18,10 @@ class WorkspaceProcessor(AsyncProcessor):
     def __init__(self, **params):
 
         super(WorkspaceProcessor, self).__init__(**params)
+
+        self.librarian_timeout = int(params.get(
+            "librarian_timeout", default_librarian_timeout
+        ))
 
         self.active_workspaces = set()
 
@@ -63,3 +68,13 @@ class WorkspaceProcessor(AsyncProcessor):
     @staticmethod
     def add_args(parser: ArgumentParser) -> None:
         AsyncProcessor.add_args(parser)
+
+    @staticmethod
+    def add_librarian_args(parser: ArgumentParser) -> None:
+        parser.add_argument(
+            '--librarian-timeout',
+            type=int,
+            default=default_librarian_timeout,
+            help=f'Librarian request timeout in seconds '
+                 f'(default: {default_librarian_timeout})',
+        )

--- a/trustgraph-flow/trustgraph/cores/service.py
+++ b/trustgraph-flow/trustgraph/cores/service.py
@@ -140,6 +140,7 @@ class Processor(WorkspaceProcessor):
                 librarian_response_queue, workspace,
             ),
             subscription=f"{self.id}--{workspace}--librarian",
+            default_timeout=self.librarian_timeout,
         )
 
         self.librarian_clients[workspace] = librarian_client
@@ -266,6 +267,7 @@ class Processor(WorkspaceProcessor):
     def add_args(parser):
 
         WorkspaceProcessor.add_args(parser)
+        WorkspaceProcessor.add_librarian_args(parser)
 
         parser.add_argument(
             '--knowledge-request-queue',

--- a/trustgraph-flow/trustgraph/retrieval/document_rag/rag.py
+++ b/trustgraph-flow/trustgraph/retrieval/document_rag/rag.py
@@ -337,7 +337,8 @@ class Processor(FlowProcessor):
             type=int,
             default=120,
             help='Timeout in seconds for fetching a document chunk from the '
-                 'librarian (default: 120)'
+                 'librarian, overrides --librarian-timeout for that call '
+                 '(default: 120)'
         )
         
         parser.add_argument(


### PR DESCRIPTION
Second slice of #874, after #1063. Against `release/v2.9`, happy to retarget.

## Changes

- Specs that create a client (`RequestResponseSpec`, `LibrarianSpec`) now take a `timeout`. If none is given they read it off the processor (`prompt_timeout`, `librarian_timeout`, `config_timeout`) and fall back to the old literal. The impl wrapper and the client methods pass `None` through instead of pinning a number, so per-call timeouts still override.
- `--prompt-timeout` (600) on `FlowProcessor`. `--librarian-timeout` (120) via `WorkspaceProcessor.add_librarian_args`, used by `FlowProcessor` and the cores service, so the librarian and flow services don't advertise a flag they don't use.
- No processor changed. The cost is that every flow processor now lists both flags in `--help`, whether or not it has that client. If you'd rather have `timeout=self.prompt_timeout` at each of the ~20 call sites instead, I'm happy to do that here.

## Behaviour

1 default moves. A bare `flow("prompt-request").request(req)` used to get the generic wrapper's 300 and now gets 600, the default every other prompt call already had. 4 callers in tree: `nlp_query/service.py:170,235` and `structured_diag/service.py:382,487`. Keeping 300 there would have left them outside the knob, so I think 600 is the right side of this, but it is a change.

`ConfigClientSpec` (exported, unused in tree) now follows `--config-timeout`, effective default still 60. `document_rag` keeps `--fetch-chunk-timeout` for the chunk fetch, only its help text changed.

## Tests

24 new tests, 20 fail with the source reverted to `release/v2.9`. Unit, contract and integration pass in CI. Also ran it against a Pulsar standalone: `--prompt-timeout 2` and `--librarian-timeout 2` cut a 5 s stub at 2 s, and the defaults behave as before.
