### PR TITLE
fix(sparql): bind boolean expression results as xsd:boolean

### DIFF
--- a/trustgraph-flow/trustgraph/query/sparql/algebra.py
+++ b/trustgraph-flow/trustgraph/query/sparql/algebra.py
@@ -461,15 +461,15 @@ async def _eval_extend(node, tc, collection, limit):
         new_sol = dict(sol)
         if isinstance(val, Term):
             new_sol[var_name] = val
-        elif isinstance(val, (int, float)):
-            new_sol[var_name] = Term(type=LITERAL, value=str(val))
-        elif isinstance(val, str):
-            new_sol[var_name] = Term(type=LITERAL, value=val)
         elif isinstance(val, bool):
             new_sol[var_name] = Term(
                 type=LITERAL, value=str(val).lower(),
                 datatype="http://www.w3.org/2001/XMLSchema#boolean"
             )
+        elif isinstance(val, (int, float)):
+            new_sol[var_name] = Term(type=LITERAL, value=str(val))
+        elif isinstance(val, str):
+            new_sol[var_name] = Term(type=LITERAL, value=val)
         elif val is not None:
             new_sol[var_name] = Term(type=LITERAL, value=str(val))
         yield new_sol


### PR DESCRIPTION
## Problem

`bool` is a subclass of `int` in Python, so in `_eval_extend` (`trustgraph-flow/trustgraph/query/sparql/algebra.py`) the `(int, float)` branch catches Python bools first and the `bool` branch written just below it is dead code:

```python
elif isinstance(val, (int, float)):
    new_sol[var_name] = Term(type=LITERAL, value=str(val))
elif isinstance(val, str):
    new_sol[var_name] = Term(type=LITERAL, value=val)
elif isinstance(val, bool):                     # unreachable
    new_sol[var_name] = Term(
        type=LITERAL, value=str(val).lower(),
        datatype="http://www.w3.org/2001/XMLSchema#boolean"
    )
```

`evaluate_expression()` returns a Python `bool` for a large part of the expression language — its own docstring says so ("The result value (Term, **bool**, number, string, or None)") — including every relational operator, `IN`, `EXISTS` / `NOT EXISTS`, `REGEX`, `isIRI` / `isLITERAL` / `isBLANK`, `BOUND` and `LANGMATCHES`.

So `BIND(?a > ?b AS ?ok)` binds `Term(LITERAL, value="True")` with **no datatype**, instead of `Term(LITERAL, value="true", datatype=xsd:boolean)`.

## Why it produces wrong results, not just a wrong lexical form

`_effective_boolean()` in `expressions.py` only reads a literal as a boolean when its datatype is `xsd:boolean`. An untyped literal falls through to the string rule:

```python
if val.datatype == "http://www.w3.org/2001/XMLSchema#boolean":
    return v.lower() in ("true", "1")
...
return len(v) > 0
```

`"False"` is five characters long, so its EBV is `True`. A query like

```sparql
BIND(?a > ?b AS ?ok) . FILTER(?ok)
```

**keeps every solution**, including the ones where the comparison was false.

## Fix

Move the `bool` branch ahead of `(int, float)`. The branch bodies are untouched.

## Verification

`_eval_extend` was extracted from `algebra.py` and `_effective_boolean` from `expressions.py` with `ast.get_source_segment` (no hand-copying), the graph-walking neighbours stubbed, and the `BIND(...) . FILTER(?ok)` chain run before and after the patch:

| BIND value | unpatched bound term | FILTER | patched bound term | FILTER |
|---|---|---|---|---|
| `True` | `value='True' datatype=None` | True | `value='true' datatype=xsd:boolean` | True |
| `False` | `value='False' datatype=None` | **True** ❌ | `value='false' datatype=xsd:boolean` | **False** ✅ |
| `1` | `value='1' datatype=None` | True | `value='1' datatype=None` | True |
| `0` | `value='0' datatype=None` | True | `value='0' datatype=None` | True |
| `42` | `value='42' datatype=None` | True | `value='42' datatype=None` | True |
| `2.5` | `value='2.5' datatype=None` | True | `value='2.5' datatype=None` | True |
| `'text'` | `value='text' datatype=None` | True | `value='text' datatype=None` | True |

Only `bool` results change; `int`, `float`, `str` and `Term` results bind exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
