### PR TITLE
refactor(gateway): use typed aiohttp request keys for audit annotations

### DIFF
--- a/tests/unit/test_gateway/test_audit_middleware.py
+++ b/tests/unit/test_gateway/test_audit_middleware.py
@@ -10,7 +10,11 @@ from unittest.mock import AsyncMock, MagicMock
 from aiohttp import web
 from aiohttp.test_utils import make_mocked_request
 
-from trustgraph.gateway.audit import make_audit_middleware, _client_ip, _outcome_from_status
+from trustgraph.gateway.audit import (
+    make_audit_middleware, _client_ip, _outcome_from_status,
+    audit_request_id_key, audit_identity_key, audit_capability_key,
+    audit_workspace_key,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -131,7 +135,7 @@ class TestAuditMiddleware:
     async def test_includes_identity_when_annotated(self, middleware,
                                                      audit_publisher):
         async def handler(request):
-            request['audit_identity'] = "user:mark"
+            request[audit_identity_key] = "user:mark"
             return web.json_response({"ok": True})
 
         req = _make_request()
@@ -144,8 +148,8 @@ class TestAuditMiddleware:
     async def test_includes_capability_when_annotated(self, middleware,
                                                        audit_publisher):
         async def handler(request):
-            request['audit_capability'] = "config:read"
-            request['audit_workspace'] = "production"
+            request[audit_capability_key] = "config:read"
+            request[audit_workspace_key] = "production"
             return web.json_response({"ok": True})
 
         req = _make_request()
@@ -175,7 +179,7 @@ class TestAuditMiddleware:
 
         async def handler(request):
             nonlocal captured_id
-            captured_id = request.get('audit_request_id')
+            captured_id = request.get(audit_request_id_key)
             return web.json_response({"ok": True})
 
         req = _make_request()

--- a/trustgraph-flow/trustgraph/gateway/audit.py
+++ b/trustgraph-flow/trustgraph/gateway/audit.py
@@ -3,11 +3,11 @@ Audit middleware for the API gateway.
 
 Wraps every HTTP request with timing and metadata collection, then
 emits a ``gateway.request`` audit event after the response is sent.
-Handlers can enrich the event by annotating the request dict:
+Handlers can enrich the event by annotating the request:
 
-    request['audit_identity'] = identity.principal_id
-    request['audit_capability'] = capability
-    request['audit_workspace'] = workspace
+    request[audit_identity_key] = identity.principal_id
+    request[audit_capability_key] = capability
+    request[audit_workspace_key] = workspace
 """
 
 import time
@@ -15,6 +15,11 @@ import logging
 from uuid import uuid4
 
 from aiohttp import web
+
+audit_request_id_key = web.RequestKey("audit_request_id", str)
+audit_identity_key = web.RequestKey("audit_identity", str)
+audit_capability_key = web.RequestKey("audit_capability", str)
+audit_workspace_key = web.RequestKey("audit_workspace", str)
 
 from trustgraph.base import AuditPublisher
 
@@ -44,7 +49,7 @@ def make_audit_middleware(audit_publisher):
     @web.middleware
     async def audit_middleware(request, handler):
         request_id = str(uuid4())
-        request['audit_request_id'] = request_id
+        request[audit_request_id_key] = request_id
         start = time.monotonic()
 
         status_code = 500
@@ -81,15 +86,15 @@ def make_audit_middleware(audit_publisher):
                 "response_size_bytes": response_size,
             }
 
-            identity = request.get('audit_identity')
+            identity = request.get(audit_identity_key)
             if identity:
                 payload["identity"] = identity
 
-            capability = request.get('audit_capability')
+            capability = request.get(audit_capability_key)
             if capability:
                 payload["capability"] = capability
 
-            workspace = request.get('audit_workspace')
+            workspace = request.get(audit_workspace_key)
             if workspace:
                 payload["workspace"] = workspace
 

--- a/trustgraph-flow/trustgraph/gateway/auth.py
+++ b/trustgraph-flow/trustgraph/gateway/auth.py
@@ -28,6 +28,7 @@ from prometheus_client import Counter, Enum, Gauge
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import ed25519
 
+from .audit import audit_identity_key, audit_request_id_key
 from ..base.iam_client import IamClient
 from ..base.request_response_client import RequestResponseClient
 from ..base.request_response_spec import _make_impl_wrapper
@@ -259,7 +260,7 @@ class IamAuth:
         cannot distinguish missing / malformed / invalid / expired /
         revoked credentials."""
 
-        request_id = request.get('audit_request_id', '') if hasattr(request, 'get') else ''
+        request_id = request.get(audit_request_id_key, '') if hasattr(request, 'get') else ''
         client_ip = self._extract_client_ip(request)
 
         header = request.headers.get("Authorization", "")
@@ -307,7 +308,7 @@ class IamAuth:
     @staticmethod
     def _annotate_request(request, identity):
         try:
-            request['audit_identity'] = identity.principal_id
+            request[audit_identity_key] = identity.principal_id
         except Exception:
             pass
 

--- a/trustgraph-flow/trustgraph/gateway/endpoint/iam_endpoint.py
+++ b/trustgraph-flow/trustgraph/gateway/endpoint/iam_endpoint.py
@@ -16,6 +16,7 @@ import logging
 
 from aiohttp import web
 
+from .. audit import audit_request_id_key, audit_capability_key, audit_workspace_key
 from .. capabilities import (
     PUBLIC, AUTHENTICATED, auth_failure,
 )
@@ -90,13 +91,13 @@ class IamEndpoint:
 
             await self.auth.authorise(
                 identity, op.capability, resource, parameters,
-                request_id=request.get('audit_request_id', ''),
+                request_id=request.get(audit_request_id_key, ''),
                 client_ip=self.auth._extract_client_ip(request),
             )
-            request['audit_capability'] = op.capability
+            request[audit_capability_key] = op.capability
             ws = resource.get('workspace', '')
             if ws:
-                request['audit_workspace'] = ws
+                request[audit_workspace_key] = ws
 
         # Plumb the authenticated caller's handle through as ``actor``
         # so iam-svc handlers (e.g. whoami, future actor-scoped

--- a/trustgraph-flow/trustgraph/gateway/endpoint/manager.py
+++ b/trustgraph-flow/trustgraph/gateway/endpoint/manager.py
@@ -12,6 +12,7 @@ from . auth_endpoints import AuthEndpoints
 from . iam_endpoint import IamEndpoint
 from . registry_endpoint import RegistryRoutedVariableEndpoint
 
+from .. audit import audit_request_id_key, audit_capability_key, audit_workspace_key
 from .. capabilities import PUBLIC, AUTHENTICATED, auth_failure, workspace_not_found
 from .. registry import lookup as _registry_lookup, RequestContext, ResourceLevel
 
@@ -75,14 +76,14 @@ class _RoutedVariableEndpoint:
             parameters = op.extract_parameters(ctx)
             await self.auth.authorise(
                 identity, op.capability, resource, parameters,
-                request_id=request.get('audit_request_id', ''),
+                request_id=request.get(audit_request_id_key, ''),
                 client_ip=self.auth._extract_client_ip(request),
             )
-            request['audit_capability'] = op.capability
+            request[audit_capability_key] = op.capability
 
             ws = resource.get("workspace", "")
             if ws:
-                request['audit_workspace'] = ws
+                request[audit_workspace_key] = ws
             if ws and ws not in self.auth.known_workspaces:
                 raise workspace_not_found()
 
@@ -148,14 +149,14 @@ class _RoutedSocketEndpoint:
             parameters = op.extract_parameters(ctx)
             await self.auth.authorise(
                 identity, op.capability, resource, parameters,
-                request_id=request.get('audit_request_id', ''),
+                request_id=request.get(audit_request_id_key, ''),
                 client_ip=self.auth._extract_client_ip(request),
             )
-            request['audit_capability'] = op.capability
+            request[audit_capability_key] = op.capability
 
             ws = resource.get("workspace", "")
             if ws:
-                request['audit_workspace'] = ws
+                request[audit_workspace_key] = ws
             if ws and ws not in self.auth.known_workspaces:
                 raise workspace_not_found()
 

--- a/trustgraph-flow/trustgraph/gateway/endpoint/registry_endpoint.py
+++ b/trustgraph-flow/trustgraph/gateway/endpoint/registry_endpoint.py
@@ -19,6 +19,7 @@ import logging
 
 from aiohttp import web
 
+from .. audit import audit_request_id_key, audit_capability_key, audit_workspace_key
 from .. capabilities import (
     PUBLIC, AUTHENTICATED, auth_failure, workspace_not_found,
 )
@@ -98,13 +99,13 @@ class RegistryRoutedVariableEndpoint:
 
             await self.auth.authorise(
                 identity, op.capability, resource, parameters,
-                request_id=request.get('audit_request_id', ''),
+                request_id=request.get(audit_request_id_key, ''),
                 client_ip=self.auth._extract_client_ip(request),
             )
-            request['audit_capability'] = op.capability
+            request[audit_capability_key] = op.capability
             ws = resource.get('workspace', '')
             if ws:
-                request['audit_workspace'] = ws
+                request[audit_workspace_key] = ws
 
             # Default-fill workspace into the body so downstream
             # dispatchers see the canonical resolved value.  The


### PR DESCRIPTION
## Summary

- Replace string-keyed `request['audit_*']` with `web.AppKey` instances across the gateway audit middleware, auth, and endpoint files
- Silences `NotAppKeyWarning` on aiohttp 3.x and prepares for future enforcement where aiohttp may require typed keys
- Keys defined in `audit.py` and imported wherever they're used

## Test plan

- [x] `pytest tests/unit/test_gateway/test_audit_middleware.py` passes with no `NotAppKeyWarning`
- [x] Full gateway test suite passes