### PR TITLE
fix: align requires-python with MCP SDK dependency (#1106)

### DIFF
--- a/trustgraph-base/pyproject.toml
+++ b/trustgraph-base/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 authors = [{name = "trustgraph.ai", email = "security@trustgraph.ai"}]
 description = "TrustGraph provides a means to run a pipeline of flexible AI processing components in a flexible means to achieve a processing pipeline."
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 dependencies = [
     "pulsar-client",
     "prometheus-client",

--- a/trustgraph-bedrock/pyproject.toml
+++ b/trustgraph-bedrock/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 authors = [{name = "trustgraph.ai", email = "security@trustgraph.ai"}]
 description = "TrustGraph provides a means to run a pipeline of flexible AI processing components in a flexible means to achieve a processing pipeline."
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 dependencies = [
     "trustgraph-base>=2.9,<2.10",
     "pulsar-client",

--- a/trustgraph-cli/pyproject.toml
+++ b/trustgraph-cli/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 authors = [{name = "trustgraph.ai", email = "security@trustgraph.ai"}]
 description = "TrustGraph provides a means to run a pipeline of flexible AI processing components in a flexible means to achieve a processing pipeline."
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 dependencies = [
     "trustgraph-base>=2.9,<2.10",
     "requests",

--- a/trustgraph-docling/pyproject.toml
+++ b/trustgraph-docling/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 authors = [{name = "trustgraph.ai", email = "security@trustgraph.ai"}]
 description = "TrustGraph document decoder powered by Docling — lightweight alternative to the unstructured-based decoder."
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 dependencies = [
     "trustgraph-base>=2.9,<2.10",
     "pulsar-client",

--- a/trustgraph-embeddings-hf/pyproject.toml
+++ b/trustgraph-embeddings-hf/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 authors = [{name = "trustgraph.ai", email = "security@trustgraph.ai"}]
 description = "HuggingFace embeddings support for TrustGraph."
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 dependencies = [
     "trustgraph-base>=2.9,<2.10",
     "trustgraph-flow>=2.9,<2.10",

--- a/trustgraph-flow/pyproject.toml
+++ b/trustgraph-flow/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 authors = [{name = "trustgraph.ai", email = "security@trustgraph.ai"}]
 description = "TrustGraph provides a means to run a pipeline of flexible AI processing components in a flexible means to achieve a processing pipeline."
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 dependencies = [
     "trustgraph-base>=2.9,<2.10",
     "aiohttp",

--- a/trustgraph-mcp/pyproject.toml
+++ b/trustgraph-mcp/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 authors = [{name = "trustgraph.ai", email = "security@trustgraph.ai"}]
 description = "TrustGraph provides a means to run a pipeline of flexible AI processing components in a flexible means to achieve a processing pipeline."
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 dependencies = [
     "mcp",
     "websockets",

--- a/trustgraph-ocr/pyproject.toml
+++ b/trustgraph-ocr/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 authors = [{name = "trustgraph.ai", email = "security@trustgraph.ai"}]
 description = "TrustGraph provides a means to run a pipeline of flexible AI processing components in a flexible means to achieve a processing pipeline."
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 dependencies = [
     "trustgraph-base>=2.9,<2.10",
     "pulsar-client",

--- a/trustgraph-unstructured/pyproject.toml
+++ b/trustgraph-unstructured/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 authors = [{name = "trustgraph.ai", email = "security@trustgraph.ai"}]
 description = "TrustGraph provides a means to run a pipeline of flexible AI processing components in a flexible means to achieve a processing pipeline."
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 dependencies = [
     "trustgraph-base>=2.9,<2.10",
     "pulsar-client",

--- a/trustgraph-vertexai/pyproject.toml
+++ b/trustgraph-vertexai/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 authors = [{name = "trustgraph.ai", email = "security@trustgraph.ai"}]
 description = "TrustGraph provides a means to run a pipeline of flexible AI processing components in a flexible means to achieve a processing pipeline."
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 dependencies = [
     "trustgraph-base>=2.9,<2.10",
     "pulsar-client",

--- a/trustgraph/pyproject.toml
+++ b/trustgraph/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 authors = [{name = "trustgraph.ai", email = "security@trustgraph.ai"}]
 description = "TrustGraph provides a means to run a pipeline of flexible AI processing components in a flexible means to achieve a processing pipeline."
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 dependencies = [
     "trustgraph-base>=2.9,<2.10",
     "trustgraph-bedrock>=2.9,<2.10",


### PR DESCRIPTION
## Summary

- Bump `requires-python` from `>=3.8` to `>=3.10` across all 11 packages
- The MCP SDK requires Python >=3.10, making the previous metadata unsatisfiable on 3.8/3.9

Closes #1106

## Test plan

- [ ] `uv pip compile` / `pip install` resolves cleanly on Python 3.10+
- [ ] CI passes
